### PR TITLE
disjoint range determination in rmap should match intersection order

### DIFF
--- a/include/hobbes/util/rmap.H
+++ b/include/hobbes/util/rmap.H
@@ -283,18 +283,14 @@ template <typename K, typename V, typename Ord>
           lr.first = Ord::succ(rr.second);
           break;
         case LRE:
-          r.push_back(range(lr.first, rr.first));
-          if (Ord::lt(rr.first, rr.second)) {
-            r.push_back(range(Ord::succ(rr.first), rr.second));
-          }
+          r.push_back(range(lr.first, Ord::pred(rr.first)));
+          r.push_back(range(rr.first, rr.second));
           ++i;
           ++j;
           break;
         case RLE:
-          r.push_back(range(rr.first, lr.first));
-          if (Ord::lt(lr.first, lr.second)) {
-            r.push_back(range(Ord::succ(lr.first), lr.second));
-          }
+          r.push_back(range(rr.first, Ord::pred(lr.first)));
+          r.push_back(range(lr.first, lr.second));
           ++i;
           ++j;
           break;
@@ -312,13 +308,17 @@ template <typename K, typename V, typename Ord>
           break;
         case LRLR:
           r.push_back(range(lr.first, Ord::pred(rr.first)));
-          r.push_back(range(rr.first, Ord::pred(lr.second)));
+          if (rr.first != lr.second) {
+            r.push_back(range(rr.first, Ord::pred(lr.second)));
+          }
           ++i;
           rr.first = lr.second;
           break;
         case RLRL:
-          r.push_back(range(rr.first, lr.first-1));
-          r.push_back(range(lr.first, rr.second-1));
+          r.push_back(range(rr.first, Ord::pred(lr.first)));
+          if (lr.first != rr.second) {
+            r.push_back(range(lr.first, Ord::pred(rr.second)));
+          }
           ++j;
           lr.first = rr.second;
           break;

--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -421,11 +421,11 @@ typedef std::vector<NFAState> NFA;
 
 // for a given set of NFA states, find the set of non-overlapping char ranges
 CharRanges usedCharRanges(const NFA& nfa, const stateset& ss) {
-  CharRanges r;
+  CharRanges rs;
   for (auto s : ss) {
-    r = nfa[s].chars.disjointRanges(r);
+    rs = nfa[s].chars.disjointRanges(rs);
   }
-  return r;
+  return rs;
 }
 
 // accumulate a regex match into an NFA
@@ -652,16 +652,24 @@ stateset epsState(const EpsClosure& ec, const stateset& ss) {
   return r;
 }
 
+void print(std::ostream& out, const stateset& ss) {
+  out << "{";
+  auto s = ss.begin();
+  if (s != ss.end()) {
+    out << *s;
+    ++s;
+    for (; s != ss.end(); ++s) {
+      out << ", " << *s;
+    }
+  }
+  out << "}";
+}
+
 void print(std::ostream& out, const EpsClosure& ec) {
   for (const auto& eset : ec) {
-    out << eset.first << " -> {";
-    auto ss = eset.second.begin();
-    out << *ss;
-    ++ss;
-    for (; ss != eset.second.end(); ++ss) {
-      out << ", " << *ss;
-    }
-    out << "}" << std::endl;
+    out << eset.first << " -> ";
+    print(out, eset.second);
+    out << std::endl;
   }
 }
 
@@ -703,7 +711,9 @@ typedef std::map<stateset, state> Nss2Ds;
 state dfaState(const NFA& nfa, const EpsClosure& ec, Nss2Ds* nss2ds, DFA* dfa, const stateset& ss, RStates* rstates) {
   // did we already make this state?  if so, just return it
   auto didIt = nss2ds->find(ss);
-  if (didIt != nss2ds->end()) { return didIt->second; }
+  if (didIt != nss2ds->end()) {
+    return didIt->second;
+  }
 
   // we need to make this state -- allocate it and remember it
   state result = dfa->size();


### PR DESCRIPTION
This fixes an issue with unreachable row determination for some match tables using regular expressions.