### PR TITLE
machine REPL improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ matrix:
         - DEPS="${DEPS} llvm@4"
         - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
         - ARGS=-V
-    - os: osx
-      compiler: clang
-      osx_image: xcode8
-      env:
-        - DEPS="${DEPS} llvm@4"
-        - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
-        - ARGS=-V
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode8
+#      env:
+#        - DEPS="${DEPS} llvm@4"
+#        - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
+#        - ARGS=-V
     - os: linux
       compiler: g++
       root: required

--- a/bin/hi/evaluator.C
+++ b/bin/hi/evaluator.C
@@ -261,7 +261,11 @@ void evaluator::resetREPLCycle() {
 
 bool evaluator::satisfied(const hobbes::ConstraintPtr& c) {
   hobbes::Definitions ds;
-  bool result = hobbes::satisfied(this->ctx.typeEnv(), c, &ds);
+  bool result = false;
+  try {
+    result = hobbes::satisfied(this->ctx.typeEnv(), c, &ds);
+  } catch (std::exception&) {
+  }
   this->ctx.drainUnqualifyDefs(ds);
   return result;
 }

--- a/include/hobbes/lang/pat/pattern.H
+++ b/include/hobbes/lang/pat/pattern.H
@@ -52,6 +52,7 @@ ExprPtr compileRegexFn(cc*, const std::string& regex, const LexicalAnnotation&);
 // a general representation of patterns to match
 class Pattern : public LexicallyAnnotated {
 public:
+  virtual ~Pattern() = default;
   virtual void show(std::ostream&) const = 0;
   virtual bool operator==(const Pattern&) const = 0;
 

--- a/include/hobbes/parse/grammar.H
+++ b/include/hobbes/parse/grammar.H
@@ -18,6 +18,7 @@ namespace hobbes {
 class GrammarValue : public LexicallyAnnotated {
 public:
   GrammarValue(const LexicallyAnnotated&);
+  virtual ~GrammarValue() = default;
   virtual void show(std::ostream&) const = 0;
 private:
   GrammarValue();

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -525,13 +525,14 @@ void cc::dumpTypeEnv() const {
 }
 
 void cc::dumpTypeEnv(str::seq* syms, str::seq* types) const {
-  const TEnv::PolyTypeEnv& ptenv = this->tenv->typeEnvTable();
-
-  for (TEnv::PolyTypeEnv::const_iterator te = ptenv.begin(); te != ptenv.end(); ++te) {
+  for (auto te : this->tenv->typeEnvTable()) {
     // don't show hidden symbols since they're not meant for users
-    if (te->first.size() > 0 && te->first[0] != '.') {
-      syms->push_back(te->first);
-      types->push_back(show(te->second));
+    if (te.first.size() > 0 && te.first[0] != '.') {
+      syms->push_back(te.first);
+
+      auto t = te.second->instantiate();
+      auto cs = expandHiddenTCs(typeEnv(), t->constraints());
+      types->push_back(show(hobbes::qualtype(cs, t->monoType())));
     }
   }
 }

--- a/lib/hobbes/ipc/prepl.C
+++ b/lib/hobbes/ipc/prepl.C
@@ -144,6 +144,77 @@ void dbglog(const std::string& msg) {
   }
 }
 
+void printAnnotatedText(cc* eval, std::ostream& out, const hobbes::LexicalAnnotation& la) {
+  static const size_t diffLine = 4;
+  static const size_t termWidth = 80;
+
+  size_t l0 = la.p0.first <= diffLine ? 0 : (la.p0.first - diffLine);
+  size_t l1 = la.p1.first + diffLine;
+
+  str::seq linenos;
+  for (size_t l = l0; l < l1; ++l) {
+    linenos.push_back(str::from(l+1));
+  }
+  linenos = str::rightAlign(linenos);
+
+  str::seq lines = la.lines(l0, l1);
+  size_t mlinelen = std::max<size_t>(str::maxStrLen(lines), termWidth);
+
+  for (size_t r = 0; r < lines.size(); ++r) {
+    out << linenos[r] << " ";
+
+    size_t lineno = r+l0+1;
+    std::string lineText = lines[r] + std::string(mlinelen - lines[r].size(), ' ');
+
+    if (lineno == la.p0.first && lineno == la.p1.first) {
+      out << lineText.substr(0, la.p0.second-1)
+          << lineText.substr(la.p0.second-1, la.p1.second-la.p0.second+1)
+          << lineText.substr(la.p1.second);
+    } else if (lineno == la.p0.first) {
+      out << lineText.substr(0, la.p0.second-1) << lineText.substr(la.p0.second-1);
+    } else if (lineno > la.p0.first && lineno < la.p1.first) {
+      out << lineText;
+    } else if (lineno == la.p1.first) {
+      out << lineText.substr(0, la.p1.second) << lineText.substr(la.p1.second);
+    } else {
+      out << lineText;
+    }
+    out << "\n";
+  }
+}
+
+bool satisfied(cc* eval, const hobbes::ConstraintPtr& c) {
+  hobbes::Definitions ds;
+  bool result = false;
+  try {
+    result = hobbes::satisfied(eval->typeEnv(), c, &ds);
+  } catch (std::exception&) {
+  }
+  eval->drainUnqualifyDefs(ds);
+  return result;
+}
+
+void printAnnotatedError(cc* eval, std::ostream& out, const hobbes::annotated_error& ae, const hobbes::Constraints& cs) {
+  dbglog("** " + std::string(ae.what()));
+
+  for (const auto& m : ae.messages()) {
+    out << m.second.lineDesc() << ": " << m.first << "\n";
+    for (const auto& c : cs) {
+      if (eval && !satisfied(eval, c)) {
+        out << "  " << hobbes::show(c) << std::endl;
+      }
+    }
+    printAnnotatedText(eval, out, m.second);
+  }
+}
+
+void printError(cc* eval, std::ostream& out, const std::exception& ex) {
+  std::string m(ex.what());
+  dbglog("** " + m);
+  out << "** " << m;
+}
+
+
 #define CMD_REFINE_VNAME    static_cast<int>(0)
 #define CMD_PRECOMPILE_EXPR static_cast<int>(1)
 #define CMD_REPL_EVAL       static_cast<int>(2)
@@ -215,10 +286,12 @@ void runMachineREPLStep(cc* c) {
       try {
         c->compileFn<void()>("print(" + expr + ")")();
         resetMemoryPool();
+      } catch (hobbes::unsolved_constraints& cs) {
+        printAnnotatedError(c, std::cout, cs, cs.constraints());
+      } catch (hobbes::annotated_error& ae) {
+        printAnnotatedError(c, std::cout, ae, hobbes::Constraints());
       } catch (std::exception& ex) {
-        std::string msg(ex.what());
-        dbglog("*** " + msg);
-        std::cout << msg;
+        printError(c, std::cout, ex);
       }
       std::cout.rdbuf(stdoutbuffer);
 
@@ -239,14 +312,29 @@ void runMachineREPLStep(cc* c) {
 
       dbglog("typeof '" + expr + "'");
 
+      // buffer the result to remove any accidental internal terminators
+      std::ostringstream ss;
+      auto stdoutbuffer = std::cout.rdbuf(ss.rdbuf());
+
       try {
-        std::string ty = show(simplifyVarNames(c->unsweetenExpression(c->readExpr(expr))->type()));
-        fdwrite(STDOUT_FILENO, ty.data(), ty.size());
+        std::cout << show(simplifyVarNames(c->unsweetenExpression(c->readExpr(expr))->type()));
+      } catch (hobbes::unsolved_constraints& cs) {
+        printAnnotatedError(c, std::cout, cs, cs.constraints());
+      } catch (hobbes::annotated_error& ae) {
+        printAnnotatedError(c, std::cout, ae, hobbes::Constraints());
       } catch (std::exception& ex) {
-        std::string msg(ex.what());
-        dbglog("*** " + msg);
+        std::ostringstream ss;
+        printError(c, ss, ex);
+        std::string msg = ss.str();
         fdwrite(STDOUT_FILENO, msg.data(), msg.size());
       }
+      std::cout.rdbuf(stdoutbuffer);
+
+      // write buffered output to stdout without internal terminators
+      for (char c : ss.str()) {
+        std::cout << (c==0?'?':c);
+      }
+      std::cout << std::flush;
       fdwrite(STDOUT_FILENO, static_cast<char>(0));
       break;
     }
@@ -272,15 +360,28 @@ void runMachineREPLStep(cc* c) {
 
       dbglog("define " + vname + " = " + expr);
 
+      // buffer the result to remove any accidental internal terminators
+      std::ostringstream ss;
+      auto stdoutbuffer = std::cout.rdbuf(ss.rdbuf());
+
       try {
-        std::string msg = vname + " :: " + show(simplifyVarNames(c->unsweetenExpression(c->readExpr(expr))->type()));
         c->define(vname, expr);
-        fdwrite(STDOUT_FILENO, msg.data(), msg.size());
+        std::cout << vname << " :: " << show(simplifyVarNames(c->unsweetenExpression(c->readExpr(expr))->type()));
+      } catch (hobbes::unsolved_constraints& cs) {
+        printAnnotatedError(c, std::cout, cs, cs.constraints());
+      } catch (hobbes::annotated_error& ae) {
+        printAnnotatedError(c, std::cout, ae, hobbes::Constraints());
       } catch (std::exception& ex) {
-        std::string msg(ex.what());
-        dbglog("*** " + msg);
-        fdwrite(STDOUT_FILENO, msg.data(), msg.size());
+        printError(c, std::cout, ex);
       }
+      std::cout.rdbuf(stdoutbuffer);
+
+      // write buffered output to stdout without internal terminators
+      for (char c : ss.str()) {
+        std::cout << (c==0?'?':c);
+      }
+      std::cout << std::flush;
+
       fdwrite(STDOUT_FILENO, static_cast<char>(0));
       break;
     }

--- a/test/PREPL.C
+++ b/test/PREPL.C
@@ -1,0 +1,43 @@
+
+#include <hobbes/hobbes.H>
+#include <hobbes/ipc/prepl.H>
+#include "test.H"
+
+using namespace hobbes;
+static cc& c() { static cc x; return x; }
+
+static proc* hiSession() {
+  static proc p;
+  static bool init = false;
+  if (!init) {
+    spawn("./hi -z", &p);
+  }
+  return &p;
+}
+
+static std::string exprEval(const std::string& x) {
+  proc* p = hiSession();
+  procEval(p, x);
+  std::ostringstream ss;
+  procRead(p, &ss);
+  return ss.str();
+}
+
+std::string exprTypeof(const std::string& x) {
+  proc* p = hiSession();
+  procTypeof(p, x);
+  std::ostringstream ss;
+  procRead(p, &ss);
+  return ss.str();
+}
+
+TEST(PREPL, EvalBasicExprs) {
+  EXPECT_EQ(exprEval("1+1"), "2");
+  EXPECT_TRUE(exprEval("undefinedVariableNameForTest").find("undefinedVariableNameForTest") != std::string::npos);
+}
+
+TEST(PREPL, Typeof) {
+  EXPECT_EQ(exprTypeof("1+1"), "int");
+  EXPECT_EQ(exprTypeof("[x|x<-[0..10],x%2==0]"), "[int]");
+}
+

--- a/test/PREPL.C
+++ b/test/PREPL.C
@@ -4,7 +4,6 @@
 #include "test.H"
 
 using namespace hobbes;
-static cc& c() { static cc x; return x; }
 
 static proc* hiSession() {
   static proc p;
@@ -31,6 +30,14 @@ std::string exprTypeof(const std::string& x) {
   return ss.str();
 }
 
+std::string exprTEnv() {
+  proc* p = hiSession();
+  procTypeEnv(p);
+  std::ostringstream ss;
+  procRead(p, &ss);
+  return ss.str();
+}
+
 TEST(PREPL, EvalBasicExprs) {
   EXPECT_EQ(exprEval("1+1"), "2");
   EXPECT_TRUE(exprEval("undefinedVariableNameForTest").find("undefinedVariableNameForTest") != std::string::npos);
@@ -39,5 +46,9 @@ TEST(PREPL, EvalBasicExprs) {
 TEST(PREPL, Typeof) {
   EXPECT_EQ(exprTypeof("1+1"), "int");
   EXPECT_EQ(exprTypeof("[x|x<-[0..10],x%2==0]"), "[int]");
+}
+
+TEST(PREPL, TEnvWithoutHiddenTCs) {
+  EXPECT_TRUE(exprTEnv().find(".genc.") == std::string::npos);
 }
 


### PR DESCRIPTION
This change will produce friendlier error messages in "machine REPL" mode, which we use in some cases where expression shells are run indirectly.

Also I found during my macOS testing that an 'illegal instruction' exception kills the 'hi' process (just on macOS I think).  This came down to a simple issue with a couple of non-virtual destructors, which I've fixed here as well.