### PR TITLE
fix an issue with dependent type definitions

### DIFF
--- a/lib/hobbes/eval/cmodule.C
+++ b/lib/hobbes/eval/cmodule.C
@@ -78,6 +78,8 @@ void import(cc* e, const std::string& mname) {
 }
 
 // replace type variable references with expanded aliases or opaque definitions as necessary
+ExprPtr applyTypeDefns(cc*, const ExprPtr&);
+
 struct appTyDefnF : public switchTyFn {
   cc* e;
   appTyDefnF(cc* e) : e(e) { }
@@ -95,6 +97,10 @@ struct appTyDefnF : public switchTyFn {
 
   MonoTypePtr with(const TApp* ap) const {
     return e->replaceTypeAliases(TApp::make(switchOf(ap->fn(), *this), switchOf(ap->args(), *this)));
+  }
+
+  MonoTypePtr with(const TExpr* x) const {
+    return TExpr::make(applyTypeDefns(this->e, x->expr()));
   }
 };
 MonoTypePtr applyTypeDefns(cc* e, const MonoTypePtr& t) {

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -72,7 +72,8 @@ TEST(Compiler, ParseTyDefStaging) {
     c().readModule(
       "bob = 42\n"
       "type BT = (TypeOf `bob` x) => x\n"
-      "frank :: BT\n"
+      "type BTI = (TypeOf `newPrim()::BT` x) => x\n"
+      "frank :: BTI\n"
       "frank = 3\n"
     )
   );


### PR DESCRIPTION
When defining types dependent on types of expressions that are dependent on earlier type definitions in the same module, those earlier type definitions would be invisible without this fix.