### PR TITLE
allow forward-declared types to be lifted as opaque pointers

### DIFF
--- a/include/hobbes/lang/tylift.H
+++ b/include/hobbes/lang/tylift.H
@@ -129,7 +129,7 @@ template <typename T, bool InStruct> struct defaultLift<T&,       InStruct> : pu
 template <typename T, bool InStruct>
   struct defaultLift<T*, InStruct> {
     static MonoTypePtr type(typedb& tenv) {
-      return tenv.opaquePtrMonoType(typeid(T), 0, false);
+      return tenv.opaquePtrMonoType(typeid(T*), 0, false);
     }
   };
 template <typename T, bool InStruct, typename P>

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -393,10 +393,15 @@ MonoTypePtr cc::opaquePtrMonoType(const std::type_info& ti, unsigned int sz, boo
   if (t != this->typeAliases.end() && hasPointerRep(t->second)) {
     return requireMonotype(t->second);
   } else {
-    this->objs->add(ti); // not pretty
+    this->objs->add(ti);
 
     // OK, we don't know what this type looks like so we'll give it an opaque pointer type
-    return MonoTypePtr(OpaquePtr::make(str::demangle(ti.name()), sz, inStruct));
+    // but strip the pointer char from the name, we assume opaqueptr types are always pointers
+    std::string tn = str::demangle(ti.name());
+    while (tn.size()>0 && tn.back()=='*') {
+      tn=tn.substr(0,tn.size()-1);
+    }
+    return MonoTypePtr(OpaquePtr::make(tn, sz, inStruct));
   }
 }
 

--- a/lib/hobbes/lang/preds/subtype/obj.C
+++ b/lib/hobbes/lang/preds/subtype/obj.C
@@ -51,6 +51,8 @@ bool Objs::add(const std::type_info* ti) {
   if (const class_type* cti = dynamic_cast<const class_type*>(ti)) {
     add(cti);
     return true;
+  } else if (const abi::__pointer_type_info* pti = dynamic_cast<const abi::__pointer_type_info*>(ti)) {
+    return add(pti->__pointee);
   } else {
     return false;
   }

--- a/test/Objects.C
+++ b/test/Objects.C
@@ -167,3 +167,11 @@ TEST(Objects, Arrays) {
   EXPECT_EQ(c().compileFn<int()>("aoage((arrobjs(9))[0])")(), 42);
 }
 
+class Undef;
+size_t undefCount(const Undef*) { return 42; }
+
+TEST(Objects, FwdDecl) {
+  c().bind("undefCount", &undefCount);
+  EXPECT_EQ((c().compileFn<size_t(const Undef*)>("u", "undefCount(u)")((const Undef*)0)), 42);
+}
+


### PR DESCRIPTION
Prior to this change, the lift code would try to get type info for the underlying type, which would fail since the type was not yet defined.

This change allows bindings involving forward-declared types (and includes a test to ensure that binding with forward-declared types works as expected).

One caveat with this change is that if an opaque type is bound and is only forward declared, then its C++ inheritance hierarchy can't be walked/imported and so the user should not expect that inheritance will work with forward-declared types.