### PR TITLE
hog batchsend supports multiple destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,12 +476,14 @@ Now, at the same time that this program runs, we will also want to run another p
 $ hog
 hog : record structured data locally or to a remote process
 
-  usage: hog [-d <dir>] [-g group+] [-p t s host:port] [-s port]
+  usage: hog [-d <dir>] [-g group+] [-p t s host:port+] [-s port] [-c] [-m <dir>]
 where
-  -d <dir>         : decides where structured data (or temporary data) is stored
-  -g group+        : decides which data to record from memory on this machine
-  -p t s host:port : decides to send data to a remote process every t time units or every s uncompressed bytes written
-  -s port          : decides to receive data on the given port
+  -d <dir>          : decides where structured data (or temporary data) is stored
+  -g group+         : decides which data to record from memory on this machine
+  -p t s host:port+ : decides to send data to remote process(es) every t time units or every s uncompressed bytes written
+  -s port           : decides to receive data on the given port
+  -c                : decides to store equally-typed data across processes in a single file
+  -m <dir>          : decides where to place the domain socket for producer registration
 $
 ```
 

--- a/bin/hog/batchrecv.C
+++ b/bin/hog/batchrecv.C
@@ -14,6 +14,7 @@
 
 #include "session.H"
 #include "netio.H"
+#include "path.H"
 
 using namespace hobbes;
 
@@ -147,7 +148,7 @@ void runRecvConnection(SessionGroup* sg, int c, std::string dir) {
     storage::statements stmts;
     read(&zb, &stmts);
 
-    auto txnF = appendStorageSession(sg, str::replace<char>(dir, "$GROUP", group), (storage::PipeQOS)qos, (storage::CommitMethod)cm, stmts);
+    auto txnF = appendStorageSession(sg, instantiateDir(group, dir), (storage::PipeQOS)qos, (storage::CommitMethod)cm, stmts);
 
     ssend(c, &ack, sizeof(ack));
 

--- a/bin/hog/batchsend.H
+++ b/bin/hog/batchsend.H
@@ -6,10 +6,11 @@
 #define HOG_BATCHSEND_H_INCLUDED
 
 #include <string>
+#include <vector>
 #include <hobbes/storage.H>
 
 namespace hog {
-void pushLocalData(const hobbes::storage::QueueConnection&, const std::string& groupName, const std::string& dir, size_t clevel, size_t batchsendsize, long batchsendtimeInMicros, const std::string& sendto);
+void pushLocalData(const hobbes::storage::QueueConnection&, const std::string& groupName, const std::string& dir, size_t clevel, size_t batchsendsize, long batchsendtimeInMicros, const std::vector<std::string>& sendto);
 }
 
 #endif

--- a/bin/hog/path.C
+++ b/bin/hog/path.C
@@ -1,0 +1,24 @@
+#include <hobbes/util/str.H>
+
+#include "path.H"
+
+namespace hog {
+
+std::string instantiateDir(const std::string& groupName, const std::string& dir) {
+  // instantiate group name
+  std::string x = hobbes::str::replace<char>(dir, "$GROUP", groupName);
+
+  // instantiate date
+  time_t now = ::time(0);
+  if (const tm* t = localtime(&now)) {
+    std::ostringstream ss;
+    ss << t->tm_year + 1900 << "." << (t->tm_mon < 10 ? "0" : "") << t->tm_mon + 1 << "." << (t->tm_mday < 10 ? "0" : "") << t->tm_mday;
+    x = hobbes::str::replace<char>(x, "$DATE", ss.str());
+  }
+
+  // that's all we will substitute
+  return x;
+}
+
+}
+

--- a/bin/hog/path.H
+++ b/bin/hog/path.H
@@ -1,0 +1,13 @@
+#ifndef HOG_PATH_H_INCLUDED
+#define HOG_PATH_H_INCLUDED
+
+#include <string>
+
+namespace hog {
+
+std::string instantiateDir(const std::string& groupName, const std::string& dir);
+
+}
+
+#endif
+

--- a/test/Hog.C
+++ b/test/Hog.C
@@ -1,0 +1,285 @@
+#include <hobbes/hobbes.H>
+#include <hobbes/storage.H>
+#include <hobbes/db/file.H>
+#include <hobbes/ipc/net.H>
+#include <hobbes/util/perf.H>
+#include "test.H"
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cstdio>
+#include <climits>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+#include <glob.h>
+
+std::string hogBinaryPath() {
+  static char path[PATH_MAX];
+  auto p = getenv("HOG_BIN");
+  if (p) {
+    return p;
+  }
+  // assuming hog and hobbes-test are in the same folder
+  getcwd(path, sizeof(path));
+  strcat(path, "/hog");
+  return path;
+}
+
+DEFINE_HSTORE_STRUCT(
+  Point3D,
+  (int, x),
+  (int, y),
+  (int, z)
+);
+
+DEFINE_STORAGE_GROUP(
+  Space,
+  1024,
+  hobbes::storage::Reliable,
+  hobbes::storage::AutoCommit
+);
+
+struct RunMode {
+  enum type { local, batchsend, batchrecv };
+
+  type                     t;
+
+  // batchsend
+  std::vector<std::string> groups;
+  std::vector<std::string> sendto;
+  std::string              batchsendsize;
+  std::string              batchsendtime;
+
+  // batchrecv
+  std::string              port;
+  bool                     consolidate;
+
+  // binary
+  std::string              program;
+
+  RunMode(const std::vector<std::string>& groups, const std::vector<std::string>& sendto, size_t size, long time)
+  : t(batchsend), groups(groups), sendto(sendto),
+    batchsendsize(std::to_string(size)),
+    batchsendtime(std::to_string(time)),
+    program(hogBinaryPath()) {
+  }
+
+  RunMode(int port, bool consolidate = false)
+    : t(batchrecv), port(std::to_string(port)), consolidate(consolidate), program(hogBinaryPath()) {}
+
+  std::vector<const char*> argv() const {
+    std::vector<const char*> args { program.c_str() };
+    if (t == batchrecv) {
+      args.push_back("-s");
+      args.push_back(port.c_str());
+      if (consolidate) {
+        args.push_back("-c");
+      }
+    } else if (t == batchsend) {
+      args.push_back("-g");
+      for (const auto & g : groups) {
+        args.push_back(g.c_str());
+      }
+      args.push_back("-p");
+      args.push_back(batchsendtime.c_str());
+      args.push_back(batchsendsize.c_str());
+      for (const auto & d : sendto) {
+        args.push_back(d.c_str());
+      }
+    }
+    args.push_back(nullptr); // required by execv()
+    return args;
+  }
+};
+
+class HogApp {
+public:
+  HogApp(const RunMode& mode)
+  : mode(mode), pid(-1) {
+    strcpy(cwd, "/var/tmp/hobbes-test/hog/XXXXXX");
+    hobbes::ensureDirExists(hobbes::str::rsplit(cwd, "/").first);
+    if (mkdtemp(cwd) == NULL) {
+      throw std::runtime_error("error while mkdtemp: " + std::string(strerror(errno)));
+    }
+  }
+
+  ~HogApp() {
+    if (started()) {
+      stop();
+    }
+  }
+
+  void start() {
+    pid = fork();
+    if (pid == -1) {
+      throw std::runtime_error("error while fork: " + std::string(strerror(errno)));
+    } else if (pid == 0) {
+      chdir(cwd);
+
+      // IO redirect
+      std::freopen("stdout", "a", stdout);
+      std::freopen("stderr", "a", stderr);
+
+      auto argv = mode.argv();
+      execv(argv[0], (char* const*)argv.data());
+
+      // shouldn't reach here
+      throw std::runtime_error("error while exec: " + std::string(strerror(errno)));
+    }
+  }
+
+  void stop() {
+    if (started()) {
+      if (kill(pid, SIGTERM) == -1) {
+        throw std::runtime_error("error while kill: " + std::string(strerror(errno)));
+      }
+      int ws;
+      if (waitpid(pid, &ws, 0) == -1) {
+        throw std::runtime_error("error while waitpid: " + std::string(strerror(errno)));
+      }
+      pid = -1;
+    }
+  }
+
+  void restart(std::function<void()> meanwhileFn = [](){}) {
+    stop();
+    if (meanwhileFn) {
+      meanwhileFn();
+    }
+    start();
+  }
+
+  bool started() const { return pid != -1; }
+
+  std::string name() const {
+    return hobbes::str::rsplit(cwd, "/").second;
+  }
+
+  std::string localport() const {
+    return "localhost:" + mode.port;
+  }
+
+  std::vector<std::string> logpaths() const {
+    std::vector<std::string> paths;
+    std::string pattern(cwd);
+    pattern += "/Space/*/*.log";
+
+    glob_t g;
+    if (glob(pattern.c_str(), GLOB_NOSORT, nullptr, &g) == 0) {
+      for (auto i = 0; i < g.gl_pathc; ++i) {
+        paths.push_back(g.gl_pathv[i]);
+      }
+      globfree(&g);
+    }
+
+    std::sort(paths.begin(), paths.end(), [](const std::string& p1, const std::string& p2){
+      struct stat s1, s2;
+      stat(p1.c_str(), &s1);
+      stat(p2.c_str(), &s2);
+      return s1.st_ctime < s2.st_ctime;
+    });
+
+    return paths;
+  }
+
+private:
+  const RunMode mode;
+  char cwd[PATH_MAX];
+  pid_t pid;
+};
+
+int availablePort(int low, int high) {
+  auto port = low;
+  while (port < high) {
+    try {
+      close(hobbes::allocateServer(port));
+      return port;
+    } catch (std::exception&) {
+      ++port;
+    }
+  }
+  throw std::runtime_error("port unavailable");
+}
+
+void flushData(int first, int last) {
+  for (auto i = first; i < last; ++i) {
+    HSTORE(Space, coordinate, Point3D{i, i, i});
+  }
+  Space.commit(); // flushing any data in the queue
+}
+
+#define EXPECT_EQ_IN_SERIES(logs, series, expr, expect) \
+  do { \
+    hobbes::cc cc; \
+    std::vector<const char*> d expect; \
+    EXPECT_EQ(logs.size(), d.size()); \
+    for (auto i = 0; i < logs.size(); ++i) { \
+      std::ostringstream logname, loadexpr, evalexpr; \
+      logname << "log" << i; \
+      loadexpr << "inputFile :: (LoadFile \"" << logs[i] << "\" w) => w"; \
+      evalexpr << "map(" << expr << ", alflatten([p|p<-" << logname.str() << "." << series << "]))"; \
+      cc.define(logname.str(), loadexpr.str()); \
+      EXPECT_TRUE(cc.compileFn<bool()>(evalexpr.str() + "==" + d[i])()); \
+    } \
+  } while (0)
+
+#define WITH_TIMEOUT(second, expectFn) \
+  do { \
+    auto now = hobbes::time(); \
+    const auto end = now + second * 1000000000L; \
+    while (true) { \
+      try { \
+        expectFn; \
+        break; \
+      } catch (std::exception&) { \
+        now = hobbes::time(); \
+        if (now < end) { \
+          sleep(1); \
+        } else { \
+          throw; \
+        } \
+      } \
+    } \
+  } while (0)
+
+TEST(BatchSend, MultiDestination) {
+  std::vector<HogApp> batchrecv {
+    HogApp(RunMode(availablePort(10000, 10100))),
+    HogApp(RunMode(availablePort(10100, 10200)))
+  };
+  HogApp batchsend(RunMode{{"Space"}, {batchrecv[0].localport(), batchrecv[1].localport()}, 1024, 1000000});
+
+  for (auto & hog : batchrecv) {
+    hog.start();
+  }
+  batchsend.start();
+  sleep(5);
+
+  flushData(0, 100);
+
+  WITH_TIMEOUT(30, EXPECT_EQ_IN_SERIES(batchrecv[0].logpaths(), "coordinate", ".x", {"[0..99]"}));
+  WITH_TIMEOUT(30, EXPECT_EQ_IN_SERIES(batchrecv[1].logpaths(), "coordinate", ".x", {"[0..99]"}));
+
+  batchrecv[0].restart([&batchrecv](){
+    flushData(100, 200);
+
+    WITH_TIMEOUT(10, EXPECT_EQ_IN_SERIES(batchrecv[0].logpaths(), "coordinate", ".x", {"[0..99]"}));
+    WITH_TIMEOUT(10, EXPECT_EQ_IN_SERIES(batchrecv[1].logpaths(), "coordinate", ".x", {"[0..199]"}));
+  });
+
+  WITH_TIMEOUT(30, EXPECT_EQ_IN_SERIES(batchrecv[0].logpaths(), "coordinate", ".x", ({"[0..99]", "[100..199]"})));
+
+  batchrecv[0].restart([&batchrecv](){
+    batchrecv[1].restart([](){
+      flushData(200, 300);
+    });
+  });
+
+  WITH_TIMEOUT(30, EXPECT_EQ_IN_SERIES(batchrecv[0].logpaths(), "coordinate", ".x", ({"[0..99]", "[100..199]", "[200..299]"})));
+  WITH_TIMEOUT(30, EXPECT_EQ_IN_SERIES(batchrecv[1].logpaths(), "coordinate", ".x", ({"[0..199]", "[200..299]"})));
+}
+

--- a/test/test.H
+++ b/test/test.H
@@ -31,12 +31,18 @@ private:
   bool install_##G##_##N = TestCoord::instance().installTest(#G, #N, &test_##G##_##N); \
   void test_##G##_##N()
 
+#define FILEINFO(file, line) (std::string("(") + hobbes::str::rsplit(file, "/").second + ":" + std::to_string(line) + ")")
+
 #define EXPECT_TRUE(p) \
   if (!(p)) { \
-    throw std::runtime_error("Expression false, expected true: " #p); \
+    std::ostringstream __errmsg; \
+    __errmsg << "Expression false, expected true: " #p << " " << FILEINFO(__FILE__, __LINE__); \
+    throw std::runtime_error(__errmsg.str()); \
   }
 #define EXPECT_FALSE(p) \
   if ((p)) { \
+    std::ostringstream __errmsg; \
+    __errmsg << "Expression true, expected false: " #p << " " << FILEINFO(__FILE__, __LINE__); \
     throw std::runtime_error("Expression true, expected false: " #p); \
   }
 #define EXPECT_EQ(p,x) \
@@ -45,7 +51,7 @@ private:
     auto z = (x); \
     if (!(v == z)) { \
       std::ostringstream __errmsg; \
-      __errmsg << "Expression '" #p "' == " << v << ", but expected " << z; \
+      __errmsg << "Expression '" #p "' == " << v << ", but expected " << z << " " << FILEINFO(__FILE__, __LINE__); \
       throw std::runtime_error(__errmsg.str()); \
     } \
   }
@@ -55,7 +61,7 @@ private:
     auto z = (x); \
     if (v == z) { \
       std::ostringstream __errmsg; \
-      __errmsg << "Expression '" #p "' == " << v << ", but expected anything else"; \
+      __errmsg << "Expression '" #p "' == " << v << ", but expected anything else" << " " << FILEINFO(__FILE__, __LINE__); \
       throw std::runtime_error(__errmsg.str()); \
     } \
   }


### PR DESCRIPTION
This change includes a trivial implementation of pushing data to multiple tcp destinations in hog batchsend mode.  The `-p` option is extended to support multiple destinations.  The sending states, e.g. segment files, of each destination are isolated from each other using dedicated folders and hard links.  In case of any connection is down, batchsend will keep pushing data on other destination(s).  Once a broken connection is re-established, batchsend will continue sending data from what it had left previously.  Given a sufficient amount of time, all destinations are expected to receive the same data.