### PR TITLE
handle transitive state substitution in DFA minimization

### DIFF
--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -1091,11 +1091,13 @@ EqStates findEquivStates(const DFA& dfa) {
   }
 
   // convert to a representation that makes state substitution explicit
+  //  (follow mapped-to states in case they are also mapped)
   EqStates r;
   for (size_t s0 = 0; s0 < dfa.size(); ++s0) {
     for (size_t s1 = 0; s1 < s0; ++s1) {
       if (eqStates(s0, s1)) {
-        r[s0] = s1;
+        auto s1t = r.find(s1);
+        r[s0] = s1t == r.end() ? s1 : s1t->second;
       }
     }
   }

--- a/test/Matching.C
+++ b/test/Matching.C
@@ -130,6 +130,9 @@ TEST(Matching, Regex) {
 
   // verify binding in regex matches
   EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("match \"foobar\" with | 'f(?<os>o*)bar' -> os | _ -> \"???\"")()), "oo");
+
+  // verify misc expressions
+  EXPECT_EQ(c().compileFn<int()>("match \"Roba\" with | 'Ka|Roba|Raa' -> 1 | _ -> 0")(), 1);
 }
 
 TEST(Matching, Support) {


### PR DESCRIPTION
This fixes a problem with some regex pattern match expressions where multi-step state substitutions incorrectly mapped to removed states (test case added to verify the fix).