### PR TITLE
build on OSX 10.11.6 El Capitan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,12 @@ target_link_libraries(hog hobbes ncurses ${sys_libs})
 install(TARGETS hobbes hobbes-pic DESTINATION "lib")
 install(TARGETS hi hog DESTINATION "bin")
 install(DIRECTORY "include/hobbes" DESTINATION "include")
+
+# Build on OSX El Capitan 10.11.6 before get_clocktime() was defined:
+OPTION (OSX_EL_CAPITAN "Build for OSX prior to 10.12 Sierra" OFF)
+if(APPLE)
+ if (OSX_EL_CAPITAN)
+   ADD_DEFINITIONS("-DOSX_BEFORE_SIERRA")
+ endif()
+endif()
+

--- a/include/hobbes/util/perf.H
+++ b/include/hobbes/util/perf.H
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <iostream>
 #include <time.h>
+#include "timing_mach.h"
 
 namespace hobbes {
 

--- a/include/hobbes/util/timing_mach.h
+++ b/include/hobbes/util/timing_mach.h
@@ -1,0 +1,155 @@
+#ifndef TIMING_MACH_H
+#define TIMING_MACH_H
+
+#if defined(__APPLE__) && defined(__MACH__) && defined(OSX_BEFORE_SIERRA)
+
+/* ************* */
+/* TIMING_MACH_H */
+
+/* from https://github.com/ChisholmKyle/PosixMachTiming
+
+Copyright (c) 2015, Kyle Chisholm and Jason E. Aten
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* C99 check */
+#if defined(__STDC__)
+# if defined(__STDC_VERSION__)
+#  if (__STDC_VERSION__ >= 199901L)
+#   define TIMING_C99
+#  endif
+# endif
+#endif
+
+#include <time.h>
+
+#define TIMING_GIGA (1000000000)
+#define TIMING_NANO (1e-9)
+
+/* inline functions - maintain ANSI C compatibility */
+#ifndef TIMING_C99
+/* this is a bad hack that makes the functions static in a header file.
+   Compiler warnings about unused functions will plague anyone using this code with ANSI C. */
+#define inline static
+#endif
+
+/* timespec to double */
+inline double timespec2secd(const struct timespec *ts_in) {
+    return ((double) ts_in->tv_sec) + ((double) ts_in->tv_nsec ) * TIMING_NANO;
+}
+
+/* double sec to timespec */
+inline void secd2timespec(struct timespec *ts_out, const double sec_d) {
+    ts_out->tv_sec = (time_t) (sec_d);
+    ts_out->tv_nsec = (long) ((sec_d - (double) ts_out->tv_sec) * TIMING_GIGA);
+}
+
+/* timespec difference (monotonic) left - right */
+inline void timespec_monodiff_lmr(struct timespec *ts_out,
+                                    const struct timespec *ts_in) {
+    /* out = out - in,
+       where out > in
+     */
+    ts_out->tv_sec = ts_out->tv_sec - ts_in->tv_sec;
+    ts_out->tv_nsec = ts_out->tv_nsec - ts_in->tv_nsec;
+    if (ts_out->tv_nsec < 0) {
+        ts_out->tv_sec = ts_out->tv_sec - 1;
+        ts_out->tv_nsec = ts_out->tv_nsec + TIMING_GIGA;
+    }
+}
+
+/* timespec difference (monotonic) right - left */
+inline void timespec_monodiff_rml(struct timespec *ts_out,
+                                    const struct timespec *ts_in) {
+    /* out = in - out,
+       where in > out
+     */
+    ts_out->tv_sec = ts_in->tv_sec - ts_out->tv_sec;
+    ts_out->tv_nsec = ts_in->tv_nsec - ts_out->tv_nsec;
+    if (ts_out->tv_nsec < 0) {
+        ts_out->tv_sec = ts_out->tv_sec - 1;
+        ts_out->tv_nsec = ts_out->tv_nsec + TIMING_GIGA;
+    }
+}
+
+/* timespec addition (monotonic) */
+inline void timespec_monoadd(struct timespec *ts_out,
+                             const struct timespec *ts_in) {
+    /* out = in + out */
+    ts_out->tv_sec = ts_out->tv_sec + ts_in->tv_sec;
+    ts_out->tv_nsec = ts_out->tv_nsec + ts_in->tv_nsec;
+    if (ts_out->tv_nsec >= TIMING_GIGA) {
+        ts_out->tv_sec = ts_out->tv_sec + 1;
+        ts_out->tv_nsec = ts_out->tv_nsec - TIMING_GIGA;
+    }
+}
+
+#ifndef TIMING_C99
+#undef inline
+#endif
+
+#ifdef __MACH__
+/* ******** */
+/* __MACH__ */
+
+/* only CLOCK_REALTIME and CLOCK_MONOTONIC are emulated */
+#ifndef CLOCK_REALTIME
+ #define CLOCK_REALTIME 0
+#endif
+#ifndef CLOCK_MONOTONIC
+# define CLOCK_MONOTONIC 1
+#endif
+
+
+/* typdef POSIX clockid_t */
+typedef int clockid_t;
+
+/* initialize mach timing */
+int timing_mach_init (void);
+
+/* clock_gettime - emulate POSIX */
+int clock_gettime(const clockid_t id, struct timespec *tspec);
+
+/* clock_nanosleep for CLOCK_MONOTONIC and TIMER_ABSTIME */
+int clock_nanosleep_abstime(const struct timespec *req);
+
+/* __MACH__ */
+/* ******** */
+#else
+/* ***** */
+/* POSIX */
+
+/* clock_nanosleep for CLOCK_MONOTONIC and TIMER_ABSTIME */
+# define clock_nanosleep_abstime(req) \
+         clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, (req), NULL)
+
+/* POSIX */
+/* ***** */
+#endif
+
+/* timer functions that make use of clock_nanosleep_abstime
+   For POSIX systems, it is recommended to use POSIX timers and signals.
+   For Mac OSX (mach), there are no POSIX timers so these functions are very helpful.
+*/
+
+/* Sets absolute time ts_target to ts_step after current time */
+int itimer_start (struct timespec *ts_target, const struct timespec *ts_step);
+
+/* Nanosleeps to ts_target then adds ts_step to ts_target for next iteration */
+int itimer_step (struct timespec *ts_target, const struct timespec *ts_step);
+
+#endif
+/* TIMING_MACH_H */
+/* ************* */
+#endif

--- a/lib/hobbes/util/timing_mach.C
+++ b/lib/hobbes/util/timing_mach.C
@@ -1,0 +1,124 @@
+#if defined(__APPLE__) && defined(__MACH__) && defined(OSX_BEFORE_SIERRA)
+
+/*  from https://github.com/ChisholmKyle/PosixMachTiming
+Copyright (c) 2015, Kyle Chisholm and Jason E. Aten
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#define _POSIX_C_SOURCE 200809L
+#include <unistd.h>
+
+#include <time.h>
+#include "hobbes/util/timing_mach.h"
+
+/* inline functions - maintain ANSI C compatibility */
+#ifdef TIMING_C99
+/* *** */
+/* C99 */
+
+extern double timespec2secd(const struct timespec *ts_in);
+extern void secd2timespec(struct timespec *ts_out, const double sec_d);
+extern void timespec_monodiff_lmr(struct timespec *ts_out,
+                                  const struct timespec *ts_in);
+extern void timespec_monodiff_rml(struct timespec *ts_out,
+                                  const struct timespec *ts_in);
+extern void timespec_monoadd(struct timespec *ts_out,
+                             const struct timespec *ts_in);
+
+#endif
+
+#ifdef __MACH__
+/* ******** */
+/* __MACH__ */
+
+#include <mach/mach_time.h>
+#include <mach/mach.h>
+#include <mach/clock.h>
+
+/* timing struct for osx */
+static struct TimingMach {
+    mach_timebase_info_data_t timebase;
+    clock_serv_t cclock;
+} timing_mach_g;
+
+/* mach clock port */
+extern mach_port_t clock_port;
+
+int timing_mach_init (void) {
+    int retval = mach_timebase_info(&timing_mach_g.timebase);
+    if (retval != 0) return retval;
+    retval = host_get_clock_service(mach_host_self(),
+                                    CALENDAR_CLOCK, &timing_mach_g.cclock);
+    return retval;
+}
+
+#ifdef __cplusplus
+/* auto initialize in C++ */
+class InitTimingMach
+{public:
+  InitTimingMach(){ timing_mach_init(); }
+};
+InitTimingMach startup; // A global instance
+#endif
+
+int clock_gettime(clockid_t id, struct timespec *tspec) {
+    mach_timespec_t mts;
+    int retval = 0;
+    if (id == CLOCK_REALTIME) {
+        retval = clock_get_time(timing_mach_g.cclock, &mts);
+        if (retval != 0) return retval;
+        tspec->tv_sec = mts.tv_sec;
+        tspec->tv_nsec = mts.tv_nsec;
+    } else if (id == CLOCK_MONOTONIC) {
+        retval = clock_get_time(clock_port, &mts);
+        if (retval != 0) return retval;
+        tspec->tv_sec = mts.tv_sec;
+        tspec->tv_nsec = mts.tv_nsec;
+    } else {
+        /* only CLOCK_MONOTOIC and CLOCK_REALTIME clocks supported */
+        return -1;
+    }
+    return 0;
+}
+
+int clock_nanosleep_abstime(const struct timespec *req) {
+    struct timespec ts_delta;
+    int retval = clock_gettime(CLOCK_MONOTONIC, &ts_delta);
+    if (retval != 0) return retval;
+    timespec_monodiff_rml (&ts_delta, req);
+    /* mach does not properly return remainder from nanosleep */
+    retval = nanosleep(&ts_delta, NULL);
+    return retval;
+}
+
+/* __MACH__ */
+/* ******** */
+#endif
+
+int itimer_start (struct timespec *ts_target, const struct timespec *ts_step) {
+    int retval = clock_gettime(CLOCK_MONOTONIC, ts_target);
+    if (retval != 0) return retval;
+    /* add step size to current monotonic time */
+    timespec_monoadd(ts_target, ts_step);
+    return retval;
+}
+
+int itimer_step (struct timespec *ts_target, const struct timespec *ts_step) {
+    int retval = clock_nanosleep_abstime(ts_target);
+    if (retval != 0) return retval;
+    /* move target along */
+    timespec_monoadd(ts_target, ts_step);
+    return retval;
+}
+
+#endif


### PR DESCRIPTION
Tried to build on OSX 10.11.6 El Capitan, got:
```
~/go/src/github.com/Morgan-Stanley/hobbes (master) $ make
Scanning dependencies of target hobbes
[  0%] Building CXX object CMakeFiles/hobbes.dir/lib/hobbes/boot/gen/boot.C.o
[  1%] Building CXX object CMakeFiles/hobbes.dir/lib/hobbes/db/bindings.C.o
[  1%] Building CXX object CMakeFiles/hobbes.dir/lib/hobbes/db/file.C.o
[  2%] Building CXX object CMakeFiles/hobbes.dir/lib/hobbes/db/series.C.o
In file included from /Users/me/go/src/github.com/Morgan-Stanley/hobbes/lib/hobbes/db/series.C:2:
In file included from /Users/me/go/src/github.com/Morgan-Stanley/hobbes/include/hobbes/db/series.H:12:
/Users/me/go/src/github.com/Morgan-Stanley/hobbes/include/hobbes/util/perf.H:15:21: error: 
      use of undeclared identifier 'CLOCK_MONOTONIC'
  if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
                    ^
/Users/me/go/src/github.com/Morgan-Stanley/hobbes/include/hobbes/util/perf.H:25:21: error: 
      use of undeclared identifier 'CLOCK_REALTIME'
  if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
                    ^
2 errors generated.
make[2]: *** [CMakeFiles/hobbes.dir/lib/hobbes/db/series.C.o] Error 1
make[1]: *** [CMakeFiles/hobbes.dir/all] Error 2
make: *** [all] Error 2
~/go/src/github.com/Morgan-Stanley/hobbes (master) $ make

```

Accordingly to this stackoverflow question, El Capitan doesn't have clock_gettime() implemented:

https://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x

Hence this PR provides code from the following repo as suggested by the above stackoverflow answer; this allows hobbes to build on OSX El Capitan, using `LLVM_DIR=/usr/local/opt/llvm@3.7/lib/llvm-3.7/share/llvm/cmake/ cmake .` as suggested in #27. 

https://github.com/ChisholmKyle/PosixMachTiming