### PR TITLE
allow compilation from an expression in a fixed char buffer

### DIFF
--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -46,6 +46,11 @@ template <>
     static ExprPtr expr(const ExprParser& p, const std::string& e) { return p(e); }
   };
 template <>
+  struct PArgl<char*> {
+    static str::seq names(char*) { return str::seq(); }
+    static ExprPtr expr(const ExprParser& p, char* e) { return p(std::string(e)); }
+  };
+template <>
   struct PArgl<const char*> {
     static str::seq names(const char*) { return str::seq(); }
     static ExprPtr expr(const ExprParser& p, const char* e) { return p(std::string(e)); }

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -36,6 +36,12 @@ TEST(Compiler, compileToSupportsMoreThanSixArgs) {
   EXPECT_TRUE(NULL != funPtr);
 }
 
+TEST(Compiler, charArrExpr) {
+  char buffer[256];
+  strncpy(buffer, "\"hello world\"\0", sizeof(buffer));
+  EXPECT_TRUE(c().compileFn<const array<char>*()>(buffer) != 0);
+}
+
 class BV { };
 namespace hobbes {
   template <>


### PR DESCRIPTION
This avoids an awkward compile error in the case where the expression to compile is in a fixed-length char buffer.