### PR TITLE
add a carray<T,N> type for variable-length arrays with fixed capacity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ env:
     - DEPS=""
 matrix:
   include:
-    - os: osx
-      compiler: clang
-      osx_image: xcode8.3
-      env:
-        - DEPS="${DEPS} llvm@4"
-        - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
-        - ARGS=-V
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode8.3
+#      env:
+#        - DEPS="${DEPS} llvm@4"
+#        - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
+#        - ARGS=-V
 #    - os: osx
 #      compiler: clang
 #      osx_image: xcode8

--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -1185,6 +1185,44 @@ template <typename T, size_t N>
     }
   };
 
+// store fixed-capacity variable-length arrays
+template <typename T, size_t N>
+  struct storeCArrayDef {
+    // data carray t n = {avail:long, buffer:[:t|n:]}
+    static ty::desc storeType() { return ty::app(prim("carray", ty::fn("t", "c", ty::rec("avail", 0, ty::prim("long"), "buffer", sizeof(size_t), ty::array(ty::var("t"), ty::var("c"))))), store<T>::storeType(), ty::nat(N)); }
+
+    static size_t size()      { static const size_t sz=align(sizeof(size_t), alignment())+store<T>::size()*N; return sz; }
+    static size_t alignment() { static const size_t a =std::max<size_t>(sizeof(size_t), store<T>::alignment()); return a; }
+  };
+
+template <typename T, size_t N>
+  struct store<carray<T,N>, typename tbool<store<T>::can_memcpy>::type> : public storeCArrayDef<T,N> {
+    static const bool can_memcpy = true;
+    static void write(imagefile*, void*       p, const carray<T,N>& x) { memcpy(p, &x, storeCArrayDef<T,N>::alignment()+sizeof(T)*x.size); }
+    static void read(imagefile*,  const void* p, carray<T,N>*       x) { memcpy(x,  p, storeCArrayDef<T,N>::alignment()+sizeof(T)*(*reinterpret_cast<const size_t*>(p))); }
+  };
+
+template <typename T, size_t N>
+  struct store<carray<T,N>, typename tbool<!store<T>::can_memcpy>::type> : public storeCArrayDef<T,N> {
+    static const bool can_memcpy = false;
+    static void write(imagefile* f, void* p, const carray<T,N>& x) {
+      *reinterpret_cast<size_t*>(p) = x.size;
+      p = reinterpret_cast<uint8_t*>(p) + storeCArrayDef<T,N>::alignment();
+      for (size_t i = 0; i < x.size; ++i) {
+        store<T>::write(f, p, x.data[i]);
+        p = reinterpret_cast<uint8_t*>(p) + store<T>::size();
+      }
+    }
+    static void read(imagefile* f, const void* p, carray<T,N>* x) {
+      x->size = *reinterpret_cast<const size_t*>(p);
+      p = reinterpret_cast<const uint8_t*>(p) + storeCArrayDef<T,N>::alignment();
+      for (size_t i = 0; i < x->size; ++i) {
+        store<T>::read(f, p, &x->data[i]);
+        p = reinterpret_cast<const uint8_t*>(p) + store<T>::size();
+      }
+    }
+  };
+
 // store strings
 template <>
   struct store<std::string> {
@@ -1379,30 +1417,35 @@ template <size_t i, size_t n, typename ... Ts>
     typedef typename TT::offs            offs;
     typedef storeTupleDef<i+1, n, Ts...> Recurse;
 
-    static void fieldDefs(ty::Struct::Fields* fs) {
-      fs->push_back(ty::Struct::Field(".f" + string::from(i), static_cast<int>(offsetAt<i, offs>::value), store<H>::storeType()));
-      Recurse::fieldDefs(fs);
+    static void fieldDefs(size_t offset, ty::Struct::Fields* fs) {
+      offset = align(offset, store<H>::alignment());
+      fs->push_back(ty::Struct::Field(".f" + string::from(i), offset, store<H>::storeType()));
+      Recurse::fieldDefs(offset + store<H>::size(), fs);
     }
-    static ty::desc storeType() { ty::Struct::Fields fs; fieldDefs(&fs); return ty::record(fs); }
+    static ty::desc storeType() { ty::Struct::Fields fs; fieldDefs(0, &fs); return ty::record(fs); }
 
-    static size_t alignment() { return TT::alignment; }
-    static size_t size()      { return TT::size;      }
+    static size_t alignment()                   { static size_t a=std::max<size_t>(store<H>::alignment(), Recurse::alignment()); return a; }
+    static size_t tailOffsetFrom(size_t offset) { return Recurse::tailOffsetFrom(align(offset, store<H>::alignment()) + store<H>::size()); }
+    static size_t size()                        { static size_t sz=align(tailOffsetFrom(0), alignment()); return sz; }
 
     static void incrWrite(imagefile* f, void* p, const tuple<Ts...>& x) {
+      p = reinterpret_cast<void*>(align(reinterpret_cast<size_t>(p), store<H>::alignment()));
       store<H>::write(f, p, x.template at<i>());
-      Recurse::incrWrite(f, p, x);
+      Recurse::incrWrite(f, reinterpret_cast<uint8_t*>(p) + store<H>::size(), x);
     }
     static void incrRead(imagefile* f, const void* p, tuple<Ts...>* x) {
+      p = reinterpret_cast<const void*>(align(reinterpret_cast<size_t>(p), store<H>::alignment()));
       store<H>::read(f, p, &x->template at<i>());
-      Recurse::incrRead(f, p, x);
+      Recurse::incrRead(f, reinterpret_cast<const uint8_t*>(p) + store<H>::size(), x);
     }
   };
 template <size_t n, typename ... Ts>
   struct storeTupleDef<n, n, Ts...> {
-    static void fieldDefs(ty::Struct::Fields*) { }
-    static ty::desc storeType()   { return ty::prim("unit"); }
-    static size_t alignment()     { return  0; }
-    static size_t size()          { return  0; }
+    static void fieldDefs(size_t, ty::Struct::Fields*) { }
+    static ty::desc storeType()                 { return ty::prim("unit"); }
+    static size_t alignment()                   { return  1; }
+    static size_t tailOffsetFrom(size_t offset) { return offset; }
+    static size_t size()                        { return  0; }
 
     static void incrWrite(imagefile*, void*, const tuple<Ts...>&) { }
     static void incrRead (imagefile*, const void*, tuple<Ts...>*) { }

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -547,9 +547,10 @@ template <typename ... Ctors>
         return variantApp<R, F, U, tuple<Ctors...>, Args...>::apply(this->tag, const_cast<void*>(reinterpret_cast<const void*>(this->storage)), args...);
       }
   public:
-    const uint32_t& unsafeTag() const { return this->tag; }
-    uint32_t&       unsafeTag()       { return this->tag; }
-    void*           unsafePayload()   { return this->storage; }
+    const uint32_t& unsafeTag() const     { return this->tag; }
+    uint32_t&       unsafeTag()           { return this->tag; }
+    const void*     unsafePayload() const { return this->storage; }
+    void*           unsafePayload()       { return this->storage; }
   private:
     uint32_t tag;
     union {
@@ -839,6 +840,25 @@ template <typename T> const T* end  (const array<T>& d) { return d.data + d.size
 template <typename T>       T* begin(      array<T>& d) { return d.data; }
 template <typename T>       T* end  (      array<T>& d) { return d.data + d.size; }
 
+// arrays with dynamically-determined length but with a fixed-capacity
+template <typename T, size_t N>
+  struct carray {
+    size_t size;
+    T      data[N];
+
+    const T& operator[](size_t i) const { return this->data[i]; }
+          T& operator[](size_t i)       { return this->data[i]; }
+  };
+
+template <typename T, size_t N> const T* begin(const carray<T,N>* d) { return d->data; }
+template <typename T, size_t N> const T* end  (const carray<T,N>* d) { return d->data + d->size; }
+template <typename T, size_t N>       T* begin(      carray<T,N>* d) { return d->data; }
+template <typename T, size_t N>       T* end  (      carray<T,N>* d) { return d->data + d->size; }
+
+template <typename T, size_t N> const T* begin(const carray<T,N>& d) { return d.data; }
+template <typename T, size_t N> const T* end  (const carray<T,N>& d) { return d.data + d.size; }
+template <typename T, size_t N>       T* begin(      carray<T,N>& d) { return d.data; }
+template <typename T, size_t N>       T* end  (      carray<T,N>& d) { return d.data + d.size; }
 
 // define opaque type aliases
 #define DEFINE_TYPE_ALIAS_AS(PRIV_ATY, N, PRIV_REPTY) \

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -802,25 +802,25 @@ TEST(Storage, FRegionCArrays) {
     hobbes::fregion::reader r(fname);
 
     auto& rxs = *r.definition<XS>("xs");
-    EXPECT_EQ(rxs.size, 10);
+    EXPECT_EQ(rxs.size, 10UL);
     for (size_t i = 0; i < rxs.size; ++i) {
-      EXPECT_EQ(rxs[i].first, i);
+      EXPECT_EQ(rxs[i].first, static_cast<int>(i));
       EXPECT_EQ(rxs[i].second, i*3.14159);
     }
 
     YS rys;
     r.definition<YS>("ys", &rys);
-    EXPECT_EQ(rys.size, 2);
+    EXPECT_EQ(rys.size, 2UL);
     EXPECT_EQ(rys[0].at<0>(), 42);
     EXPECT_EQ(rys[0].at<1>(), "cowboy");
-    EXPECT_EQ(rys[0].at<2>().size(), 3);
+    EXPECT_EQ(rys[0].at<2>().size(), 3UL);
     EXPECT_TRUE(rys[0].at<2>()[0] == IorD(100));
     EXPECT_TRUE(rys[0].at<2>()[1] == IorD(3.14159));
     EXPECT_TRUE(rys[0].at<2>()[2] == IorD(200));
 
     EXPECT_EQ(rys[1].at<0>(), 8675);
     EXPECT_EQ(rys[1].at<1>(), "chicken");
-    EXPECT_EQ(rys[1].at<2>().size(), 3);
+    EXPECT_EQ(rys[1].at<2>().size(), 3UL);
     EXPECT_TRUE(rys[1].at<2>()[0] == IorD(2.1));
     EXPECT_TRUE(rys[1].at<2>()[1] == IorD(4.2));
     EXPECT_TRUE(rys[1].at<2>()[2] == IorD(29));

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -767,3 +767,75 @@ TEST(Storage, CFRegion_H2C) {
   }
 }
 
+TEST(Storage, FRegionCArrays) {
+  std::string fname = mkFName();
+  try {
+    hobbes::fregion::writer w(fname);
+
+    // verify memcopyable carrays can be accessed by reference
+    //   'carray (int*double) 20'
+    typedef std::pair<int,double> IandD;
+    typedef hobbes::carray<IandD, 20> XS;
+
+    auto& xs = *w.define<XS>("xs");
+    for (size_t i = 0; i < 10; ++i) {
+      xs[i] = std::pair<int,double>(i,i*3.14159);
+    }
+    xs.size = 10;
+    
+    // verify that non-memcopyable can be written
+    //     'carray (int * [char]@? * [int+double]@?) 20'
+    typedef hobbes::variant<int,double> IorD;
+    typedef std::vector<IorD>   IorDs;
+    typedef hobbes::tuple<int, std::string, IorDs> Y;
+    typedef hobbes::carray<Y, 20> YS;
+
+    IorDs idi; idi.push_back(IorD(100)); idi.push_back(IorD(3.14159)); idi.push_back(IorD(200));
+    IorDs ddi; ddi.push_back(IorD(2.1)); ddi.push_back(IorD(4.2));     ddi.push_back(IorD(29));
+    YS ys;
+    ys[0] = Y(42, "cowboy", idi);
+    ys[1] = Y(8675, "chicken", ddi);
+    ys.size = 2;
+    w.define<YS>("ys", ys);
+
+    // expect to be able to read back the carray data from C++
+    hobbes::fregion::reader r(fname);
+
+    auto& rxs = *r.definition<XS>("xs");
+    EXPECT_EQ(rxs.size, 10);
+    for (size_t i = 0; i < rxs.size; ++i) {
+      EXPECT_EQ(rxs[i].first, i);
+      EXPECT_EQ(rxs[i].second, i*3.14159);
+    }
+
+    YS rys;
+    r.definition<YS>("ys", &rys);
+    EXPECT_EQ(rys.size, 2);
+    EXPECT_EQ(rys[0].at<0>(), 42);
+    EXPECT_EQ(rys[0].at<1>(), "cowboy");
+    EXPECT_EQ(rys[0].at<2>().size(), 3);
+    EXPECT_TRUE(rys[0].at<2>()[0] == IorD(100));
+    EXPECT_TRUE(rys[0].at<2>()[1] == IorD(3.14159));
+    EXPECT_TRUE(rys[0].at<2>()[2] == IorD(200));
+
+    EXPECT_EQ(rys[1].at<0>(), 8675);
+    EXPECT_EQ(rys[1].at<1>(), "chicken");
+    EXPECT_EQ(rys[1].at<2>().size(), 3);
+    EXPECT_TRUE(rys[1].at<2>()[0] == IorD(2.1));
+    EXPECT_TRUE(rys[1].at<2>()[1] == IorD(4.2));
+    EXPECT_TRUE(rys[1].at<2>()[2] == IorD(29));
+
+    // expect to be able to read back carrays from hobbes
+    hobbes::cc c;
+    c.define("db", "inputFile::(LoadFile \"" + fname + "\" w)=>w");
+
+    EXPECT_TRUE(c.compileFn<bool()>("db.xs == [(i, i*3.14159) | i <- [0..9]]")());
+    EXPECT_TRUE(c.compileFn<bool()>("db.ys == [(42, \"cowboy\", [|0=100|::(int+double), |1=3.14159|, |0=200|]), (8675, \"chicken\", [|1=2.1|, |1=4.2|, |0=29|])]")());
+
+    unlink(fname.c_str());
+  } catch (...) {
+    unlink(fname.c_str());
+    throw;
+  }
+}
+


### PR DESCRIPTION
This change adds a C++ type carray<T,N> for variable-length arrays of T values up to length N.  It's defined to have a consistent memory layout with the hobbes type "carray" already used for segments of series data written.

This also adds two store<carray<T,N>> definitions, one for the case where T can be memcopied and another for the case where it can't be.  A test was added in tests/Storage.C to demonstrate the expected behavior through the fregion API and also how hobbes queries on such data are expected to work.

A couple of unrelated fixes to tuple and variant logic are included.  The variant change is just to provide a const accessor for 'unsafePayload'.  The store<tuple<...>> change fixes a bug where non-memcopyable tuples stored with incorrect offsets/alignment.