### PR TITLE
allocate aligned out of memory regions

### DIFF
--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -272,7 +272,17 @@ public:
   void bindExternFunction(const std::string& fname, const MonoTypePtr& fty, void* fn);
 
   // allocate global data
-  void* memalloc(size_t);
+  void* memalloc(size_t, size_t);
+
+  template <typename T>
+    array<T>* makeArray(size_t n) {
+      auto* r = reinterpret_cast<array<T>*>(this->memalloc(sizeof(long) + (sizeof(T) * n), std::max<size_t>(sizeof(long), alignof(T))));
+      r->size = n;
+      if (r->size > 0) {
+        new (r->data) T[r->size];
+      }
+      return r;
+    }
 private:
   // cache for expression search results
   SearchCache searchCache;

--- a/include/hobbes/eval/funcdefs.H
+++ b/include/hobbes/eval/funcdefs.H
@@ -9,7 +9,7 @@ namespace hobbes {
 void initStdFuncDefs(cc& ctx);
 
 // pooled memory allocation
-char* memalloc(size_t);
+char* memalloc(size_t, size_t);
 
 // dynamic string construction utilities
 const array<char>* makeString(const std::string& x);

--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -68,8 +68,8 @@ public:
   void            compileFunctions(const LetRec::Bindings&);
 
   // compile an allocation statement (to dynamically allocate some data)
-  llvm::Value* compileAllocStmt(size_t sz, llvm::Type* mty, bool zeroMem = false);
-  llvm::Value* compileAllocStmt(llvm::Value* sz, llvm::Type* mty, bool zeroMem = false);
+  llvm::Value* compileAllocStmt(size_t sz, size_t asz, llvm::Type* mty, bool zeroMem = false);
+  llvm::Value* compileAllocStmt(llvm::Value* sz, llvm::Value* asz, llvm::Type* mty, bool zeroMem = false);
 
   // begin a function with the given name, argument type list, return type
   llvm::Function* allocFunction(const std::string& fname, const MonoTypes& argl, const MonoTypePtr& rty);
@@ -110,7 +110,7 @@ public:
   ExprPtr inlineGlobals(const ExprPtr&);
 
   // allocate some global data attached to this JIT
-  void* memalloc(size_t);
+  void* memalloc(size_t, size_t);
 private:
   TEnvPtr tenv;
 

--- a/include/hobbes/hobbes.H
+++ b/include/hobbes/hobbes.H
@@ -31,7 +31,7 @@ datetimeT datetimeAt(datetimeT, timeT);
 timespanT gmtoffset(datetimeT);
 
 // allocate some memory in the calling thread's memory pool
-char* memalloc(size_t);
+char* memalloc(size_t, size_t);
 
 // string representations, I/O
 const array<char>* makeString(const std::string& x);
@@ -58,14 +58,14 @@ template <typename T>
 
 template <typename T>
   array<T>* makeArray(region& m, long n) {
-    array<T>* r = reinterpret_cast<array<T>*>(m.malloc(sizeof(long) + (sizeof(T) * n)));
+    array<T>* r = reinterpret_cast<array<T>*>(m.malloc(sizeof(long) + (sizeof(T) * n), std::max<size_t>(sizeof(long), alignof(T))));
     r->size = n;
     return defInitArray<T>(r);
   }
 
 template <typename T>
   array<T>* makeArray(long n) {
-    array<T>* r = reinterpret_cast<array<T>*>(memalloc(sizeof(long) + (sizeof(T) * n)));
+    array<T>* r = reinterpret_cast<array<T>*>(memalloc(sizeof(long) + (sizeof(T) * n), std::max<size_t>(sizeof(long), alignof(T))));
     r->size = n;
     return defInitArray<T>(r);
   }
@@ -73,7 +73,7 @@ template <typename T>
 // allocate ... something
 template <typename T, typename ... Args>
   T* make(const Args& ... args) {
-    return new (memalloc(sizeof(T))) T(args...);
+    return new (memalloc(sizeof(T), alignof(T))) T(args...);
   }
 
 // resets the thread-local memory pool for expressions

--- a/include/hobbes/util/region.H
+++ b/include/hobbes/util/region.H
@@ -18,8 +18,8 @@ public:
   region(size_t minPageSize, size_t initialFreePages = 1, size_t maxPageSize = /*1GB*/ 1*1024*1024*1024);
   ~region();
 
-  // allocate 'sz' bytes of memory
-  void* malloc(size_t sz);
+  // allocate 'sz' bytes of memory aligned to 'asz'
+  void* malloc(size_t sz, size_t asz = sizeof(size_t));
 
   // deallocate all pages (make sure you're not holding any references after this)
   void clear();

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -589,8 +589,8 @@ void cc::bindExternFunction(const std::string& fname, const MonoTypePtr& fty, vo
   this->jit.bindGlobal(fname, fty, fn);
 }
 
-void* cc::memalloc(size_t sz) {
-  return this->jit.memalloc(sz);
+void* cc::memalloc(size_t sz, size_t asz) {
+  return this->jit.memalloc(sz, asz);
 }
 
 inline TEnvPtr allocTEnvFrame(const str::seq& names, const MonoTypes& tys, const TEnvPtr& ptenv) {

--- a/lib/hobbes/eval/func.C
+++ b/lib/hobbes/eval/func.C
@@ -307,7 +307,7 @@ public:
     llvm::Value* aclen = c->builder()->CreateAdd(c0, c1);
     llvm::Value* mlen  = c->builder()->CreateAdd(cvalue(static_cast<long>(sizeof(long))), c->builder()->CreateMul(aclen, cvalue(static_cast<long>(sizeOf(aty->type())))));
 
-    llvm::Value* cmdata = c->compileAllocStmt(mlen, toLLVM(tys[0]));
+    llvm::Value* cmdata = c->compileAllocStmt(mlen, cvalue(std::max<long>(sizeof(long), alignment(aty->type()))), toLLVM(tys[0]));
     c->builder()->CreateStore(aclen, structOffset(c->builder(), cmdata, 0));
 
     if (!isUnit(aty->type())) {
@@ -513,9 +513,9 @@ public:
     if (isUnit(rty)) {
       return cvalue(true);
     } else if (!hasPointerRep(rty)) {
-      return c->builder()->CreateLoad(c->compileAllocStmt(sizeOf(rty), ptrType(toLLVM(rty, true)), this->zeroMem));
+      return c->builder()->CreateLoad(c->compileAllocStmt(sizeOf(rty), alignment(rty), ptrType(toLLVM(rty, true)), this->zeroMem));
     } else {
-      return c->compileAllocStmt(sizeOf(rty), toLLVM(rty, true), this->zeroMem);
+      return c->compileAllocStmt(sizeOf(rty), alignment(rty), toLLVM(rty, true), this->zeroMem);
     }
   }
 
@@ -538,7 +538,7 @@ public:
 
     llvm::Value* aclen  = c->compile(es[0]);
     llvm::Value* mlen   = c->builder()->CreateAdd(cvalue(static_cast<long>(sizeof(long))), c->builder()->CreateMul(aclen, cvalue(static_cast<long>(sizeOf(aty->type())))));
-    llvm::Value* cmdata = c->compileAllocStmt(mlen, toLLVM(rty));
+    llvm::Value* cmdata = c->compileAllocStmt(mlen, cvalue(std::max<long>(sizeof(long), alignment(aty->type()))), toLLVM(rty));
     c->builder()->CreateStore(aclen, structOffset(c->builder(), cmdata, 0));
 
     return cmdata;

--- a/lib/hobbes/eval/funcdefs.C
+++ b/lib/hobbes/eval/funcdefs.C
@@ -82,12 +82,12 @@ size_t makeMemRegion(const array<char>* n) {
   return addThreadRegion(makeStdString(n), new region(32768));
 }
 
-char* memalloc(size_t n) {
-  return reinterpret_cast<char*>(threadRegion().malloc(n));
+char* memalloc(size_t n, size_t asz) {
+  return reinterpret_cast<char*>(threadRegion().malloc(n, asz));
 }
 
-char* memallocz(size_t n) {
-  char* r = reinterpret_cast<char*>(threadRegion().malloc(n));
+char* memallocz(size_t n, size_t asz) {
+  char* r = reinterpret_cast<char*>(threadRegion().malloc(n, asz));
   memset(r, 0, n);
   return r;
 }
@@ -202,11 +202,11 @@ template <typename T>
     typedef variant<unit, T> ty;
 
     static const maybe<T>::ty* nothing() {
-      return new (memalloc(sizeof(ty))) ty(unit());
+      return new (memalloc(sizeof(ty), alignof(ty))) ty(unit());
     }
 
     static const maybe<T>::ty* just(const T& x) {
-      return new (memalloc(sizeof(ty))) ty(x);
+      return new (memalloc(sizeof(ty), alignof(ty))) ty(x);
     }
   };
 

--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -559,9 +559,9 @@ void jitcc::popGlobalRegion(size_t x) {
   setThreadRegion(x);
 }
 
-void* jitcc::memalloc(size_t sz) {
+void* jitcc::memalloc(size_t sz, size_t asz) {
   size_t r = pushGlobalRegion();
-  void* result = ::hobbes::memalloc(sz);
+  void* result = ::hobbes::memalloc(sz, asz);
   popGlobalRegion(r);
   return result;
 }
@@ -761,14 +761,14 @@ void jitcc::unsafeCompileFunctions(UCFS* ufs) {
   }
 }
 
-llvm::Value* jitcc::compileAllocStmt(llvm::Value* sz, llvm::Type* mty, bool zeroMem) {
+llvm::Value* jitcc::compileAllocStmt(llvm::Value* sz, llvm::Value* asz, llvm::Type* mty, bool zeroMem) {
   llvm::Function* f = lookupFunction(zeroMem ? "mallocz" : "malloc");
   if (!f) throw std::runtime_error("Expected heap allocation function as call.");
-  return builder()->CreateBitCast(fncall(builder(), f, sz), mty);
+  return builder()->CreateBitCast(fncall(builder(), f, list(sz, asz)), mty);
 }
 
-llvm::Value* jitcc::compileAllocStmt(size_t sz, llvm::Type* mty, bool zeroMem) {
-  return compileAllocStmt(cvalue(static_cast<long>(sz)), mty, zeroMem);
+llvm::Value* jitcc::compileAllocStmt(size_t sz, size_t asz, llvm::Type* mty, bool zeroMem) {
+  return compileAllocStmt(cvalue(static_cast<long>(sz)), cvalue(static_cast<long>(asz)), mty, zeroMem);
 }
 
 void jitcc::releaseMachineCode(void*) {

--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -1056,11 +1056,11 @@ DEFINE_STRUCT(
 );
 
 array<DFAStateRep>* makeDFARep(cc* c, const DFA& dfa) {
-  auto result = reinterpret_cast<array<DFAStateRep>*>(c->memalloc(sizeof(size_t) + dfa.size() * sizeof(DFAStateRep)));
+  auto result = c->makeArray<DFAStateRep>(dfa.size());
   for (size_t i = 0; i < dfa.size(); ++i) {
     DFAStateRep& s = result->data[i];
     auto ctnm = dfa[i].chars.mapping();
-    s.transitions = reinterpret_cast<CTransitions*>(c->memalloc(sizeof(size_t) + ctnm.size() * sizeof(CTransition)));
+    s.transitions = c->makeArray<CTransition>(ctnm.size());
     for (size_t j = 0; j < ctnm.size(); ++j) {
       s.transitions->data[j] = ctnm[j];
     }

--- a/test/Arrays.C
+++ b/test/Arrays.C
@@ -2,6 +2,8 @@
 #include <hobbes/hobbes.H>
 #include "test.H"
 
+namespace hobbes { region& threadRegion(); }
+
 using namespace hobbes;
 static cc& c() { static cc x; return x; }
 
@@ -54,5 +56,17 @@ TEST(Arrays, CppRAIIConsistency) {
   for (size_t i = 0; i < xs->size; ++i) {
     EXPECT_EQ(xs->data[i], "");
   }
+}
+
+TEST(Arrays, Alignment) {
+  short*        s = reinterpret_cast<short*>(threadRegion().malloc(sizeof(short), alignof(short)));
+  int*          i = reinterpret_cast<int*>(threadRegion().malloc(sizeof(int)), alignof(int));
+  double*       d = reinterpret_cast<double*>(threadRegion().malloc(sizeof(double)), alignof(double));
+  array<int>*   a = makeArray<int>(100);
+
+  EXPECT_EQ(reinterpret_cast<size_t>(s)%sizeof(short),  size_t(0));
+  EXPECT_EQ(reinterpret_cast<size_t>(i)%sizeof(int),    size_t(0));
+  EXPECT_EQ(reinterpret_cast<size_t>(d)%sizeof(double), size_t(0));
+  EXPECT_EQ(reinterpret_cast<size_t>(a)%sizeof(size_t), size_t(0));
 }
 

--- a/test/Objects.C
+++ b/test/Objects.C
@@ -53,12 +53,7 @@ public:
 };
 
 array<ArrObjV*>* arrobjs(int n) {
-  array<ArrObjV*>* r = reinterpret_cast<array<ArrObjV*>*>(memalloc(sizeof(long) + sizeof(ArrObjV) * n));
-  r->size = n;
-  for (int i = 0; i < n; ++i) {
-    new (r->data + n) ArrObjV();
-  }
-  return r;
+  return makeArray<ArrObjV*>(n);
 }
 
 // verify compilation of simple single-inheritance


### PR DESCRIPTION
This will avoid unaligned access on dynamically allocated data.