### PR TITLE
Support for building with clang on Linux

### DIFF
--- a/bin/hog/batchrecv.C
+++ b/bin/hog/batchrecv.C
@@ -87,7 +87,7 @@ void read(gzbuffer* in, uint8_t* b, size_t n) {
   in->read(b, n);
 }
 
-#ifdef __clang__
+#if defined(BUILD_OSX) && defined(__clang__)
 void read(gzbuffer* in, size_t*   n) { read(in, (uint8_t*)n, sizeof(*n)); }
 #endif
 void read(gzbuffer* in, uint32_t* n) { read(in, (uint8_t*)n, sizeof(*n)); }

--- a/include/hobbes/net.H
+++ b/include/hobbes/net.H
@@ -329,7 +329,7 @@ _HNET_DEFINE_PRIMTYS(int32_t,  "int");
 _HNET_DEFINE_PRIMTYS(uint32_t, "int");
 _HNET_DEFINE_PRIMTYS(int64_t,  "long");
 _HNET_DEFINE_PRIMTYS(uint64_t, "long");
-#ifdef __clang__
+#if defined(BUILD_OSX) && defined(__clang__)
 _HNET_DEFINE_PRIMTYS(size_t,   "long");
 #endif
 _HNET_DEFINE_PRIMTYS(float,    "float");

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -776,7 +776,7 @@ _HSTORE_DEFINE_PRIMTYS(int32_t,  "int");
 _HSTORE_DEFINE_PRIMTYS(uint32_t, "int");
 _HSTORE_DEFINE_PRIMTYS(int64_t,  "long");
 _HSTORE_DEFINE_PRIMTYS(uint64_t, "long");
-#ifdef __clang__
+#if defined(BUILD_OSX) && defined(__clang__)
 _HSTORE_DEFINE_PRIMTYS(size_t, "long");
 #endif
 _HSTORE_DEFINE_PRIMTYS(float,    "float");


### PR DESCRIPTION
It seems building with clang on Linux requires only a simple modification, that too to clang-specific ifdef-ed code.

I don't know about OSX, but on 64-bit Linux, `size_t` being `long unsigned int` is part of the OS API (down to the kernel). Clang on Linux has little choice but to adhere to the same typedef.

There are portions of the code which treat `size_t` as different from `uint64_t` (and `uint32_t`, for that matter) if building under clang. Perhaps that is the case on OSX (seeing as how Linux and OSX are the only two systems hobbes supports building on). So this PR modifies the `ifdef __clang__` guards around the `size_t` handling code to also check for OSX.

To be proper though, I'd like to use typedef equality checks instead of platform flags in ifdefs, but C++'s typedef equality checks only happen at compile-time template resolution and not during preprocessing.