### PR TITLE
show a friendlier error message in storage.H errors

### DIFF
--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -264,11 +264,21 @@ inline std::string defaultStoreDir() {
 }
 
 inline int connectGroupHost(const std::string& groupName, const std::string& sdir = defaultStoreDir()) {
-  return mqconnect(sdir + "/hstore." + groupName + ".sk");
+  auto sp = sdir + "/hstore." + groupName + ".sk";
+  try {
+    return mqconnect(sp);
+  } catch (std::exception& e) {
+    throw std::runtime_error("Failed to connect to log consumer for group '" + groupName + "' on socket '" + sp + "' (" + std::string(e.what()) + ")");
+  }
 }
 
 inline int makeGroupHost(const std::string& groupName, const std::string& sdir = defaultStoreDir()) {
-  return mqlisten(sdir + "/hstore." + groupName + ".sk");
+  auto sp = sdir + "/hstore." + groupName + ".sk";
+  try {
+    return mqlisten(sp);
+  } catch (std::exception& e) {
+    throw std::runtime_error("Failed to listen for log connections for group '" + groupName + "' on socket '" + sp + "' (" + std::string(e.what()) + ")");
+  }
 }
 
 // identify this process/thread


### PR DESCRIPTION
If a log producer can't connect to its consumer process, it would be useful to see what group was responsible and where the domain socket was expected.