### PR TITLE
small changes to get hobbes to work under Debian with LLVM 3.7

### DIFF
--- a/lib/hobbes/eval/func.C
+++ b/lib/hobbes/eval/func.C
@@ -840,6 +840,11 @@ public:
   }
 };
 
+/*
+ * NOTE: stdstrsizeF and stdstrelemF assume a certain memory representation for std::string
+ *       this makes them very efficient in e.g. large match expressions on std::string values
+ *       however it also makes them very dangerous for cross platform / cross compiler use
+ *       they have been disabled for this reason but some hobbes users may want to consider this option
 class stdstrsizeF : public op {
   llvm::Value* apply(jitcc* c, const MonoTypes& tys, const MonoTypePtr& rty, const Exprs& es) {
     llvm::Value* str    = c->compile(es[0]);
@@ -871,6 +876,9 @@ class stdstrelemF : public op {
     return polytype(qualtype(functy(list(lift<std::string*>::type(db), lift<long>::type(db)), lift<char>::type(db))));
   }
 };
+*/
+size_t stdstrsize(const std::string& x) { return x.size(); }
+char stdstrelem(const std::string& x, size_t i) { return x[i]; }
 
 class packLongF : public op {
   llvm::Value* apply(jitcc* c, const MonoTypes& tys, const MonoTypePtr& rty, const Exprs& es) {
@@ -1039,9 +1047,9 @@ void initDefOperators(cc* c) {
   BINDF(".variantSplit",      new varSplit());
   BINDF(".variantInjectHead", new varInjH());
 
-  // hack in some special knowledge about std::string's representation
-  BINDF("stdstrsize", new stdstrsizeF());
-  BINDF("stdstrelem", new stdstrelemF());
+  // access std::string fields
+  c->bind("stdstrsize", &stdstrsize);
+  c->bind("stdstrelem", &stdstrelem);
 
   // pack primitive types (a bit of a hack to make pattern matching on strings faster)
   BINDF("packLong",  new packLongF());

--- a/lib/hobbes/lang/preds/hasfield/record.C
+++ b/lib/hobbes/lang/preds/hasfield/record.C
@@ -4,7 +4,7 @@
 
 namespace hobbes {
 
-static MonoTypePtr stdstrty  = opaqueptr<std::string>(false);
+static MonoTypePtr stdstrty  = OpaquePtr::make("std::string", 0, false);
 static MonoTypePtr chararrty = arrayty(primty("char"));
 static MonoTypePtr unitty    = primty("unit");
 

--- a/lib/hobbes/lang/tylift.H
+++ b/lib/hobbes/lang/tylift.H
@@ -185,6 +185,11 @@ template <typename F, typename S>
 template <typename F, typename S>
   struct lift< std::pair<F, S>*, false > : public liftPair<F, S> { };
 
+template <>
+  struct lift< std::string, true > { static MonoTypePtr type(typedb&) { return OpaquePtr::make("std::string", sizeof(std::string), true); }  };
+template <>
+  struct lift< std::string*, false > { static MonoTypePtr type(typedb&) { return OpaquePtr::make("std::string", 0, false); }  };
+
 // lift only indeterminate-length arrays passed by reference
 // (arrays are always represented by a pointer but should internally store inline)
 template <typename T>

--- a/lib/hobbes/util/llvm.H
+++ b/lib/hobbes/util/llvm.H
@@ -4,7 +4,7 @@
 
 #include <hobbes/util/array.H>
 
-#include <llvm/Config/config.h>
+#include <llvm/Config/llvm-config.h>
 
 #if LLVM_VERSION_MAJOR != 3
 #error "I don't know how to use this version of LLVM"


### PR DESCRIPTION
This should specifically address issues encountered when trying to build/run hobbes for Debian with LLVM 3.7.