### PR TITLE
in compileFn, also infer function types by pointer

### DIFF
--- a/include/hobbes/util/func.H
+++ b/include/hobbes/util/func.H
@@ -15,6 +15,13 @@ template <typename R, typename ... Args>
     typedef R result_type;
   };
 
+template <typename R, typename ... Args>
+  struct func<R(*)(Args...)> {
+    static const std::size_t arity = sizeof...(Args);
+    typedef R (*type)(Args...);
+    typedef R result_type;
+  };
+
 template <typename R, typename C, typename ... Args>
   struct func<R(C::*)(Args...)> {
     static const std::size_t arity = sizeof...(Args);

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -51,3 +51,8 @@ TEST(Compiler, liftApathy) {
   EXPECT_EQ(show(lift<const BV&>::type(c())), "(<char> * long)");
 }
 
+TEST(Compiler, compileFnTypes) {
+  EXPECT_EQ(c().compileFn<int(const std::string&)>("_","42")(""), 42);
+  EXPECT_EQ(c().compileFn<int(*)(const std::string&)>("_","42")(""), 42);
+}
+


### PR DESCRIPTION
This makes some user code simpler, as some people were writing redundant type descriptions.