### PR TITLE
use structural equality for rtti checks instead of pointer equality

### DIFF
--- a/lib/hobbes/lang/preds/subtype/obj.C
+++ b/lib/hobbes/lang/preds/subtype/obj.C
@@ -30,7 +30,7 @@ void Objs::add(const class_type* ct) {
   
   ClassDefs::const_iterator cd = this->classDefs.find(cn);
   if (cd != this->classDefs.end()) {
-    if (cd->second != ct) {
+    if (*cd->second != *ct) {
       throw std::runtime_error("While recording class type information, inconsistent definitions for the '" + cn + "' class.");
     }
   } else {


### PR DESCRIPTION
(for .so linkage)