### PR TITLE
remove the old typeAlias type, standardize on the method in reflect.H

### DIFF
--- a/include/hobbes/hobbes.H
+++ b/include/hobbes/hobbes.H
@@ -15,18 +15,20 @@
 namespace hobbes {
 
 // type aliases for common types
-extern const char timespanTNV[];
-typedef typeAlias<timespanTNV, int64_t> timespanT;
+DEFINE_TYPE_ALIAS_AS(timespanT, timespan, int64_t);
 
 inline uint64_t microseconds(const timespanT& ts) { return ts.value; }
 inline uint64_t milliseconds(const timespanT& ts) { return microseconds(ts) / 1000; }
 inline uint64_t seconds     (const timespanT& ts) { return milliseconds(ts) / 1000; }
 
-extern const char timeTNV[];
-typedef typeAlias<timeTNV, int64_t> timeT;
+DEFINE_TYPE_ALIAS_AS(timeT, time, int64_t);
+DEFINE_TYPE_ALIAS_AS(datetimeT, datetime, int64_t);
 
-extern const char datetimeTNV[];
-typedef typeAlias<datetimeTNV, int64_t> datetimeT;
+datetimeT now();
+datetimeT truncDate(datetimeT);
+timeT truncTime(datetimeT);
+datetimeT datetimeAt(datetimeT, timeT);
+timespanT gmtoffset(datetimeT);
 
 // allocate some memory in the calling thread's memory pool
 char* memalloc(size_t);

--- a/include/hobbes/lang/tylift.H
+++ b/include/hobbes/lang/tylift.H
@@ -58,15 +58,6 @@ extern nulltypedb nulltdb;
  * C++ representations for common hobbes types
  *************/
 
-// allow opaque type aliases to reuse basic types
-template <const char* TN, typename T>
-  struct typeAlias {
-    typeAlias(const T& v) : value(v) { }
-    typeAlias() { }
-    T value;
-    inline bool operator==(const typeAlias<TN, T>& rhs) const { return this->value == rhs.value; }
-  };
-
 // allow the generic definition of simple recursive types
 template <typename T>
   struct recursive {
@@ -246,17 +237,17 @@ template <typename T>
   inline MonoTypePtr prim() { return lift<T, false>::type(nulltdb); }
 
 // introduce opaque (named) alias types
-template <const char* TN, typename T, bool InStruct>
-  struct lift< typeAlias<TN, T>, InStruct > {
+template <typename T, bool InStruct>
+  struct lift<T, InStruct, typename tbool<T::is_hmeta_alias>::type> {
     static MonoTypePtr type(typedb& tenv) {
-      return tenv.defineNamedType(TN, str::seq(), lift<T, InStruct>::type(tenv));
+      return tenv.defineNamedType(T::name(), str::seq(), lift<typename T::type, InStruct>::type(tenv));
     }
   };
 
-template <const char* TN, typename T, bool InStruct>
-  struct lift< typeAlias<TN, T>*, InStruct > {
+template <typename T, bool InStruct>
+  struct lift<T*, InStruct, typename tbool<T::is_hmeta_alias>::type> {
     static MonoTypePtr type(typedb& tenv) {
-      return tenv.defineNamedType(TN, str::seq(), lift<T*, InStruct>::type(tenv));
+      return tenv.defineNamedType(T::name(), str::seq(), lift<typename T::type*, InStruct>::type(tenv));
     }
   };
 

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -580,19 +580,22 @@ template <typename ... Ts>
 
 
 // define opaque type aliases
-#define DEFINE_TYPE_ALIAS(PRIV_ATY, PRIV_REPTY) \
+#define DEFINE_TYPE_ALIAS_AS(PRIV_ATY, N, PRIV_REPTY) \
   struct PRIV_ATY { \
     static const bool is_hmeta_alias = true; \
+    typedef void is_hstore_alias; \
     typedef PRIV_REPTY type; \
-    static const char* name() { return #PRIV_ATY; } \
+    static const char* name() { return #N; } \
     inline operator PRIV_REPTY() { return this->value; } \
     PRIV_REPTY value; \
     PRIV_ATY() : value() { } \
     PRIV_ATY(const PRIV_REPTY& x) : value(x) { } \
-    PRIV_ATY(const PRIV_ATY& x) : value(x.value) { } \
-    PRIV_ATY& operator=(const PRIV_ATY& x) { this->value = x.value; return *this; } \
+    constexpr PRIV_ATY(const PRIV_ATY& x) = default; \
+    PRIV_ATY& operator=(const PRIV_ATY& x) = default; \
     bool operator==(const PRIV_ATY& x) const { return this->value == x.value; } \
   }
+
+#define DEFINE_TYPE_ALIAS(PRIV_ATY, PRIV_REPTY) DEFINE_TYPE_ALIAS_AS(PRIV_ATY, PRIV_ATY, PRIV_REPTY)
 
 /***************************************************
  *

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -1652,8 +1652,9 @@ template <>
     PRIV_REPTY value; \
     PRIV_ATY() : value() { } \
     PRIV_ATY(const PRIV_REPTY& x) : value(x) { } \
-    PRIV_ATY(const PRIV_ATY& x) : value(x.value) { } \
-    PRIV_ATY& operator=(const PRIV_ATY& x) { this->value = x.value; return *this; } \
+    constexpr PRIV_ATY(const PRIV_ATY& x) = default; \
+    PRIV_ATY& operator=(const PRIV_ATY& x) = default; \
+    bool operator==(const PRIV_ATY& x) const { return this->value == x.value; } \
   }
 
 template <typename T>

--- a/lib/hobbes/eval/funcdefs.C
+++ b/lib/hobbes/eval/funcdefs.C
@@ -304,19 +304,13 @@ const array<char>* showString(std::string* x) {
   return makeString("\"" + *x + "\"");
 }
 
-const char timespanTNV[] = "timespan";
-
 const array<char>* showTimespanV(timespanT x) {
   return makeString(showTimespan(x.value));
 }
 
-const char timeTNV[] = "time";
-
 const array<char>* showTimeV(timeT x) {
   return makeString(showTime(x.value));
 }
-
-const char datetimeTNV[] = "datetime";
 
 const array<char>* showDateTimeV(datetimeT x) {
   return makeString(showDateTime(x.value));

--- a/test/Hog.C
+++ b/test/Hog.C
@@ -114,9 +114,6 @@ struct RunMode {
   }
 };
 
-void rmrfdir(const char* p) {
-}
-
 class HogApp {
 public:
   HogApp(const RunMode& mode)
@@ -426,9 +423,11 @@ struct SectTest {
   double y() const { return 3.14159; }
   std::array<short, 10> z;
   std::string w;
+  hobbes::datetimeT dt;
+  hobbes::timespanT ts;
   void* q;
 };
-DEFINE_HSTORE_STRUCT_VIEW(SectTest, x, y, z, w);
+DEFINE_HSTORE_STRUCT_VIEW(SectTest, x, y, z, w, dt, ts);
 
 TEST(Hog, SupportedTypes) {
   HogApp local(RunMode{{"TestRecTypes"}, /* consolidate = */ true});
@@ -439,6 +438,8 @@ TEST(Hog, SupportedTypes) {
   st.x = 42;
   for (size_t i = 0; i < 10; ++i) { st.z[i] = short(i); }
   st.w = "test";
+  st.dt.value = hobbes::now();
+  st.ts.value = 60*1000*1000;
   HLOG(TestRecTypes, sectView, "test sect view", st);
   TestRecTypes.commit();
 


### PR DESCRIPTION
This will let us avoid the more hacky way of specifying the alias name that was required with the 'typeAlias' type.  Also it will let standard alias types work transparently with net/storage/fregion logic.