### PR TITLE
allow optional placement of the hstore producer registration domain socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - os: linux
       compiler: g++
       root: required
+      dist: trusty
+      group: deprecated-2017Q4
       services:
         - docker
       env:

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -240,8 +240,13 @@ inline int mqlisten(const std::string& fileName) {
   return s;
 }
 
-inline std::string tempDir() {
+inline std::string defaultStoreDir() {
   const char* td = 0;
+  if ((td = ::getenv("HOBBES_STORE_DIR"))) {
+    if (::strlen(td) > 0 && ::access(td, W_OK) == 0) {
+      return std::string(td);
+    }
+  }
   if ((td = ::getenv("TMPDIR"))) {
     if (::strlen(td) > 0 && ::access(td, W_OK) == 0) {
       return std::string(td);
@@ -258,12 +263,12 @@ inline std::string tempDir() {
   return "/tmp";
 }
 
-inline int connectGroupHost(const std::string& groupName) {
-  return mqconnect(tempDir() + "/hstore." + groupName + ".sk");
+inline int connectGroupHost(const std::string& groupName, const std::string& sdir = defaultStoreDir()) {
+  return mqconnect(sdir + "/hstore." + groupName + ".sk");
 }
 
-inline int makeGroupHost(const std::string& groupName) {
-  return mqlisten(tempDir() + "/hstore." + groupName + ".sk");
+inline int makeGroupHost(const std::string& groupName, const std::string& sdir = defaultStoreDir()) {
+  return mqlisten(sdir + "/hstore." + groupName + ".sk");
 }
 
 // identify this process/thread


### PR DESCRIPTION
This will make it possible to isolate recording sessions for the same application/group on a single host.  Previously the domain socket used for producer registration was always placed in the temp directory, meaning that just a single 'hog' instance could be running for a particular storage group system-wide.