### PR TITLE
make the pageEntries function work again

### DIFF
--- a/lib/hobbes/db/bindings.C
+++ b/lib/hobbes/db/bindings.C
@@ -1084,9 +1084,22 @@ public:
   }
 };
 
-reader::PageEntries* pageEntries(reader* r) {
-  return r->pageEntries();
+reader::PageEntries* pageEntries(long f) {
+  return reinterpret_cast<reader*>(f)->pageEntries();
 }
+struct pageEntriesF : public op {
+  std::string f;
+
+  pageEntriesF(const std::string& f) : f(f) {
+  }
+  llvm::Value* apply(jitcc* c, const MonoTypes& tys, const MonoTypePtr& rty, const Exprs& es) {
+    ExprPtr wfrtfn = var(this->f, functy(list(primty("long")), lift<reader::PageEntries*>::type(nulltdb)), es[0]->la());
+    return c->compile(fncall(wfrtfn, list(es[0]), es[0]->la()));
+  }
+  PolyTypePtr type(typedb& tenv) const {
+    return polytype(2, qualtype(functy(list(tapp(primty("file"), list(tgen(0), tgen(1)))), lift<reader::PageEntries*>::type(nulltdb))));
+  }
+};
 
 // load definitions for working with storage files into a compiler context
 void initStorageFileDefs(FieldVerifier* fv, cc& c) {
@@ -1151,7 +1164,8 @@ void initStorageFileDefs(FieldVerifier* fv, cc& c) {
   c.bind(".printFile", &printFileUF);
   c.bindLLFunc("printFile", new printFileF(".printFile"));
 
-  c.bind("pageEntries", &pageEntries);
+  c.bind(".pageEntries", &pageEntries);
+  c.bindLLFunc("pageEntries", new pageEntriesF(".pageEntries"));
 
   // import signalling functions on files as well
   initSignalsDefs(fv, c);


### PR DESCRIPTION
This function allows us to inspect page layout and usage details.  This can help us to identify where (for example) we might be wasting unused space in files, or allocating more data than expected for TOC entries or type definitions.