### PR TITLE
allow the Data constraint to open types through abstraction and application

### DIFF
--- a/include/hobbes/eval/func.H
+++ b/include/hobbes/eval/func.H
@@ -10,19 +10,6 @@
 namespace hobbes {
 
 // low-level representation decisions ...
-inline MonoTypePtr repType(const MonoTypePtr& t) {
-  if (const Prim* pt = is<Prim>(t)) {
-    if (pt->representation()) {
-      return repType(pt->representation());
-    }
-  } else if (const TApp* a = is<TApp>(t)) {
-    if (const TAbs* tf = is<TAbs>(repType(a->fn()))) {
-      return repType(substitute(substitution(tf->args(), a->args()), tf->body()));
-    }
-  }
-  return t;
-}
-
 inline bool hasPointerRep(const MonoTypePtr& t) {
   MonoTypePtr rt = repType(t);
 

--- a/include/hobbes/lang/type.H
+++ b/include/hobbes/lang/type.H
@@ -1004,6 +1004,9 @@ MonoTypePtr   simplifyVarNames(const MonoType&);
 MonoTypePtr   simplifyVarNames(const MonoTypePtr&);
 MonoTypes     simplifyVarNames(const MonoTypes& mts);
 
+// forget fancy type aliases, determine a reduced representation type
+MonoTypePtr repType(const MonoTypePtr&);
+
 // simplify working with type structures lifting of C++ types
 inline MonoTypePtr primty(const char* x) {
   return Prim::make(x);


### PR DESCRIPTION
The motivating use-case here is to store "fancy types" in structured logs, e.g. an "enum set" represented by a 64-bit int -- stored as a 64-bit int but can be queried/displayed as a "set of enum values".