### PR TITLE
compress regex DFAs by merging equivalent states

### DIFF
--- a/include/hobbes/util/array.H
+++ b/include/hobbes/util/array.H
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <functional>
 #include <sstream>
+#include <string.h>
 
 namespace hobbes {
 

--- a/include/hobbes/util/array.H
+++ b/include/hobbes/util/array.H
@@ -308,6 +308,69 @@ template <typename T>
     return r;
   }
 
+
+// basic bit-packed 2D bool array (maybe there's already something that does this job?)
+class bit_table {
+public:
+  inline bit_table() : rowc(0), colc(0), data(0) {
+  }
+  inline bit_table(size_t rowc, size_t colc, bool s) : rowc(rowc), colc(colc) {
+    size_t msz = 1+((rowc*colc)/8);
+    this->data = new uint8_t[msz];
+    memset(this->data, s ? 0xFF : 0, msz);
+  }
+  inline bit_table(const bit_table& rhs) : rowc(rhs.rowc), colc(rhs.colc) {
+    size_t msz = 1+((this->rowc*this->colc)/8);
+    this->data = new uint8_t[msz];
+    memcpy(this->data, rhs.data, msz);
+  }
+  inline bit_table& operator=(const bit_table& rhs) {
+    if (this != &rhs) {
+      delete[] this->data;
+      this->rowc = rhs.rowc;
+      this->colc = rhs.colc;
+      size_t msz = 1+((this->rowc*this->colc)/8);
+      this->data = new uint8_t[msz];
+      memcpy(this->data, rhs.data, msz);
+    }
+    return *this;
+  }
+  inline ~bit_table() {
+    delete[] this->data;
+  }
+  inline bool operator()(size_t r, size_t c) const {
+    size_t  i = (r*this->colc)+c;
+    size_t  k = i / 8;
+    uint8_t b = i % 8;
+    return (this->data[k] & (1 << b)) != 0;
+  }
+  inline void set(size_t r, size_t c, bool f) {
+    size_t  i = (r*this->colc)+c;
+    size_t  k = i / 8;
+    uint8_t b = i % 8;
+
+    if (f) {
+      this->data[k] |= 1 << b;
+    } else {
+      this->data[k] &= ~(1 << b);
+    }
+  }
+  inline size_t rows() const { return this->rowc; }
+  inline size_t cols() const { return this->colc; }
+private:
+  uint8_t* data;
+  size_t   rowc, colc;
+};
+inline std::ostream& operator<<(std::ostream& out, const bit_table& bt) {
+  for (size_t r = 0; r != bt.rows(); ++r) {
+    for (size_t c = 0; c != bt.cols(); ++c) {
+      out << (bt(r,c) ? "1 " : "0 ");
+    }
+    out << "\n";
+  }
+  return out;
+}
+
 }
 
 #endif

--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -1013,7 +1013,7 @@ void makeDFAFunc(cc* c, const std::string& fname, const DFA& dfa, const LexicalA
 }
 
 // merge char-range mappings where possible and conflate duplicate result states
-void minimizeInto(DFA* dfa, const RStates& fstates, RStates* rstates) {
+void mergeCharRangesAndEqResults(DFA* dfa, const RStates& fstates, RStates* rstates) {
   std::map<RegexIdxs, size_t> results;
 
   for (auto& s : *dfa) {
@@ -1035,6 +1035,109 @@ void minimizeInto(DFA* dfa, const RStates& fstates, RStates* rstates) {
       }
     }
   }
+}
+
+/**************************
+ * compress a DFA by merging equivalent states
+ **************************/
+typedef std::map<state, state> EqStates;
+EqStates findEquivStates(const DFA& dfa) {
+  bit_table eqStates(dfa.size(), dfa.size(), false);
+  for (state s = 0; s < dfa.size(); ++s) { eqStates.set(s, s, true); }
+
+  // identify equivalent states to a fixed point
+  // (probably this could be done more efficiently)
+  bool updatedEQ = true;
+  while (updatedEQ) {
+    updatedEQ = false;
+    for (size_t s0 = 0; s0 < dfa.size(); ++s0) {
+      for (size_t s1 = 0; s1 < s0; ++s1) {
+        // if we already know that two states are equivalent, they're still equivalent
+        if (eqStates(s0, s1)) continue;
+
+        // if two states have different accepting bits, they can't be equivalent
+        if (dfa[s0].acc != dfa[s1].acc) continue;
+
+        // if two states have different capture sets, they can't be equivalent
+        if (dfa[s0].begins != dfa[s1].begins) continue;
+        if (dfa[s0].ends   != dfa[s1].ends)   continue;
+
+        // if the shape of mapping sets differs between states, they can't be equivalent
+        auto m0 = dfa[s0].chars.mapping();
+        auto m1 = dfa[s1].chars.mapping();
+        if (m0.size() != m1.size()) continue;
+
+        // if there is a transition (c,q) in s0 and (c,q') in s1 and q != q', then s0 != s1 (in this cycle)
+        bool tsEq = true;
+        for (size_t i = 0; i < m0.size() && tsEq; ++i) {
+          tsEq = m0[i].first == m1[i].first && eqStates(m0[i].second, m1[i].second);
+        }
+        if (tsEq) {
+          eqStates.set(s0, s1, true);
+          updatedEQ = true;
+        }
+      }
+    }
+  }
+
+  // convert to a representation that makes state substitution explicit
+  EqStates r;
+  for (size_t s0 = 0; s0 < dfa.size(); ++s0) {
+    for (size_t s1 = 0; s1 < s0; ++s1) {
+      if (eqStates(s0, s1)) {
+        r[s0] = s1;
+      }
+    }
+  }
+  return r;
+}
+
+DFA removeEquivStates(const DFA& dfa, const EqStates& eqs) {
+  // after removing states, some states will need to be renumbered
+  // we can infer this mapping from the eqstate mapping
+  std::map<state, state> shifted;
+  size_t accShift = 0;
+  for (auto eq = eqs.begin(); eq != eqs.end();) {
+    state s0 = eq->first+1;
+    ++eq;
+    state s1 = (eq == eqs.end()) ? dfa.size() : eq->first;
+    ++accShift;
+
+    for (state s = s0; s < s1; ++s) {
+      shifted[s] = s - accShift;
+    }
+  }
+
+  // now make a new DFA with eq states removed
+  // all references to states need to be
+  // patched up to account for merging/shifting
+  DFA result;
+  result.reserve(dfa.size()-eqs.size());
+
+  for (size_t s = 0; s < dfa.size(); ++s) {
+    const auto& sd = dfa[s];
+
+    // don't include eliminated states
+    if (eqs.find(s) != eqs.end()) continue;
+
+    // bring this state over to the result
+    result.push_back(dfa[s]);
+    auto& rsd = result.back();
+
+    // patch its transitions to account for merged and shifted states
+    for (const auto& m : sd.chars.mapping()) {
+      auto eq = eqs.find(m.second);
+      if (eq != eqs.end()) {
+        rsd.chars.insert(m.first, eq->second);
+      } else {
+        auto ss = shifted.find(m.second);
+        if (ss != shifted.end()) {
+          rsd.chars.insert(m.first, ss->second);
+        }
+      }
+    }
+  }
+  return result;
 }
 
 /**************************
@@ -1089,8 +1192,11 @@ CRegexes makeRegexFn(cc* c, const Regexes& regexes, const LexicalAnnotation& roo
   RStates fstates;
   disambiguate(nfa, &dfa, &fstates);
 
-  // minimize the results to avoid redundant work in the caller
-  minimizeInto(&dfa, fstates, &result.rstates);
+  // make all char ranges compact and minimize the results to avoid redundant work in the caller
+  mergeCharRangesAndEqResults(&dfa, fstates, &result.rstates);
+
+  // in case of blowup, minimize the size of this DFA
+  dfa = removeEquivStates(dfa, findEquivStates(dfa));
 
   // translate this DFA to a function
   std::string fname = ".regex." + freshName();

--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -1126,14 +1126,13 @@ DFA removeEquivStates(const DFA& dfa, const EqStates& eqs) {
 
     // patch its transitions to account for merged and shifted states
     for (const auto& m : sd.chars.mapping()) {
-      auto eq = eqs.find(m.second);
-      if (eq != eqs.end()) {
-        rsd.chars.insert(m.first, eq->second);
-      } else {
-        auto ss = shifted.find(m.second);
-        if (ss != shifted.end()) {
-          rsd.chars.insert(m.first, ss->second);
-        }
+      auto  eq    = eqs.find(m.second);
+      state tgt   = (eq == eqs.end()) ? m.second : eq->second;
+      auto  shift = shifted.find(tgt);
+      state stgt  = (shift == shifted.end()) ? tgt : shift->second;
+
+      if (stgt != m.second) {
+        rsd.chars.insert(m.first, stgt);
       }
     }
   }


### PR DESCRIPTION
In some cases, regex match compilation produces DFAs that are larger than necessary because they contain some functionally identical states.  This change will merge such states, making the match DFA smaller.

As an example of the effect of this change, while I was developing it I used the internal print functions to show intermediate states of data structures that are used to translate regex matches to code:

```
> "foobar" matches 'f(o|o)*b(a|a)*r'
   a b f o r acc mbegin mend
-- - - - - - --- ------ ----
0:     1       0
1:   2   5
2: 3       4
3: 3       4
4:             1
5:   2   5

eq table:
1 0 0 0 0 0
0 1 0 0 0 0
0 0 1 0 0 0
0 0 1 1 0 0
0 0 0 0 1 0
0 1 0 0 0 1

replace #3 with #2
replace #5 with #1

minimizes to:
   a b f o r acc mbegin mend
-- - - - - - --- ------ ----
0:     1       0
1:   2   1
2: 2       3
3:             1

true
```