### PR TITLE
reject 'matches' tests with inaccessible binding names

### DIFF
--- a/include/hobbes/lang/pat/pattern.H
+++ b/include/hobbes/lang/pat/pattern.H
@@ -7,6 +7,7 @@
 
 #include <hobbes/lang/expr.H>
 #include <hobbes/lang/pat/regex.H>
+#include <hobbes/util/str.H>
 #include <hobbes/util/hash.H>
 #include <hobbes/util/lannotation.H>
 
@@ -274,6 +275,9 @@ bool refutable(const PatternPtr&);
 
 // is a pattern a match on unit?
 bool isUnitPat(const PatternPtr&);
+
+// what variable names are introduced by a pattern (excluding _)?
+str::set accessibleBindingNames(const PatternPtr&);
 
 }
 

--- a/test/Matching.C
+++ b/test/Matching.C
@@ -149,6 +149,14 @@ TEST(Matching, Support) {
 TEST(Matching, Tests) {
   EXPECT_TRUE(c().compileFn<bool()>("\"8675309\" matches '[0-9]+'")());
   EXPECT_TRUE(c().compileFn<bool()>("(1,2) matches (1,2)")());
+
+  // make sure that tests with inaccessible names are rejected
+  EXPECT_EXCEPTION(c().compileFn<bool()>("\"JIMMY\" matches JIMMY")());
+  EXPECT_EXCEPTION(c().compileFn<bool()>("[{x=just(\"JIMMY\")}] matches [{x=|1=JIMMY|}]")());
+  
+  // make sure that tests with inaccessible _ names are allowed
+  EXPECT_TRUE(c().compileFn<bool()>("\"JIMMY\" matches _")());
+  EXPECT_TRUE(c().compileFn<bool()>("[{x=just(\"JIMMY\")}] matches [{x=|1=_|}]")());
 }
 
 TEST(Matching, Functions) {

--- a/test/test.H
+++ b/test/test.H
@@ -66,5 +66,20 @@ private:
     } \
   }
 
+#define EXPECT_EXCEPTION(p) \
+  { \
+    bool __pass = true; \
+    try { \
+      (p); \
+      __pass = false; \
+    } catch (...) { \
+    } \
+    if (!__pass) { \
+      std::ostringstream __errmsg; \
+      __errmsg << "Expression '" #p "' ran successfully but an exception was expected" << " " << FILEINFO(__FILE__, __LINE__); \
+      throw std::runtime_error(__errmsg.str()); \
+    } \
+  }
+
 #endif
 


### PR DESCRIPTION
This can prevent some mistakes, since presumably explicit binding names are introduced under the assumption that they're usable (which they aren't in "matches" tests).