### PR TITLE
introduce a feature for "proof search"

### DIFF
--- a/bin/hi/evaluator.C
+++ b/bin/hi/evaluator.C
@@ -259,5 +259,35 @@ void evaluator::resetREPLCycle() {
   hobbes::resetMemoryPool();
 }
 
+void showSearchResults(const std::string& expr, const hobbes::SearchEntries& ses) {
+  if (ses.size() > 0) {
+    std::map<std::string, std::string> stbl;
+    for (const auto& se : ses) {
+      stbl[se.sym] = hobbes::show(se.ty);
+    }
+
+    hobbes::str::seqs cols;
+    cols.push_back(hobbes::str::seq());
+    cols.push_back(hobbes::str::seq());
+    cols.push_back(hobbes::str::seq());
+    for (const auto& sse : stbl) {
+      cols[0].push_back(sse.first);
+      cols[1].push_back("::");
+      cols[2].push_back(sse.second);
+    }
+    hobbes::str::printHeadlessLeftAlignedTable(std::cout, cols);
+    std::cout << std::endl;
+  }
+}
+
+void evaluator::searchDefs(const std::string& expr_to_type) {
+  auto p = hobbes::str::rsplit(expr_to_type, "?");
+  if (p.first.empty()) {
+    showSearchResults(expr_to_type, this->ctx.search(expr_to_type, "a"));
+  } else {
+    showSearchResults(p.first, this->ctx.search(p.first, p.second));
+  }
+}
+
 }
 

--- a/bin/hi/evaluator.H
+++ b/bin/hi/evaluator.H
@@ -51,6 +51,7 @@ public:
 
   void perfTestExpr(const std::string& expr);
   void breakdownEvalExpr(const std::string& expr);
+  void searchDefs(const std::string& expr_to_type);
   void resetREPLCycle();
 private:
   hobbes::cc ctx;

--- a/bin/hi/main.C
+++ b/bin/hi/main.C
@@ -151,20 +151,21 @@ void showShellHelp(const CmdDescs& cds) {
 
 void showShellHelp() {
   CmdDescs cds;
-  cds.push_back(CmdDesc(":h",   "Show this help"));
-  cds.push_back(CmdDesc(":q",   "Quit the hi shell"));
-  cds.push_back(CmdDesc(":a",   "Print the active LLVM module"));
-  cds.push_back(CmdDesc(":t",   "Print all global variable::type bindings"));
-  cds.push_back(CmdDesc(":d S", "Print the docs for a symbol"));
-  cds.push_back(CmdDesc(":t E", "Show the type of the expression E"));
-  cds.push_back(CmdDesc(":p E", "Show the type of E with hidden type classes left intact"));
-  cds.push_back(CmdDesc(":l F", "Load the hobbes script or image file F"));
-  cds.push_back(CmdDesc(":u E", "Show the 'unsweeten' transform of E"));
-  cds.push_back(CmdDesc(":x E", "Show the x86 assembly code produced by compiling E"));
-  cds.push_back(CmdDesc(":e E", "Find the average run-time of E (in CPU cycles)"));
-  cds.push_back(CmdDesc(":z E", "Evaluate E and show a breakdown of compilation/evaluation time"));
-  cds.push_back(CmdDesc(":c N", "Describe the type class named N"));
-  cds.push_back(CmdDesc(":i N", "Show instances and instance generators for the type class N"));
+  cds.push_back(CmdDesc(":h",     "Show this help"));
+  cds.push_back(CmdDesc(":q",     "Quit the hi shell"));
+  cds.push_back(CmdDesc(":s E T", "Search for paths from the expression E to the type T"));
+  cds.push_back(CmdDesc(":a",     "Print the active LLVM module"));
+  cds.push_back(CmdDesc(":t",     "Print all global variable::type bindings"));
+  cds.push_back(CmdDesc(":d S",   "Print the docs for a symbol"));
+  cds.push_back(CmdDesc(":t E",   "Show the type of the expression E"));
+  cds.push_back(CmdDesc(":p E",   "Show the type of E with hidden type classes left intact"));
+  cds.push_back(CmdDesc(":l F",   "Load the hobbes script or image file F"));
+  cds.push_back(CmdDesc(":u E",   "Show the 'unsweeten' transform of E"));
+  cds.push_back(CmdDesc(":x E",   "Show the x86 assembly code produced by compiling E"));
+  cds.push_back(CmdDesc(":e E",   "Find the average run-time of E (in CPU cycles)"));
+  cds.push_back(CmdDesc(":z E",   "Evaluate E and show a breakdown of compilation/evaluation time"));
+  cds.push_back(CmdDesc(":c N",   "Describe the type class named N"));
+  cds.push_back(CmdDesc(":i N",   "Show instances and instance generators for the type class N"));
   showShellHelp(cds);
 }
 
@@ -278,23 +279,19 @@ void evalLine(char* x) {
     }
 
     // should we do something other than evaluate the input expression?
-    enum EvMode { Eval, ShowASM, Typeof, PuglyTypeof, Unsweeten, PerfTest, BreakdownEval };
+    enum EvMode { Eval, ShowASM, Typeof, PuglyTypeof, Unsweeten, PerfTest, BreakdownEval, SearchDefs };
     EvMode em = Eval;
 
     if (line.size() > 3 && line[0] == ':') {
-      if (line[1] == 'x') {
-        em = ShowASM;
-      } else if (line[1] == 't') {
-        em = Typeof;
-      } else if (line[1] == 'p') {
-        em = PuglyTypeof;
-      } else if (line[1] == 'u') {
-        em = Unsweeten;
-      } else if (line[1] == 'e') {
-        em = PerfTest;
-      } else if (line[1] == 'z') {
-        em = BreakdownEval;
-      } else {
+      switch (line[1]) {
+      case 'x': em = ShowASM;       break;
+      case 't': em = Typeof;        break;
+      case 'p': em = PuglyTypeof;   break;
+      case 'u': em = Unsweeten;     break;
+      case 'e': em = PerfTest;      break;
+      case 'z': em = BreakdownEval; break;
+      case 's': em = SearchDefs;    break;
+      default:
         throw std::runtime_error("Unrecognized command: " + line);
       }
       line = line.substr(3);
@@ -327,6 +324,9 @@ void evalLine(char* x) {
       break;
     case BreakdownEval:
       eval->breakdownEvalExpr(line);
+      break;
+    case SearchDefs:
+      eval->searchDefs(line);
       break;
     }
 

--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -11,6 +11,7 @@
 #include <hobbes/lang/typepreds.H>
 #include <hobbes/read/parser.H>
 #include <hobbes/eval/jitcc.H>
+#include <hobbes/eval/search.H>
 
 #include <hobbes/util/func.H>
 #include <hobbes/util/llvm.H>
@@ -81,7 +82,15 @@ public:
 
   typedef ExprPtr (*readExprFn)(cc*, const std::string&);
   ExprPtr readExpr(const std::string&);
+  MonoTypePtr readMonoType(const std::string&);
   void setReadExprFn(readExprFn);
+
+  // search for paths from one type to another
+  // (currently just one-step paths, may be useful to consider multi-step paths)
+  SearchEntries search(const MonoTypePtr&, const MonoTypePtr&);
+  SearchEntries search(const ExprPtr&, const MonoTypePtr&);
+  SearchEntries search(const std::string&, const MonoTypePtr&);
+  SearchEntries search(const std::string&, const std::string&);
 private:
   readModuleFileFn readModuleFileF;
   readModuleFn     readModuleF;
@@ -231,6 +240,9 @@ public:
   // bind external functions
   void bindExternFunction(const std::string& fname, const MonoTypePtr& fty, void* fn);
 private:
+  // cache for expression search results
+  SearchCache searchCache;
+
   // the JIT engine that compiles our monotyped expressions
   jitcc jit;
 

--- a/include/hobbes/eval/search.H
+++ b/include/hobbes/eval/search.H
@@ -1,0 +1,32 @@
+
+#ifndef HOBBES_EVAL_SEARCH_HPP_INCLUDED
+#define HOBBES_EVAL_SEARCH_HPP_INCLUDED
+
+#include <hobbes/lang/expr.H>
+#include <hobbes/lang/type.H>
+#include <hobbes/util/lannotation.H>
+#include <vector>
+#include <map>
+
+namespace hobbes {
+
+struct SearchEntry {
+  LexicalAnnotation la;  // where in a user's source this entry comes from
+  std::string       sym; // a symbol matching a user query
+  MonoTypePtr       ty;  // the exact result type given by this symbol
+};
+typedef std::vector<SearchEntry> SearchEntries;
+
+struct SearchCache {
+  std::map<MonoTypePtr, SearchEntries> univByType;
+};
+class cc;
+
+// find functions/properties from an expression/type to reach a result type
+SearchEntries search(cc&, SearchCache&, const MonoTypePtr&, const MonoTypePtr&);
+SearchEntries search(cc&, SearchCache&, const ExprPtr&, const MonoTypePtr&);
+
+}
+
+#endif
+

--- a/include/hobbes/ipc/prepl.H
+++ b/include/hobbes/ipc/prepl.H
@@ -20,6 +20,7 @@ struct proc {
 };
 
 void spawn(const std::string&, proc*);
+void procSearch(proc*, const std::string&, const std::string&);
 void procDefine(proc*, const std::string&, const std::string&);
 void procEval(proc*, const std::string&);
 void procTypeof(proc* p, const std::string& x);

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -117,6 +117,11 @@ cc::cc() :
 cc::~cc() {
 }
 
+SearchEntries cc::search(const MonoTypePtr& src, const MonoTypePtr& dst) { return hobbes::search(*this, this->searchCache, src, dst); }
+SearchEntries cc::search(const ExprPtr&     e,   const MonoTypePtr& dst) { return hobbes::search(*this, this->searchCache, e, dst); }
+SearchEntries cc::search(const std::string& e,   const MonoTypePtr& dst) { return search(readExpr(e), dst); }
+SearchEntries cc::search(const std::string& e,   const std::string& t)   { return search(readExpr(e), readMonoType(t)); }
+
 ModulePtr cc::readModuleFile(const std::string& x) { return this->readModuleFileF(this, x); }
 void cc::setReadModuleFileFn(readModuleFileFn f) { this->readModuleFileF = f; }
 
@@ -128,6 +133,14 @@ void cc::setReadExprDefnFn(readExprDefnFn f) { this->readExprDefnF = f; }
 
 ExprPtr cc::readExpr(const std::string& x) { return this->readExprF(this, x); }
 void cc::setReadExprFn(readExprFn f) { this->readExprF = f; }
+MonoTypePtr cc::readMonoType(const std::string& x) {
+  ExprPtr e = readExpr("()::"+x);
+  if (const Assump* a = is<Assump>(e)) {
+    return a->ty()->monoType();
+  } else {
+    throw std::runtime_error("Couldn't parse as type: " + x);
+  }
+}
 
 ExprPtr cc::unsweetenExpression(const TEnvPtr& te, const ExprPtr& e) {
   return unsweetenExpression(te, "", e);

--- a/lib/hobbes/eval/search.C
+++ b/lib/hobbes/eval/search.C
@@ -1,0 +1,208 @@
+
+#include <hobbes/eval/cc.H>
+#include <hobbes/eval/search.H>
+
+namespace hobbes {
+
+// labels :: TEnv -> [string]
+//  (find the universe of all "labels" [record field names, variant constructor names, ...])
+struct findLabelsF : public switchType<unit> {
+  std::set<std::string>* lbls;
+  findLabelsF(std::set<std::string>* lbls) : lbls(lbls) { }
+
+  unit with(const TString* v) const {
+    this->lbls->insert(v->value());
+    return unit();
+  }
+
+  unit with(const Variant* v) const {
+    for (const auto& m : v->members()) {
+      if (!m.selector.empty() && m.selector[0] != '.') {
+        this->lbls->insert(m.selector);
+      }
+      switchOf(m.type, *this);
+    }
+    return unit();
+  }
+
+  unit with(const Record* v) const {
+    for (const auto& m : v->members()) {
+      if (!m.field.empty() && m.field[0] != '.') {
+        this->lbls->insert(m.field);
+      }
+      switchOf(m.type, *this);
+    }
+    return unit();
+  }
+
+  unit with(const TAbs*       v) const { return switchOf(v->body(), *this); }
+  unit with(const TApp*       v) const { switchOf(v->fn(), *this); switchOf(v->args(), *this); return unit(); }
+  unit with(const FixedArray* v) const { switchOf(v->type(), *this); return switchOf(v->length(), *this); }
+  unit with(const Array*      v) const { return switchOf(v->type(), *this); }
+  unit with(const Func*       v) const { switchOf(v->argument(), *this); return switchOf(v->result(), *this); }
+  unit with(const Exists*     v) const { return switchOf(v->absType(), *this); }
+  unit with(const Recursive*  v) const { return switchOf(v->recType(), *this); }
+  
+  unit with(const Prim*       v) const { return unit(); }
+  unit with(const OpaquePtr*  v) const { return unit(); }
+  unit with(const TVar*       v) const { return unit(); }
+  unit with(const TGen*       v) const { return unit(); }
+  unit with(const TLong*      v) const { return unit(); }
+  unit with(const TExpr*      v) const { return unit(); }
+};
+static void accumLabels(std::set<std::string>* lbls, const MonoTypePtr& t) {
+  switchOf(t, findLabelsF(lbls));
+}
+static void accumLabels(std::set<std::string>* lbls, const TEnvPtr& tenv) {
+  // gather labels across ground SLookup instances since these will be relevant
+  // (it might be reasonable to gather labels across types in _all_ ground type class instances)
+  try {
+    auto uq = tenv->lookupUnqualifier("SLookup");
+    if (const TClass* c = dynamic_cast<const TClass*>(uq.get())) {
+      for (auto i : c->instances()) {
+        if (i->types().size() > 2) {
+          if (const TString* s = is<TString>(i->types()[1])) {
+            lbls->insert(s->value());
+          }
+        }
+      }
+    }
+  } catch (std::exception&) {
+  }
+
+  // gather labels across all bindings in the type environment
+  for (const auto& vnt : tenv->typeEnvTable()) {
+    if (!vnt.first.empty() && vnt.first[0] != '.') {
+      lbls->insert(vnt.first);
+
+      if (vnt.second->typeVariables() == 0 && vnt.second->qualtype()->constraints().size() == 0) {
+        accumLabels(lbls, vnt.second->qualtype()->monoType());
+      }
+    }
+  }
+}
+
+static std::set<std::string> labels(const TEnvPtr& tenv) {
+  std::set<std::string> r;
+  accumLabels(&r, tenv);
+  return r;
+}
+
+// find all "properties" for a given type
+void findProperties(cc& c, SearchEntries* es, const MonoTypePtr& t) {
+  for (const auto& lbl : labels(c.typeEnv())) {
+    try {
+      MonoTypeUnifier u(c.typeEnv());
+      MonoTypePtr sty = freshTypeVar();
+      ConstraintPtr tcst(HasField::newConstraint(HasField::Read, t, TString::make(lbl), sty));
+
+      // refine this constraint to a fixed point
+      Definitions ds;
+      while (refine(c.typeEnv(), tcst, &u, &ds)) {
+        c.drainUnqualifyDefs(ds);
+        ds.clear();
+      }
+      c.drainUnqualifyDefs(ds);
+
+      // make sure that the output type exists and is realizable
+      MonoTypePtr result = u.substitute(sty);
+
+      if (isMonoSingular(result)) {
+        SearchEntry e;
+        e.la  = LexicalAnnotation::null();
+        e.sym = "." + lbl;
+        e.ty  = result;
+        es->push_back(e);
+      }
+    } catch (std::exception&) {
+    }
+  }
+  hobbes::compactMTypeMemory();
+}
+
+
+// find all possible search entries for a given type
+SearchEntries findAll(cc& c, const MonoTypePtr& src) {
+  SearchEntries result;
+  findProperties(c, &result, src);
+  return result;
+}
+
+// test whether an existing search entry matches a desired destination type
+struct containsTypeF : public switchType<bool> {
+  MonoTypePtr ty;
+  containsTypeF(const MonoTypePtr& ty) : ty(ty) { }
+  bool baseC(const MonoType& t) const { return t == *this->ty; }
+  bool anyC(const MonoTypes& ts) const { for (const auto& t : ts) { if (switchOf(t, *this)) return true; } return false; }
+
+  bool with(const Variant* v) const {
+    if (baseC(*v)) return true;
+    for (const auto& m : v->members()) {
+      if (switchOf(m.type, *this)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool with(const Record* v) const {
+    if (baseC(*v)) return true;
+    for (const auto& m : v->members()) {
+      if (switchOf(m.type, *this)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool with(const TAbs*       v) const { return baseC(*v) || switchOf(v->body(), *this); }
+  bool with(const TApp*       v) const { return baseC(*v) || switchOf(v->fn(), *this) || anyC(v->args()); }
+  bool with(const FixedArray* v) const { return baseC(*v) || switchOf(v->type(), *this) || switchOf(v->length(), *this); }
+  bool with(const Array*      v) const { return baseC(*v) || switchOf(v->type(), *this); }
+  bool with(const Func*       v) const { return baseC(*v) || switchOf(v->argument(), *this) || switchOf(v->result(), *this); }
+  bool with(const Exists*     v) const { return baseC(*v) || switchOf(v->absType(), *this); }
+  bool with(const Recursive*  v) const { return baseC(*v) || switchOf(v->recType(), *this); }
+  
+  bool with(const Prim*      v) const { return baseC(*v); }
+  bool with(const OpaquePtr* v) const { return baseC(*v); }
+  bool with(const TVar*      v) const { return baseC(*v); }
+  bool with(const TGen*      v) const { return baseC(*v); }
+  bool with(const TLong*     v) const { return baseC(*v); }
+  bool with(const TString*   v) const { return baseC(*v); }
+  bool with(const TExpr*     v) const { return baseC(*v); }
+};
+bool validSearchResult(const SearchEntry& e, const MonoTypePtr& dst) {
+  return switchOf(e.ty, containsTypeF(dst));
+}
+
+// search for symbols going from one type to another
+SearchEntries search(cc& c, SearchCache& sc, const MonoTypePtr& src, const MonoTypePtr& dst) {
+  if (sc.univByType[src].size() == 0) {
+    sc.univByType[src] = findAll(c, src);
+  }
+
+  if (is<TVar>(dst)) {
+    // searching for everything, we already have it
+    return sc.univByType[src];
+  } else {
+    // include just entries that match the desired dest type
+    SearchEntries r;
+    for (const auto& e : sc.univByType[src]) {
+      if (validSearchResult(e, dst)) {
+        r.push_back(e);
+      }
+    }
+    return r;
+  }
+}
+
+SearchEntries search(cc& c, SearchCache& sc, const ExprPtr& e, const MonoTypePtr& t) {
+  try {
+    return search(c, sc, requireMonotype(c.unsweetenExpression(e)->type()), t);
+  } catch (std::exception&) {
+    return SearchEntries();
+  }
+}
+
+}
+


### PR DESCRIPTION
This is just a basic first draft of a feature to allow us to search for properties and functions to get from a source expression to a destination type.

Hopefully this will ultimately be a great help to automate documentation and support of hobbes programs.

I tested it by adding some simple "properties" to the datetime type and then searched for them, in this way:

```
$ cat t.hob
instance SLookup datetime "time" time where
  slookup = time
instance SLookup datetime "ymd" [char] where
  slookup dt = strftime("%Y%m%d", convert(dt))
instance SLookup datetime "hms" [char] where
  slookup dt = strftime("%H:%M:%S",convert(dt))

$ hi -s t.hob
> :s now()
.hms  :: [char]
.time :: time
.ymd  :: [char]
> :s now() ? time
.time :: time
> :s now() ? [char]
.hms :: [char]
.ymd :: [char]
```