### PR TITLE
fix a bug with type parsing that sometimes required an extra level of parens

### DIFF
--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -325,10 +325,12 @@ struct repTypeAliasesF : public switchTyFn {
   }
 
   MonoTypePtr with(const Prim* v) const {
-    auto td = this->ttyDefs.find(v->name());
-    if (td != this->ttyDefs.end()) {
-      if (td->second.first.size() == 0) {
-        return td->second.second;
+    if (!v->representation()) {
+      auto td = this->ttyDefs.find(v->name());
+      if (td != this->ttyDefs.end()) {
+        if (td->second.first.size() == 0) {
+          return td->second.second;
+        }
       }
     }
     return c(v);

--- a/lib/hobbes/read/pgen/hexpr.parse.C
+++ b/lib/hobbes/read/pgen/hexpr.parse.C
@@ -282,7 +282,7 @@ Expr* makeProjSeq(Expr* rec, const str::seq& fields, const LexicalAnnotation& la
 
 MonoTypePtr monoTypeByName(const std::string& tn) {
   if (isPrimName(tn) || yyParseCC->isTypeAliasName(tn)) {
-    return Prim::make(tn);
+    return yyParseCC->replaceTypeAliases(Prim::make(tn));
   } else if (yyParseCC->isTypeName(tn)) {
     return Prim::make(tn, yyParseCC->namedTypeRepresentation(tn));
   } else {

--- a/lib/hobbes/read/pgen/hexpr.y
+++ b/lib/hobbes/read/pgen/hexpr.y
@@ -218,7 +218,7 @@ Expr* makeProjSeq(Expr* rec, const str::seq& fields, const LexicalAnnotation& la
 
 MonoTypePtr monoTypeByName(const std::string& tn) {
   if (isPrimName(tn) || yyParseCC->isTypeAliasName(tn)) {
-    return Prim::make(tn);
+    return yyParseCC->replaceTypeAliases(Prim::make(tn));
   } else if (yyParseCC->isTypeName(tn)) {
     return Prim::make(tn, yyParseCC->namedTypeRepresentation(tn));
   } else {


### PR DESCRIPTION
For transparent type aliases, this allows some redundant parens to be removed in scripts.