### PR TITLE
introduce a constraint/function for more efficient generic variant deconstruction

### DIFF
--- a/include/hobbes/lang/preds/vapp.H
+++ b/include/hobbes/lang/preds/vapp.H
@@ -1,0 +1,33 @@
+
+#ifndef HOBBES_LANG_TYPEPREDS_VARIANTAPP_HPP_INCLUDED
+#define HOBBES_LANG_TYPEPREDS_VARIANTAPP_HPP_INCLUDED
+
+#include <hobbes/lang/tyunqualify.H>
+
+namespace hobbes {
+
+// a 'VariantApp' constraint asserts that a record of functions can be applied to a variant as analogous to 'match' on cases
+//   e.g.:
+//    yes: VariantApp |x:int,y:bool| {x:int -> r, y:bool -> r}
+//    no:  VariantApp |x:int,y:bool| {y:bool -> r, x:int -> r}    (doesn't match structure, x should come first)
+//
+// this constraint can be inferred "forward" (when reducing a variant with known structure but unknown function)
+class VariantAppP : public Unqualifier {
+public:
+  static std::string constraintName();
+
+  // unqualifier interface
+  bool        refine(const TEnvPtr&,const ConstraintPtr&,MonoTypeUnifier*,Definitions*);
+  bool        satisfied(const TEnvPtr&,const ConstraintPtr&,Definitions*)                  const;
+  bool        satisfiable(const TEnvPtr&,const ConstraintPtr&,Definitions*)                const;
+  void        explain(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds, annmsgs* msgs);
+  ExprPtr     unqualify(const TEnvPtr&,const ConstraintPtr&, const ExprPtr&, Definitions*) const;
+  PolyTypePtr lookup   (const std::string& vn)                                             const;
+  SymSet      bindings ()                                                                  const;
+  FunDeps     dependencies(const ConstraintPtr&)                                           const;
+};
+
+}
+
+#endif
+

--- a/include/hobbes/lang/typepreds.H
+++ b/include/hobbes/lang/typepreds.H
@@ -15,6 +15,7 @@
 #include <hobbes/lang/preds/appendsto.H>
 #include <hobbes/lang/preds/consrecord.H>
 #include <hobbes/lang/preds/consvariant.H>
+#include <hobbes/lang/preds/vapp.H>
 #include <hobbes/lang/preds/equal.H>
 #include <hobbes/lang/preds/not.H>
 #include <hobbes/lang/preds/recty.H>

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -98,6 +98,7 @@ cc::cc() :
 
   // support deconstructing variants (compile-time reflection on variants)
   this->tenv->bind(VariantDeconstructor::constraintName(), UnqualifierPtr(new VariantDeconstructor()));
+  this->tenv->bind(VariantAppP::constraintName(), UnqualifierPtr(new VariantAppP()));
 
   // support appending (appendable) types
   this->tenv->bind(AppendsToUnqualifier::constraintName(), UnqualifierPtr(new AppendsToUnqualifier()));

--- a/lib/hobbes/lang/preds/vapp.C
+++ b/lib/hobbes/lang/preds/vapp.C
@@ -1,0 +1,211 @@
+
+#include <hobbes/lang/preds/vapp.H>
+#include <hobbes/lang/preds/class.H>
+#include <hobbes/lang/expr.H>
+#include <hobbes/lang/tylift.H>
+#include <hobbes/lang/typeinf.H>
+#include <hobbes/util/array.H>
+
+namespace hobbes {
+
+MonoTypePtr recordDtorType(const Variant& vty, const MonoTypePtr& result) {
+  Record::Members fs;
+  for (const auto& vm : vty.members()) {
+    fs.push_back(Record::Member(vm.selector, closty(vm.type, result)));
+  }
+  return Record::make(fs);
+}
+
+void decClosure(const MonoTypePtr& cty, MonoTypePtr* arg, MonoTypePtr* result) {
+  if (const Exists* e = is<Exists>(cty)) {
+    if (const Record* r = is<Record>(e->absType())) {
+      if (r->members().size() == 2) {
+        if (const Func* f = is<Func>(r->members()[0].type)) {
+          if (f->parameters().size() == 2) {
+            *arg    = f->parameters()[1];
+            *result = f->result();
+            return;
+          }
+        }
+      }
+    }
+  }
+  throw std::runtime_error("Can't decode as variant applicator, field not a closure type: " + show(cty));
+}
+
+MonoTypePtr variantTypeFromDtor(const Record& rty) {
+  Variant::Members vms;
+  uint32_t id = 0;
+  for (const auto& rm : rty.members()) {
+    MonoTypePtr arg, result;
+    decClosure(rm.type, &arg, &result);
+    vms.push_back(Variant::Member(rm.field, arg, id++));
+  }
+  return Variant::make(vms);
+}
+
+MonoTypePtr dtorResultFromDtor(const Record& rty) {
+  if (rty.members().size() == 0) {
+    throw std::runtime_error("Internal error, impossible variant applicator type: ()");
+  } else {
+    MonoTypePtr arg, result;
+    decClosure(rty.members()[0].type, &arg, &result);
+    return result;
+  }
+}
+
+bool vappVarEquiv(const Variant& lhs, const Variant& rhs) {
+  if (lhs.members().size() != rhs.members().size()) {
+    return false;
+  } else {
+    for (size_t i = 0; i < lhs.members().size(); ++i) {
+      const auto& lhsc = lhs.members()[i];
+      const auto& rhsc = rhs.members()[i];
+
+      if (lhsc.selector != rhsc.selector || !(*lhsc.type == *rhsc.type)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+bool vappVarEquiv(const Variant& lhs, const MonoTypePtr& rhs) {
+  if (const Variant* trhs = is<Variant>(rhs)) {
+    return vappVarEquiv(lhs, *trhs);
+  } else {
+    return false;
+  }
+}
+
+struct VariantAppD {
+  MonoTypePtr variantType;
+  MonoTypePtr recordDtorType;
+  MonoTypePtr resultType;
+};
+
+static bool dec(const ConstraintPtr& c, VariantAppD* va) {
+  if (c->name() == VariantAppP::constraintName() && c->arguments().size() == 3) {
+    va->variantType    = c->arguments()[0];
+    va->recordDtorType = c->arguments()[1];
+    va->resultType     = c->arguments()[2];
+    return true;
+  }
+  return false;
+}
+
+#define REF_VAR_APP "variantApp"
+
+std::string VariantAppP::constraintName() {
+  return "VariantApp";
+}
+
+bool VariantAppP::refine(const TEnvPtr&, const ConstraintPtr& cst, MonoTypeUnifier* u, Definitions*) {
+  VariantAppD va;
+  if (dec(cst, &va)) {
+    if (const Variant* vty = is<Variant>(va.variantType)) {
+      auto s = u->size();
+      mgu(va.recordDtorType, recordDtorType(*vty, va.resultType), u);
+      return s != u->size();
+    } else if (const Record* rty = is<Record>(va.recordDtorType)) {
+      auto s = u->size();
+      mgu(va.resultType, dtorResultFromDtor(*rty), u);
+      return s != u->size();
+    }
+  }
+  return false;
+}
+
+bool VariantAppP::satisfied(const TEnvPtr&, const ConstraintPtr& cst, Definitions*) const {
+  VariantAppD va;
+  if (dec(cst, &va)) {
+    if (!(hasFreeVariables(va.variantType) || hasFreeVariables(va.recordDtorType) || hasFreeVariables(va.resultType))) {
+      if (const Variant* vty = is<Variant>(va.variantType)) {
+        if (const Record* rty = is<Record>(va.recordDtorType)) {
+          return vappVarEquiv(*vty, variantTypeFromDtor(*rty)) && *va.recordDtorType == *recordDtorType(*vty, va.resultType);
+        }
+      }
+    }
+  }
+  return false;
+}
+
+bool VariantAppP::satisfiable(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const {
+  VariantAppD va;
+  if (dec(cst, &va)) {
+    if (const Variant* vty = is<Variant>(va.variantType)) {
+      if (const Record* rty = is<Record>(va.recordDtorType)) {
+        return hasFreeVariables(va.variantType) || hasFreeVariables(va.recordDtorType) || hasFreeVariables(va.resultType) || satisfied(tenv, cst, ds);
+      } else {
+        return is<TVar>(va.recordDtorType);
+      }
+    } else {
+      return is<TVar>(va.variantType);
+    }
+  }
+  return false;
+}
+
+void VariantAppP::explain(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds, annmsgs* msgs) {
+}
+
+PolyTypePtr VariantAppP::lookup(const std::string& vn) const {
+  if (vn == REF_VAR_APP) {
+    // variantApp :: (VariantApp v f r) => (v,f) -> r
+    return polytype(3, qualtype(list(ConstraintPtr(new Constraint(VariantAppP::constraintName(), list(tgen(0), tgen(1), tgen(2))))), functy(list(tgen(0), tgen(1)), tgen(2))));
+  } else {
+    return PolyTypePtr();
+  }
+}
+
+SymSet VariantAppP::bindings() const {
+  SymSet r;
+  r.insert(REF_VAR_APP);
+  return r;
+}
+
+FunDeps VariantAppP::dependencies(const ConstraintPtr&) const {
+  FunDeps result;
+  result.push_back(FunDep(list(0, 2), 1));
+  result.push_back(FunDep(list(1), 2));
+  return result;
+}
+
+// resolve satisfied variant deconstruction predicates
+struct VAUnqualify : public switchExprTyFn {
+  const ConstraintPtr& constraint;
+  VAUnqualify(const ConstraintPtr& constraint) : constraint(constraint) { }
+
+  QualTypePtr withTy(const QualTypePtr& qt) const {
+    return removeConstraint(this->constraint, qt);
+  }
+
+  ExprPtr with(const Var* v) const {
+    if (hasConstraint(this->constraint, v->type())) {
+      if (v->value() == REF_VAR_APP) {
+        // rewrite this variable to become a function that does the promised case analysis and dispatch to closure calls
+        auto uvty = this->constraint->arguments()[0];
+        auto urty = this->constraint->arguments()[1];
+
+        if (const Variant* vty = is<Variant>(uvty)) {
+          if (const Record* rty = is<Record>(urty)) {
+            Case::Bindings cs;
+            for (const auto& vm : vty->members()) {
+              cs.push_back(Case::Binding(vm.selector, ".x", closcall(proj(var(".f", urty, v->la()), vm.selector, v->la()), list(var(".x", vm.type, v->la())), v->la())));
+            }
+            ExprPtr c(new Case(var(".v", uvty, v->la()), cs, v->la()));
+            c->type(qualtype(this->constraint->arguments()[2]));
+            return wrapWithTy(v->type(), new Fn(str::strings(".v", ".f"), c, v->la()));
+          }
+        }
+      }
+    }
+    return wrapWithTy(v->type(), v->clone());
+  }
+};
+
+ExprPtr VariantAppP::unqualify(const TEnvPtr&, const ConstraintPtr& cst, const ExprPtr& e, Definitions*) const {
+  return switchOf(e, VAUnqualify(cst));
+}
+
+}
+


### PR DESCRIPTION
Although 'variantSplit' can generically deconstruct variants correctly, it does so only by successive tests on constructor IDs (as opposed to usual case analysis on variants which dispatches in a single test).  For small variants, this inefficiency is fine, but for very large variants (like the ones we produce in structured logs) this can be a significant problem.

This change introduces an alternative function 'variantApp', which takes a variant and a record of closures (with each record field matching its correspondingly-named variant constructor case) so that we can generically deconstruct a variant much more efficiently (analogous to normal case analysis).