### PR TITLE
Special case for single-value logging

### DIFF
--- a/include/hobbes/lang/expr.H
+++ b/include/hobbes/lang/expr.H
@@ -773,6 +773,13 @@ inline ExprPtr mkrecord(const MkRecord::FieldDefs& fds, const LexicalAnnotation&
   }
 }
 
+// maybe generalize to make a tuple expr of any size
+inline ExprPtr mktuple(const ExprPtr& e, const LexicalAnnotation& la) {
+  MkRecord::FieldDefs fs;
+  fs.push_back(MkRecord::FieldDef(".f0", e));
+  return mkrecord(fs, la);
+}
+
 inline ExprPtr proj(const ExprPtr& rec, const Record* rty, const std::string& field, const LexicalAnnotation& la) {
   ExprPtr p(new Proj(rec, field, la));
   p->type(qualtype(rec->type()->constraints(), rty->member(field)));

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -1259,12 +1259,14 @@ template <>
 // make a function for describing store payload types
 template <typename ... Ts>
   struct hstore_payload_types {
+    typedef void head_type;
     static const size_t count = 0;
     static void encode(size_t,bytes*) {}
     static std::string describe() { return ""; }
   };
 template <typename T, typename ... Ts>
   struct hstore_payload_types<T,Ts...> {
+    typedef T head_type;
     static const size_t count = 1 + hstore_payload_types<Ts...>::count;
     static void encode(size_t f, bytes* out) {
       char fn[32];
@@ -1289,12 +1291,19 @@ template <typename TyList>
     if (e) {
       size_t localArity = TyList::count;
 
-      if (localArity > 0) {
+      // don't bother to entuple log argument lists if there's just one argument
+      switch (localArity) {
+      case 0:
+        encode_primty("unit", e);
+        break;
+      case 1:
+        store<typename TyList::head_type>::encode(e);
+        break;
+      default:
         w(_HSTORE_TYCTOR_STRUCT, e);
         w(localArity, e);
         TyList::encode(0, e);
-      } else {
-        encode_primty("unit", e);
+        break;
       }
     }
 


### PR DESCRIPTION
if an HLOG or HSTORE statement just records one value, don't bother to put it in a tuple (even if it's a primitive)