### PR TITLE
Fix a bug with global function aliases

### DIFF
--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -460,13 +460,13 @@ llvm::Value* jitcc::loadConstant(const std::string& vn) {
   if (cv != this->constants.end()) {
     if (is<Array>(cv->second.mtype)) {
       return builder()->CreateLoad(refGlobal(vn, cv->second.ref));
-    } else {
-      llvm::Value* r = refGlobal(vn, cv->second.ref);
+    } else if (llvm::Value* r = refGlobal(vn, cv->second.ref)) {
       return hasPointerRep(cv->second.mtype) ? r : builder()->CreateLoad(r);
+    } else {
+      return cv->second.value;
     }
-  } else {
-    return 0;
   }
+  return 0;
 }
 
 void jitcc::defineGlobal(const std::string& vn, const ExprPtr& ue) {

--- a/test/Definitions.C
+++ b/test/Definitions.C
@@ -46,3 +46,15 @@ TEST(Definitions, RecType) {
   EXPECT_TRUE(c().compileFn<bool()>("llen(cons(9L,nil())) == 1L")());
   EXPECT_TRUE(c().compileFn<bool()>("llen(cons(9S,nil())) == 1L")());
 }
+
+TEST(Definitions, FuncAliases) {
+  c().define("f1", "(\\(). 42)::()->int");
+  c().define("f2", "f1");
+  EXPECT_EQ(c().compileFn<int()>("f2()")(), 42)
+}
+
+TEST(Definitions, StructsWithFns) {
+  c().define("prof", "{x=[1,2,3], y=\\().putStrLn(\"hello world\")}");
+  EXPECT_EQ(c().compileFn<int()>("sum(prof.x)")(), 6);
+}
+


### PR DESCRIPTION
Defining one global function as an alias for another failed to produce the right reference and led to a crash inside of LLVM.  This fixes that bug and validates it with a test.