### PR TITLE
prevent record introduction with duplicate field names

### DIFF
--- a/lib/hobbes/lang/typeinf.C
+++ b/lib/hobbes/lang/typeinf.C
@@ -712,8 +712,13 @@ struct expTypeInfF : public switchExprM<UnitV> {
 
   UnitV with(MkRecord* v) {
     QualTypes ftys;
+    str::set fnames;
 
     for (MkRecord::FieldDefs::const_iterator f = v->fields().begin(); f != v->fields().end(); ++f) {
+      if (!fnames.insert(f->first).second) {
+        throw annotated_error(*v, "Duplicate field name introduction: " + f->first);
+      }
+
       switchOf(f->second, *this);
       ftys.push_back(f->second->type());
     }

--- a/test/Matching.C
+++ b/test/Matching.C
@@ -121,12 +121,13 @@ TEST(Matching, Regex) {
   EXPECT_EQ(c().compileFn<int()>("match \"foo\" 42 with | 'a(b|c)' 1 -> 1 | 'ab' 2 -> 2 | 'ac' 3 -> 3 | _ _ -> 4")(), 4);
 
   // verify unreachable row determination
+  bool unreachableExn = false;
   try {
     c().compileFn<int()>("match \"foo123ooo\" with | '123|foo.*' -> 0 | 'foo.*' -> 1 | _ -> -1");
-    EXPECT_FALSE("failed to determine expected unreachable regex row");
   } catch (std::exception&) {
-    EXPECT_TRUE(true);
+    unreachableExn = true;
   }
+  EXPECT_TRUE(unreachableExn && "failed to determine expected unreachable regex row");
 
   // verify binding in regex matches
   EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("match \"foobar\" with | 'f(?<os>o*)bar' -> os | _ -> \"???\"")()), "oo");

--- a/test/Structs.C
+++ b/test/Structs.C
@@ -102,11 +102,21 @@ TEST(Structs, Bindings) {
 }
 
 TEST(Structs, Assignment) {
+  bool assignExn = false;
   try {
     c().compileFn<void()>("bob.x <- 'c'")();
-    EXPECT_TRUE( false && "Expected char assignment to int field to fail to compile (mistake in assignment compilation?)" );
   } catch (std::exception&) {
+    assignExn = true;
   }
+  EXPECT_TRUE( assignExn && "Expected char assignment to int field to fail to compile (mistake in assignment compilation?)" );
+
+  bool introExn = false;
+  try {
+    c().compileFn<int()>("{x=1, x='c'}.x");
+  } catch (std::exception&) {
+    introExn = true;
+  }
+  EXPECT_TRUE( introExn && "Expected rejection of record introduction with duplicate field names" );
 
   c().compileFn<void()>("bob.x <- 90")();
   EXPECT_TRUE(c().compileFn<bool()>("bob.x == 90")());


### PR DESCRIPTION
This will show a more obvious error message when scripts introduce records with duplicate field names.