### PR TITLE
lift hobbes closures to C++

### DIFF
--- a/include/hobbes/lang/tylift.H
+++ b/include/hobbes/lang/tylift.H
@@ -320,7 +320,12 @@ template <typename R, typename ... Args>
 template <typename R, typename ... Args>
   struct liftClosure {
     static MonoTypePtr type(typedb& tenv) {
-      return closty(typeSeq<Args...>::liftSeq(tenv), lift<R, false>::type(tenv));
+      auto args = typeSeq<Args...>::liftSeq(tenv);
+      if (args.size() == 0) {
+        return closty(list(primty("unit")), lift<R, false>::type(tenv));
+      } else {
+        return closty(args, lift<R, false>::type(tenv));
+      }
     }
   };
 

--- a/include/hobbes/lang/tylift.H
+++ b/include/hobbes/lang/tylift.H
@@ -269,7 +269,7 @@ template <typename T, size_t N, bool InStruct>
 template <typename T, size_t N, bool InStruct>
   struct lift<const T[N], InStruct> : public liftFixedArray<T, N> { };
 
-// generated lifts for C functions
+// lifts for C functions
 template <typename ... Ts>
   struct typeSeq {
     static void accum(MonoTypes*, typedb&) { }
@@ -302,6 +302,30 @@ template <typename R, typename ... Args>
   struct lift<R(*)(Args...), true> : public liftFunction<R(Args...)> { };
 template <typename R, typename ... Args>
   struct lift<R(*)(Args...), false> : public liftFunction<R(Args...)> { };
+
+// lifts for closures
+template <typename F>
+  struct closure { };
+template <typename R, typename ... Args>
+  struct closure<R(Args...)> {
+    typedef R (*F)(const void*,Args...);
+    F    f;
+    char data[1];
+
+    R operator()(const Args&... args) const {
+      return this->f(&this->data[0], args...);
+    }
+  };
+
+template <typename R, typename ... Args>
+  struct liftClosure {
+    static MonoTypePtr type(typedb& tenv) {
+      return closty(typeSeq<Args...>::liftSeq(tenv), lift<R, false>::type(tenv));
+    }
+  };
+
+template <bool InStruct, typename R, typename ... Args>
+  struct lift<closure<R(Args...)>*, InStruct> : public liftClosure<R, Args...> { };
 
 // lift variant types
 // -- first by lifting constructor names

--- a/include/hobbes/parse/lalr.H
+++ b/include/hobbes/parse/lalr.H
@@ -122,8 +122,8 @@ itemset  follow(const grammar& g, const itemset& is, terminal* v);
 itemsets follow(const grammar& g, const itemset& is, const terminals& vs);
 
 // close an itemset
-itemset closure(const grammar& g, const itemset& is);
-void closure(const grammar& g, itemset* is);
+itemset gclosure(const grammar& g, const itemset& is);
+void gclosure(const grammar& g, itemset* is);
 
 // find or create a state in a parser from a (closed) itemset
 nat parserState(const itemset& s, parserdef* p);

--- a/lib/hobbes/parse/lalr.C
+++ b/lib/hobbes/parse/lalr.C
@@ -324,7 +324,7 @@ itemsets follow(const grammar& g, const itemset& is, const terminals& vs) {
   return r;
 }
 
-void closure(const grammar& g, itemset* is) {
+void gclosure(const grammar& g, itemset* is) {
   // add implied items to a fixed point
   bool changed = true;
   while (changed) {
@@ -339,9 +339,9 @@ void closure(const grammar& g, itemset* is) {
   }
 }
 
-itemset closure(const grammar& g, const itemset& is) {
+itemset gclosure(const grammar& g, const itemset& is) {
   itemset r = is;
-  closure(g, &r);
+  gclosure(g, &r);
   return r;
 }
 
@@ -370,7 +370,7 @@ state_transitions follow(const grammar& g, const itemset& is, const terminalset&
   state_transitions r;
   for (terminalset::const_iterator v = vs.begin(); v != vs.end(); ++v) {
     if (*v != endOfFile::value()) {
-      r[*v] = parserState(closure(g, follow(g, is, *v)), p);
+      r[*v] = parserState(gclosure(g, follow(g, is, *v)), p);
     }
   }
   return r;
@@ -390,7 +390,7 @@ parserdef lr0parser(const grammar& g, terminal* s) {
   p.g[boot].push_back(br);
 
   // enumerate the state space implied by this grammar
-  nat n = parserState(closure(p.g, ruleItems(p.g, boot)), &p);
+  nat n = parserState(gclosure(p.g, ruleItems(p.g, boot)), &p);
   while (n < p.states.size()) {
     const itemset& nis = parserStateDef(p, n);
     p.transitions[n] = follow(p.g, nis, next(p.g, nis), &p);

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -56,3 +56,9 @@ TEST(Compiler, compileFnTypes) {
   EXPECT_EQ(c().compileFn<int(*)(const std::string&)>("_","42")(""), 42);
 }
 
+static int appC(const closure<int(int)>& c) { return c(7); }
+TEST(Compiler, liftClosTypes) {
+  c().bind("appC", &appC);
+  EXPECT_EQ(c().compileFn<int()>("(\\x.appC(\\y.x*y-x))(7)")(), 42);
+}
+

--- a/test/Main.C
+++ b/test/Main.C
@@ -32,6 +32,7 @@ int TestCoord::runTestGroups(const std::set<std::string>& gs) {
     auto gi = this->tests.find(gn);
     if (gi == this->tests.end()) {
       std::cout << "ERROR: no test group named '" << gn << "' exists" << std::endl;
+      continue;
     }
     const auto& g = gi->second;
 


### PR DESCRIPTION
This will make it possible for low-level C++ code to receive properly typed hobbes closures.