### PR TITLE
when matching on unit, add implied type equality to help inference

### DIFF
--- a/test/Matching.C
+++ b/test/Matching.C
@@ -81,7 +81,8 @@ TEST(Matching, Variant) {
   EXPECT_EQ(c().compileFn<int()>("match |foo=(\"abd\", 4)| with | |foo=(_, 2)| -> 1 | |foo=(\"abc\", _)| -> 2 | |foo=(_, 3)| -> 3 | |foo=_| -> 4")(), 4);
 
   // ensure match preserves variant constructor order
-  EXPECT_EQ(c().compileFn<int()>("((\\v.match v with | |S=_|->0 | |F=x|->x)::|S:(),F:int|->int)(|F=42|)")(), 42);
+  // and that unit matches drive type inference
+  EXPECT_EQ(c().compileFn<int()>("(\\v.match v with | |S|->0 | |F=x|->x)(|F=42|)")(), 42);
 }
 
 TEST(Matching, Efficiency) {


### PR DESCRIPTION
This will fix Sam's issue where he noticed that a function that should not have been polymorphic was actually polymorphic in what should have been a unit type:

```
$ cat v.hob
classify v = match v with
| |S|   -> 0
| |F=x| -> x
$ hi -s ./v.hob
> :t classify
(|S:a, F:int|) -> int
```

After this change, along with a validating test case, the same function definition will have its type inferred as `|S,F:int|->int` with no user annotation required.