### PR TITLE
Python support for reading fregions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.sw?
 /build/
+scripts/*.pyc
 CMakeCache.txt
 CMakeFiles/
 /doc/en/_build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,20 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${cxx_flags}")
 
-enable_testing()
-add_executable(hobbes-test ${test_files})
-target_link_libraries(hobbes-test hobbes ncurses ${sys_libs})
-add_test(hobbes-test hobbes-test)
-
 add_executable(hi ${hi_files})
 target_link_libraries(hi hobbes ncurses readline ${sys_libs})
 add_executable(hog ${hog_files})
 target_link_libraries(hog hobbes ncurses ${sys_libs})
 
+enable_testing()
+add_executable(hobbes-test ${test_files})
+target_link_libraries(hobbes-test hobbes ncurses ${sys_libs})
+add_test(hobbes-test hobbes-test)
+include(FindPythonInterp)
+set_property(TARGET hobbes-test PROPERTY COMPILE_FLAGS "-DPYTHON_EXECUTABLE=\"${PYTHON_EXECUTABLE}\" -DSCRIPT_DIR=\"${CMAKE_SOURCE_DIR}/scripts/\"")
+
 install(TARGETS hobbes hobbes-pic DESTINATION "lib")
 install(TARGETS hi hog DESTINATION "bin")
 install(DIRECTORY "include/hobbes" DESTINATION "include")
+install(DIRECTORY "scripts" DESTINATION "scripts")
+

--- a/bin/hog/batchrecv.C
+++ b/bin/hog/batchrecv.C
@@ -18,17 +18,6 @@
 
 using namespace hobbes;
 
-namespace {
-
-#if defined BUILD_LINUX
-  const uint8_t* const_workaround(const uint8_t* p) { return p; }
-#else // BUILD_OSX
-  // On one macOS paltform ZLIB_CONST does not take effect
-  uint8_t* const_workaround(const uint8_t* p) { return const_cast<uint8_t*>(p); }
-#endif
-
-} // namespace
-
 namespace hog {
 
 struct gzbuffer {
@@ -46,7 +35,7 @@ struct gzbuffer {
     this->zin.zalloc    = Z_NULL;
     this->zin.zfree     = Z_NULL;
     this->zin.opaque    = Z_NULL;
-    this->zin.next_in   = const_workaround(inb.data());
+    this->zin.next_in   = const_cast<uint8_t*>(inb.data());
     this->zin.avail_in  = inb.size();
     
 #pragma GCC diagnostic push

--- a/docker/build/xenial.Dockerfile
+++ b/docker/build/xenial.Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
 ENV  ARGS -V
 RUN  apt update
-RUN  apt install -y cmake libedit-dev g++ llvm-3.7-dev libncurses5-dev zlib1g-dev libreadline-dev
+RUN  apt install -y cmake libedit-dev g++ llvm-3.7-dev libncurses5-dev zlib1g-dev libreadline-dev python2.7
 CMD  mkdir -p /build && cd /build && cmake /src && make -j2 && make test

--- a/docker/build/xllvm4.Dockerfile
+++ b/docker/build/xllvm4.Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
 ENV  ARGS -V
 RUN  apt update
-RUN  apt install -y cmake libedit-dev g++ llvm-4.0-dev libncurses5-dev zlib1g-dev libreadline-dev
+RUN  apt install -y cmake libedit-dev g++ llvm-4.0-dev libncurses5-dev zlib1g-dev libreadline-dev python2.7
 CMD  mkdir -p /build && cd /build && cmake /src && make -j2 && make test

--- a/scripts/fregion.py
+++ b/scripts/fregion.py
@@ -1,0 +1,926 @@
+#!/usr/bin/env python
+
+########################################################
+#
+# fregion.py : read structured data files
+#
+#    to load a file from the path P into the variable f:
+#      f = fregion.FRegion(P)
+#
+#    to read the stored field 'x' out of f:
+#      f.x
+#
+#    to read the 'metadata' for the field 'x' (type and offset details):
+#      meta(f).x
+#
+########################################################
+
+import os
+import mmap
+import struct
+import math
+
+#######
+#
+# Type Descriptions
+#
+#######
+
+class Prim:
+  def __init__(self, name, rep):
+    self.name = name
+    self.rep  = rep
+  def __eq__(self,x): return isinstance(x,Prim) and self.name==x.name and self.rep==x.rep
+  def __repr__(self): return '()' if self.name=="unit" else self.name
+
+class Var:
+  def __init__(self, name):
+    self.name = name
+  def __eq__(self,x): return isinstance(x,Var) and self.name==x.name
+  def __repr__(self): return self.name
+
+class FixedArr:
+  def __init__(self, ty, tlen):
+    self.ty   = ty
+    self.tlen = tlen
+  def __eq__(self,x): return isinstance(x,FixedArr) and self.ty==x.ty and self.tlen==x.tlen
+  def __repr__(self): return '[:' + str(self.ty) + '|' + str(self.tlen) + ':]'
+
+class Arr:
+  def __init__(self, ty):
+    self.ty = ty
+  def __eq__(self,x): return isinstance(x,Arr) and self.ty==x.ty
+  def __repr__(self): return '[' + str(self.ty) + ']'
+
+class Variant:
+  def __init__(self, ctors):
+    self.ctors = ctors
+  def __eq__(self,x): return isinstance(x,Variant) and self.ctors==x.ctors
+  def __repr__(self):
+    if (len(self.ctors) == 0):
+      return 'void'
+    elif (self.isSum()):
+      return self.showAsSum()
+    else:
+      return self.showAsVariant()
+  def isSum(self):
+    return len(self.ctors)>0 and self.ctors[0][0][0] == '.'
+  def showAsSum(self):
+    s = '('
+    s += str(self.ctors[0][2])
+    for i in range(1, len(self.ctors)):
+      s += '+' + str(self.ctors[i][2])
+    s += ')'
+    return s
+  def showAsVariant(self):
+    s = '|'
+    s += self.descCtor(self.ctors[0])
+    for i in range(1,len(self.ctors)):
+      s += ', '
+      s += self.descCtor(self.ctors[i])
+    s += '|'
+    return s
+
+  def descCtor(self, ctor):
+    return ctor[0] + ':' + str(ctor[2])
+
+class Struct:
+  def __init__(self, fields):
+    self.fields = fields
+  def __eq__(self,x): return isinstance(x,Struct) and self.fields==x.fields
+  def __repr__(self):
+    if (len(self.fields) == 0):
+      return '()'
+    elif (self.isTuple()):
+      return self.showAsTuple()
+    else:
+      return self.showAsStruct()
+  def isTuple(self):
+    return len(self.fields)>0 and self.fields[0][0][0] == '.'
+  def showAsTuple(self):
+    s = '('
+    s += str(self.fields[0][2])
+    for i in range(1,len(self.fields)):
+      s += '*' + str(self.fields[i][2])
+    s += ')'
+    return s
+  def showAsStruct(self):
+    s = '{'
+    s += self.descField(self.fields[0])
+    for i in range(1,len(self.fields)):
+      s += ', '
+      s += self.descField(self.fields[i])
+    s += '}'
+    return s
+  def descField(self, field):
+    return field[0] + ':' + str(field[2])
+
+class TLong:
+  def __init__(self, n):
+    self.n = n
+  def __eq__(self,x): return isinstance(x,TLong) and self.n==x.n
+  def __repr__(self): return str(self.n)
+
+class App:
+  def __init__(self,f,args):
+    self.f = f
+    self.args = args
+  def __eq__(self,x): return isinstance(x,App) and self.f==x.f and self.args==x.args
+  def __repr__(self):
+    if (isinstance(self.f,Prim)):
+      if (self.f.name == "fileref" and len(self.args)>0):
+        return str(self.args[0])+"@?"
+    return self.showGeneric()
+  def showGeneric(self):
+    s = str(self.f) + '('
+    if (len(self.args)>0):
+      s += str(self.args[0])
+      for i in range(1,len(self.args)):
+        s += ', ' + str(self.args[i])
+    s += ')'
+    return s
+
+class Recursive:
+  def __init__(self,vn,ty):
+    self.vn = vn
+    self.ty = ty
+  def __repr__(self):
+    return '^' + self.vn + '.' + str(self.ty)
+
+class Abs:
+  def __init__(self,vns,ty):
+    self.vns = vns
+    self.ty  = ty
+  def __repr__(self):
+    s = '\\'
+    if (len(self.vns)>0):
+      s += self.vns[0]
+      for i in range(1,len(self.vns)):
+        s += ', ' + self.vns[i]
+    s += '.' + str(self.ty)
+    return s
+
+class TyCase:
+  def __init__(self, dtors):
+    self.dtors = dtors
+  def apply(self,ty):
+    if (isinstance(ty,Prim)):
+      return self.dtors["prim"](ty)
+    elif (isinstance(ty,Var)):
+      return self.dtors["var"](ty)
+    elif (isinstance(ty,FixedArr)):
+      return self.dtors["farr"](ty)
+    elif (isinstance(ty,Arr)):
+      return self.dtors["arr"](ty)
+    elif (isinstance(ty,Variant)):
+      return self.dtors["variant"](ty)
+    elif (isinstance(ty,Struct)):
+      return self.dtors["struct"](ty)
+    elif (isinstance(ty,TLong)):
+      return self.dtors["long"](ty)
+    elif (isinstance(ty,App)):
+      return self.dtors["app"](ty)
+    elif (isinstance(ty,Recursive)):
+      return self.dtors["rec"](ty)
+    elif (isinstance(ty,Abs)):
+      return self.dtors["abs"](ty)
+    else:
+      raise Exception("Can't deconstruct unknown type description")
+
+def fail(msg):
+  raise Exception(msg)
+
+def expectFn(ty):
+  if (isinstance(ty,Prim)):
+    if (ty.rep == None):
+      if (ty.name == "fileref"):
+        return Abs(["t"], Prim("long",None))
+      else:
+        raise Exception("Expected function representation in place of primitive: " + ty.name)
+    else:
+      return expectFn(ty.rep)
+  elif (isinstance(ty,Abs)):
+    return ty
+  else:
+    raise Exception("Expected function in place of type: " + str(ty))
+
+def dictWithout(m,k):
+  r=m.copy()
+  r.drop(k)
+  return r
+def dictWithouts(m,ks):
+  r=m.copy()
+  for k in ks:
+    r.drop(k)
+  return r
+def dictMerge(m0,m1):
+  m=m0.copy()
+  m.update(m1)
+  return m
+def addFreeVar(m,vn):
+  m[vn]=None
+def freeVarsIntoVariant(m,v):
+  for ctor in v.ctors:
+    freeVarsInto(m,ctor[2])
+def freeVarsIntoStruct(m,s):
+  for field in s.fields:
+    freeVarsInto(m,field[2])
+def freeVarsIntoApp(m,a):
+  freeVarsInto(m,a.f)
+  for ty in a.args:
+    freeVarsInto(m,ty)
+def freeVarsIntoRec(m,r):
+  lm=freeVars(r.ty)
+  lm.drop(r.vn)
+  m.update(lm)
+def freeVarsIntoAbs(m,a):
+  lm=freeVars(a.ty)
+  for n in a.vns:
+    lm.drop(n)
+  m.update(lm)
+
+def freeVarsInto(m,ty):
+  tyDisp = {
+    "prim":    lambda p:  None,
+    "var":     lambda v:  addFreeVar(m,v.name),
+    "farr":    lambda fa: (freeVarsInto(m,fa.ty), freeVarsInto(m,fa.tlen)),
+    "arr":     lambda a:  freeVarsInto(m,a.ty),
+    "variant": lambda v:  freeVarsIntoVariant(m,v),
+    "struct":  lambda s:  freeVarsIntoStruct(m,s),
+    "long":    lambda n:  None,
+    "app":     lambda a:  freeVarsIntoApp(m,a),
+    "rec":     lambda r:  freeVarsIntoRec(m,r),
+    "abs":     lambda a:  freeVarsIntoAbs(m,a)
+  }
+  return TyCase(tyDisp).apply(ty)
+
+def freeVars(ty):
+  m={}
+  freeVarsInto(m,ty)
+  return m
+def dictFreeVars(m):
+  lm={}
+  for n, ty in m.items():
+    freeVarsInto(lm,ty)
+  return lm
+def freeName(m):
+  vn='t0'
+  n=0
+  while (True):
+    if (not(vn in m)):
+      break
+    else:
+      n+=1
+      vn='t'+str(n)
+  return vn
+
+def substituteInVariant(m,v):
+  ctors=[]
+  for ctor in v.ctors:
+    ctors.append((ctor[0], ctor[1], substitute(m, ctor[2])))
+  return Variant(ctors)
+def substituteInStruct(m,s):
+  fields=[]
+  for field in s.fields:
+    fields.append((field[0], field[1], substitute(m,field[2])))
+  return Struct(fields)
+def substituteInApp(m,a):
+  args=[]
+  for ty in a.args:
+    args.append(substitute(m,ty))
+  return App(substitute(m,a.f),args)
+def substituteInRec(m,r):
+  lm=dictWithout(m,r.vn)
+  fvs=dictFreeVars(lm)
+  if (r.vn in fvs):
+    nn=freeName(fvs)
+    return Recursive(nn, substitute(lm, substitute({r.vn:Var(nn)},r.ty)))
+  else:
+    return Recursive(r.vn, substitute(lm, r.ty))
+def substituteInAbs(m,a):
+  lm=dictWithouts(m,r.vns)
+  fvs=dictFreeVars(lm)
+  vns=[]
+  for vn in a.vns:
+    if (vn in fvs):
+      nn=freeName(lm)
+      lm[vn] = Var(nn)
+      vns.append(nn)
+    else:
+      vns.append(vn)
+  if (vns!=a.vns):
+    return Abs(vns, substitute(lm,a.ty))
+  else:
+    return Abs(a.vns, substitute(lm,a.ty))
+
+def substitute(m,ty):
+  tyDisp = {
+    "prim":    lambda p:  Prim(p.name,substitute(m,p.rep)) if (p.rep != None) else p,
+    "var":     lambda v:  m[v.name] if (v.name in m.keys()) else v,
+    "farr":    lambda fa: FixedArr(substitute(m,fa.ty), substitute(m,fa.tlen)),
+    "arr":     lambda a:  Arr(substitute(m,a.ty)),
+    "variant": lambda v:  substituteInVariant(m,v),
+    "struct":  lambda s:  substituteInStruct(m,s),
+    "long":    lambda n:  n,
+    "app":     lambda a:  substituteInApp(m,a),
+    "rec":     lambda r:  substituteInRec(m,r),
+    "abs":     lambda a:  substituteInAbs(m,a)
+  }
+  return TyCase(tyDisp).apply(ty)
+
+#######
+#
+# determine memory layout of any type
+#
+#######
+
+def align(x, b):
+  if (x % b == 0):
+    return x
+  else:
+    return b*(int(x/b)+1)
+
+def alignOfStruct(s):
+  a=1
+  for field in s.fields:
+    a=max(a,alignOf(field[2]))
+  return a
+
+def alignOfVariant(v):
+  a=4
+  for ctor in v.ctors:
+    a=max(a,alignOf(ctor[2]))
+  return a
+
+def alignOfApp(a):
+  f = expectFn(a.f)
+  if (len(a.args)!=len(f.vns)):
+    raise Exception("Arity mismatch in application (expected " + str(len(f.vns)) + " arguments): " + str(a))
+  m={}
+  for i in range(len(f.vns)):
+    m[f.vns[i]] = a.args[i]
+  return alignOf(substitute(m, f.ty))
+
+def alignOf(ty):
+  tyDisp = {
+    "prim":    lambda p:  1 if (p.name == "unit") else sizeOfPrim(p),
+    "var":     lambda v:  fail("Can't determine alignment of type variable: " + v.name),
+    "farr":    lambda fa: alignOf(fa.ty),
+    "arr":     lambda a:  fail("Can't determine alignment of variable-length array: " + str(a)),
+    "variant": lambda v:  alignOfVariant(v),
+    "struct":  lambda s:  alignOfStruct(s),
+    "long":    lambda n:  fail("Can't get alignment of type-level number: " + str(n.n)),
+    "app":     lambda a:  alignOfApp(a),
+    "rec":     lambda r:  fail("Can't get alignment of recursive type: " + str(r)),
+    "abs":     lambda a:  fail("Can't get alignment of type-level function: " + str(a))
+  }
+  return TyCase(tyDisp).apply(ty)
+
+def sizeOfPrim(p):
+  if (p.rep != None):
+    return sizeOf(p.rep)
+  else:
+    if (p.name == "unit"):
+      return 0
+    elif (p.name == "bool"):
+      return 1
+    elif (p.name == "byte"):
+      return 1
+    elif (p.name == "char"):
+      return 1
+    elif (p.name == "short"):
+      return 2
+    elif (p.name == "int"):
+      return 4
+    elif (p.name == "long"):
+      return 8
+    elif (p.name == "float"):
+      return 4
+    elif (p.name == "double"):
+      return 8
+    else:
+      raise Exception("Can't determine size of unknown primitive type: " + p.name)
+
+def sizeOfStruct(s):
+  o=0
+  for f in s.fields:
+    o = align(o, alignOf(f[2])) + sizeOf(f[2])
+  return align(o, alignOf(s))
+
+def sizeOfVariant(v):
+  a=alignOf(v)
+  maxsz=0
+  for ctor in v.ctors:
+    maxsz=max(maxsz,sizeOf(ctor[2]))
+  return align(align(4,a)+maxsz,a)
+
+def sizeOfApp(a):
+  f = expectFn(a.f)
+  if (len(a.args)!=len(f.vns)):
+    raise Exception("Arity mismatch in application (expected " + str(len(f.vns)) + " arguments): " + str(a))
+  m={}
+  for i in range(len(f.vns)):
+    m[f.vns[i]] = a.args[i]
+  return sizeOf(substitute(m, f.ty))
+
+def sizeOf(ty):
+  tyDisp = {
+    "prim":    lambda p:  sizeOfPrim(p),
+    "var":     lambda v:  fail("Can't determine size of type variable: " + v.name),
+    "farr":    lambda fa: sizeOf(fa.ty)*fa.tlen.n,
+    "arr":     lambda a:  fail("Can't determine size of variable-length array: " + str(a)),
+    "variant": lambda v:  sizeOfVariant(v),
+    "struct":  lambda s:  sizeOfStruct(s),
+    "long":    lambda n:  fail("Can't get size of type-level number: " + str(n.n)),
+    "app":     lambda a:  sizeOfApp(a),
+    "rec":     lambda r:  fail("Can't get size of recursive type: " + str(r)),
+    "abs":     lambda a:  fail("Can't get size of type-level function: " + str(a))
+  }
+  return TyCase(tyDisp).apply(ty)
+
+#######
+#
+# Type Description Decoding
+#
+#######
+
+# a cheap cursor
+class ReadPos:
+  def __init__(self):
+    self.pos = 0
+  def __repr__(self): return str(self.pos)
+
+# type descriptions
+TYCTOR_PRIM      = 0
+TYCTOR_TVAR      = 2
+TYCTOR_FIXEDARR  = 4
+TYCTOR_ARR       = 5
+TYCTOR_VARIANT   = 6
+TYCTOR_STRUCT    = 7
+TYCTOR_SIZE      = 11
+TYCTOR_TAPP      = 12
+TYCTOR_RECURSIVE = 13
+TYCTOR_TABS      = 15
+
+def decodeBool(d, p):
+  b = struct.unpack('B', d[p.pos:p.pos+1])[0]
+  p.pos += 1
+  return b != 0
+
+def decodeInt(d, p):
+  n = struct.unpack('I', d[p.pos:p.pos+4])[0]
+  p.pos += 4
+  return n
+
+def decodeLong(d, p):
+  n = struct.unpack('Q', d[p.pos:p.pos+8])[0]
+  p.pos += 8
+  return n
+
+def decodeStr(d, p):
+  n = decodeLong(d,p)
+  s = str(d[p.pos:p.pos+n])
+  p.pos += n
+  return s
+
+def decodeTypeDesc(d, p):
+  c = decodeInt(d,p)
+  if (c == TYCTOR_PRIM):
+    name = decodeStr(d, p)
+    if (decodeBool(d, p)):
+      return Prim(name, decodeTypeDesc(d, p))
+    else:
+      return Prim(name, None)
+  elif (c == TYCTOR_TVAR):
+    name = decodeStr(d, p)
+    return Var(name)
+  elif (c == TYCTOR_FIXEDARR):
+    ty   = decodeTypeDesc(d, p)
+    tlen = decodeTypeDesc(d, p)
+    return FixedArr(ty, tlen)
+  elif (c == TYCTOR_ARR):
+    ty = decodeTypeDesc(d, p)
+    return Arr(ty)
+  elif (c == TYCTOR_VARIANT):
+    n = decodeLong(d,p)
+    ctors = []
+    for i in range(n):
+      name = decodeStr(d,p)
+      cid  = decodeInt(d,p)
+      ty   = decodeTypeDesc(d,p)
+      ctors.append((name,cid,ty))
+    return Variant(ctors)
+  elif (c == TYCTOR_STRUCT):
+    n = decodeLong(d,p)
+    fields = []
+    for i in range(n):
+      name = decodeStr(d,p)
+      cid  = decodeInt(d,p)
+      ty   = decodeTypeDesc(d,p)
+      fields.append((name,cid,ty))
+    return Struct(fields)
+  elif (c == TYCTOR_SIZE):
+    return TLong(decodeLong(d,p))
+  elif (c == TYCTOR_TAPP):
+    f = decodeTypeDesc(d,p)
+    n = decodeLong(d,p)
+    args = []
+    for i in range(n):
+      args.append(decodeTypeDesc(d,p))
+    return App(f,args)
+  elif (c == TYCTOR_RECURSIVE):
+    vn = decodeStr(d,p)
+    ty = decodeTypeDesc(d,p)
+    return Recursive(vn,ty)
+  elif (c == TYCTOR_TABS):
+    n = decodeLong(d,p)
+    vns = []
+    for i in range(n):
+      vns.append(decodeStr(d,p))
+    ty = decodeTypeDesc(d,p)
+    return Abs(vns,ty)
+  else:
+    raise Exception('Not a supported type constructor ID: ' + str(c))
+
+#######
+#
+# File envelope decoding (read page data, environment data)
+#
+#######
+
+# page entry decoding
+def isEnvPage(p):
+  return (p >> 14) == 2
+def availBytes(p):
+  return p & 0x3FFF
+
+# a file variable definition
+class EnvEntry:
+  def __init__(self, offset, ty):
+    self.offset = offset
+    self.ty     = ty
+  def __repr__(self):
+    return str(self.ty) + "@" + str(self.offset)
+
+# read file metadata
+class FREnvelope:
+  def __init__(self, fpath):
+    self.p = fpath
+    self.f = open(self.p, 'r+b')
+    self.m = mmap.mmap(self.f.fileno(), 0, mmap.ACCESS_READ)
+
+    # make sure that the file header is what we expect
+    if (struct.unpack('I', self.m[0:4])[0] != 0x10A1DB0D):
+      raise Exception('Not a valid structured data file: ' + self.p)
+
+    self.pageSize = struct.unpack('H', self.m[4:6])[0]
+    self.version  = struct.unpack('H', self.m[6:8])[0]
+
+    if (self.pageSize != 4096):
+      raise Exception('Expected 4K page size')
+    if (self.version != 2):
+      raise Exception('Structured data file format version ' + str(self.version) + ' not supported')
+
+    # read the page data in this file
+    self.pages = []
+    self.readPageEntries(self.pages, 8, 4096)
+
+    # read the environment data in this file
+    self.env = dict([])
+    for page in range(0, len(self.pages)):
+      if (isEnvPage(self.pages[page])):
+        page += self.readEnvPage(self.env, page)
+
+  # read page data entries into the 'pages' argument
+  # if there is a link to a subsequent page to read page data from, follow it
+  def readPageEntries(self, pages, i, o):
+    k = i
+    e = o - 8
+    while (k < e):
+      p = struct.unpack('H', self.m[k:k+2])[0]
+      if (p == 0):
+        break
+      pages.append(p)
+      k += 2
+    n = struct.unpack('Q', self.m[e:e+8])[0]
+    if (n != 0):
+      self.readPageEntries(self, pages, n*4096, (n+1)*4096)
+
+  # read environment data into the 'env' argument out of 'page'
+  def readEnvPage(self, env, page):
+    initOffset = page * 4096
+    offset = initOffset
+    while (True):
+      offset = self.readEnvRecord(env, offset)
+
+      pos   = offset - 1
+      tpage = pos / 4096
+      rpos  = (pos % 4096) + 1
+      if (rpos == (4096 - availBytes(self.pages[tpage]))):
+        break
+
+    return int(math.ceil((float(offset-initOffset))/4096)-1)
+
+  def readEnvRecord(self, env, offset):
+    vpos = struct.unpack('Q', self.m[offset:offset+8])[0]
+    offset += 8
+
+    vnlen = struct.unpack('Q', self.m[offset:offset+8])[0]
+    offset += 8
+
+    vn = str(self.m[offset:offset+vnlen])
+    offset += vnlen
+
+    tylen = struct.unpack('Q', self.m[offset:offset+8])[0]
+    offset += 8
+
+    if (len(vn) > 0 and vn[0] != '.' and tylen > 0):
+      env[vn] = EnvEntry(vpos, decodeTypeDesc(self.m[offset:offset+tylen], ReadPos()))
+
+    offset += tylen
+    return offset
+
+#######
+#
+# Read structured data
+#
+#######
+
+class UnitReader:
+  def read(self,m,offset): return None
+  def __repr__(self): return "()"
+
+class UnpackReader:
+  def __init__(self,fmt,sz):
+    self.fmt = fmt
+    self.sz = sz
+  def read(self,m,offset):
+    return struct.unpack(self.fmt,m[offset:offset+self.sz])[0]
+  def __repr__(self):
+    return str(self.value)
+
+class FArrReader:
+  def __init__(self, renv, ty, c):
+    self.c   = c
+    self.rdr = makeReader(renv, ty)
+    self.esz = sizeOf(ty)
+  def read(self,m,offset):
+    r=[]
+    o=offset;
+    for i in range(self.c):
+      r.append(self.rdr.read(m,o))
+      o += self.esz
+    return r
+
+def tupleReaders(renv, tys):
+  o  = 0
+  os = []
+  rs = []
+  for ty in tys:
+    o = align(o, alignOf(ty))
+    os.append(o)
+    rs.append(makeReader(renv, ty))
+    o += sizeOf(ty)
+  return (os,rs)
+
+class TupleReader:
+  def __init__(self, renv, tys):
+    os, rs = tupleReaders(renv, tys)
+    self.os = os
+    self.rs = rs
+  def read(self,m,offset):
+    vs=[]
+    for i in range(len(self.os)):
+      vs.append(self.rs[i].read(m,offset+self.os[i]))
+    return tuple(vs)
+
+class StructView:
+  def __init__(self, fs, foffs, vs):
+    self.fs = fs
+    self.foffs = foffs
+    self.vs = vs
+  def __repr__(self):
+    r = '{'
+    if (len(self.vs)>0):
+      r += self.fs[0] + '=' + str(self.vs[0])
+      for i in range(1,len(self.vs)):
+        r += ', ' + self.fs[i] + '=' + str(self.vs[i])
+    r += '}'
+    return r
+  def __getattr__(self, attr):
+    return self.vs[self.foffs[attr]]
+
+class StructReader:
+  def __init__(self, renv, fs, tys):
+    os, rs = tupleReaders(renv, tys)
+    self.fs = fs
+    self.os = os
+    self.rs = rs
+    foffs={}
+    for i in range(0,len(self.fs)):
+      foffs[self.fs[i]] = i
+    self.foffs = foffs
+  def read(self,m,offset):
+    vs=[]
+    for i in range(len(self.os)):
+      vs.append(self.rs[i].read(m,offset+self.os[i]))
+    return StructView(self.fs, self.foffs, vs)
+
+class VariantView:
+  def __init__(self, cn, value):
+    self.cn    = cn
+    self.value = value
+  def __repr__(self):
+    if (len(self.cn)>0 and self.cn[0] == '.'):
+      return "|" + self.cn[2:] + "=" + str(self.value) + "|"
+    else:
+      return "|" + self.cn + "=" + str(self.value) + "|"
+
+class VariantReader:
+  def __init__(self, renv, ctors):
+    poff=4
+    crs={}
+    for ctor in ctors:
+      poff = align(poff, alignOf(ctor[2]))
+      crs[ctor[1]] = makeReader(renv, ctor[2])
+
+    self.tr    = UnpackReader('I', 4)
+    self.ctors = ctors
+    self.poff  = poff
+    self.crs   = crs
+  def read(self,m,offset):
+    t = self.tr.read(m,offset)
+    return VariantView(self.ctors[t][0], self.crs[t].read(m,offset+self.poff))
+
+class FileRefReader:
+  def __init__(self,renv,ty):
+    self.pr = UnpackReader('Q',8)
+    self.r = makeReader(renv,ty)
+  def read(self,m,offset):
+    return self.r.read(m,self.pr.read(m,offset))
+
+class ArrReader:
+  def __init__(self,renv,ty):
+    self.nr   = UnpackReader('Q',8)
+    self.r    = makeReader(renv,ty)
+    self.vlen = sizeOf(ty)
+  def read(self,m,offset):
+    n=self.nr.read(m,offset)
+    vs=[]
+    o=offset+8
+    for i in range(n):
+      vs.append(self.r.read(m,o))
+      o+=self.vlen
+    return vs
+
+class NYIReader:
+  def read(self,m,offset):
+    raise Exception("nyi")
+
+def makePrimReader(p):
+  if (p.name == "unit"):
+    return UnitReader()
+  elif (p.name == "bool"):
+    return UnpackReader('?', 1)
+  elif (p.name == "char"):
+    return UnpackReader('c', 1)
+  elif (p.name == "byte"):
+    return UnpackReader('B', 1)
+  elif (p.name == "short"):
+    return UnpackReader('H', 2)
+  elif (p.name == "int"):
+    return UnpackReader('I', 4)
+  elif (p.name == "long"):
+    return UnpackReader('Q', 8)
+  elif (p.name == "float"):
+    return UnpackReader('f', 4)
+  elif (p.name == "double"):
+    return UnpackReader('d', 8)
+  else:
+    raise Exception("I don't know how to decode this primitive type: " + p.name)
+
+def makeFArrReader(renv,fa):
+  return FArrReader(renv, fa.ty, fa.tlen.n)
+
+def makeArrReader(renv,a):
+  return ArrReader(renv,a.ty)
+
+def makeVariantReader(renv,v):
+  return VariantReader(renv,v.ctors)
+
+def makeStructReader(renv,s):
+  if (len(s.fields) == 0):
+    return UnitReader()
+  elif (s.fields[0][0][0] == '.'): # should we read this as a tuple?
+    return TupleReader(renv, map(lambda f:f[2], s.fields))
+  else:
+    return StructReader(renv, map(lambda f:f[0], s.fields), map(lambda f:f[2], s.fields))
+
+def makeAppReader(renv,app):
+  if (isinstance(app.f,Prim)):
+    if (app.f.name=="fileref" and len(app.args)>=1):
+      return FileRefReader(renv, app.args[0])
+    elif (app.f.name=="carray" and len(app.args)>=2):
+      return ArrReader(renv, app.args[0])
+  raise Exception("I don't know how to read '" + str(app) + "'")
+
+class RecReader:
+  def __init__(self):
+    self.r = None
+  def read(self,m,offset):
+    return self.r.read(m,offset)
+
+def makeRecReader(renv, rec):
+  r = RecReader()
+  renv[rec.vn] = r
+  r.r = makeReader(renv, rec.ty)
+  return r
+
+def makeVarReader(renv, vn):
+  if vn in renv:
+    return renv[vn]
+  else:
+    raise Exception("Can't make reader with variable not in environment: " + vn)
+
+def makeReader(renv,ty):
+  readerDisp = {
+    "prim":    lambda p:  makePrimReader(p),
+    "var":     lambda v:  makeVarReader(renv, v.name),
+    "farr":    lambda fa: makeFArrReader(renv,fa),
+    "arr":     lambda a:  makeArrReader(renv,a),
+    "variant": lambda v:  makeVariantReader(renv,v),
+    "struct":  lambda s:  makeStructReader(renv,s),
+    "long":    lambda n:  fail("Can't read type-level number: " + str(n.n)),
+    "app":     lambda a:  makeAppReader(renv,a),
+    "rec":     lambda r:  makeRecReader(renv,r),
+    "abs":     lambda a:  fail("Can't read type-level function: " + str(a))
+  }
+  return TyCase(readerDisp).apply(ty)
+
+#######
+#
+# the user interface to structured data
+#
+#######
+
+def formatRow(cns, cs, r):
+  s=''
+  for k in range(len(cs)-1):
+    s += cs[k][r].ljust(cns[k], ' ')
+  s += cs[len(cs)-1][r]
+  return s
+
+def tableFormat(cs):
+  cns=[]
+  rc=0
+  for c in cs:
+    n = 0
+    rc = len(c) if rc==0 else min(rc, len(c))
+    for s in c:
+      n = max(n, len(s))
+    cns.append(n)
+
+  s = ''
+  if (rc > 0):
+    s = formatRow(cns, cs, 0)
+    for r in range(1, rc):
+      s += '\n' + formatRow(cns, cs, r)
+
+  return s
+
+class FRegion:
+  def __init__(self, fpath):
+    self.rep = FREnvelope(fpath)
+
+    for vn, bind in self.rep.env.iteritems():
+      bind.reader = makeReader({}, bind.ty)
+
+  def __repr__(self):
+    vns = []
+    hts = []
+    tds = []
+    for vn, bind in self.rep.env.iteritems():
+      vns.append(vn)
+      hts.append(' :: ')
+      tds.append(str(bind.ty))
+    return tableFormat([vns, hts, tds])
+
+  def __getattr__(self, attr):
+    b = self.rep.env.get(attr, None)
+    if (b == None):
+      raise Exception("FRegion has no field named '" + attr + "'")
+    else:
+      return b.reader.read(self.rep.m, b.offset)
+
+class FRMeta:
+  def __init__(self, f): self.f = f
+  def __repr__(self): return repr(self.f)
+  def __getattr__(self, attr):
+    b = self.f.rep.env.get(attr, None)
+    if (b == None):
+      raise Exception("FRegion has no field named '" + attr + "'")
+    else:
+      return b
+
+def meta(f): return FRMeta(f)
+

--- a/scripts/fregion.py
+++ b/scripts/fregion.py
@@ -895,6 +895,8 @@ class FRegion:
     for vn, bind in self.rep.env.iteritems():
       bind.reader = makeReader({}, bind.ty)
 
+  def __str__(self): return self.__repr__()
+
   def __repr__(self):
     vns = []
     hts = []

--- a/test/Python.C
+++ b/test/Python.C
@@ -1,0 +1,227 @@
+
+#include <hobbes/hobbes.H>
+#include <hobbes/db/file.H>
+#include <hobbes/fregion.H>
+#include <fstream>
+#include "test.H"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define DEF_STR(x) SDEF_STR(x)
+#define SDEF_STR(x) #x
+
+using namespace hobbes;
+using namespace hobbes::fregion;
+
+class PythonProc {
+public:
+  PythonProc(const std::string& py, const std::string& moddir, const std::string& script, const std::string& db) : py(py), moddir(moddir), script(script), db(db)
+  {
+    this->argv.push_back(this->py.c_str());
+    this->argv.push_back(this->script.c_str());
+    this->argv.push_back(this->db.c_str());
+    this->argv.push_back(nullptr); // end
+  }
+
+  int run() {
+    pid_t pid = fork();
+    if (pid == -1) {
+      throw std::runtime_error("error while fork: " + std::string(strerror(errno)));
+    } else if (pid == 0) {
+      setenv("PYTHONPATH", this->moddir.c_str(), 1);
+      execv(this->argv[0], const_cast<char* const*>(this->argv.data()));
+
+      std::cout << "error trying to exec '" << argv[0] << "' : " << strerror(errno) << std::endl;
+      exit(-1);
+    } else {
+      int ws;
+      wait(&ws);
+      pid = -1;
+      return WEXITSTATUS(ws);
+    }
+  }
+private:
+  std::string py;
+  std::string moddir;
+  std::string script;
+  std::string db;
+  std::vector<const char*> argv;
+};
+
+static std::string mkFName(const std::string& ext = "db") {
+  return hobbes::uniqueFilename("/tmp/hdb-unittest", "." + ext);
+}
+
+typedef std::array<int, 10> IArr;
+DEFINE_STRUCT(
+  TestStruct,
+  (int, x),
+  (double, y),
+  (IArr, xs)
+);
+
+DEFINE_VARIANT(
+  TestVariant,
+  (cars, int),
+  (dogs, double),
+  (chickens, IArr)
+);
+
+void makeTestData(const std::string& path) {
+  hobbes::fregion::writer w(path);
+  *w.define<bool>   ("f") = true;
+  *w.define<char>   ("c") = 'e';
+  *w.define<uint8_t>("b") = 0xff;
+  *w.define<short>  ("s") = 42;
+  *w.define<int>    ("i") = 42;
+  *w.define<float>  ("e") = 3.14159;
+  *w.define<double> ("d") = 3.14159;
+
+  *w.define<std::pair<int, double>>("p") = std::make_pair(42, 3.14159);
+
+  auto& xs = *w.define<std::array<int, 10>>("xs");
+  for (size_t i = 0; i < xs.size(); ++i) {
+    xs[i] = i;
+  }
+
+  auto& mat = *w.define<std::array<std::array<int,10>,10>>("mat");
+  for (size_t i = 0; i < mat.size(); ++i) {
+    for (size_t j = 0; j < mat[i].size(); ++j) {
+      mat[i][j] = i*j;
+    }
+  }
+
+  auto& ts = *w.define<TestStruct>("ts");
+  ts.x = 42;
+  ts.y = 3.14159;
+  for (size_t i = 0; i < ts.xs.size(); ++i) {
+    ts.xs[i] = i;
+  }
+
+  auto& tss = *w.define<std::array<TestStruct, 10>>("tss");
+  for (size_t i = 0; i < tss.size(); ++i) {
+    tss[i].x = 42*i;
+    tss[i].y = 3.14159*i;
+    for (size_t j = 0; j < tss[i].xs.size(); ++j) {
+      tss[i].xs[j] = j*i;
+    }
+  }
+
+  *w.define<TestVariant>("tv") = TestVariant::cars(42);
+
+  auto& tvs = *w.define<std::array<TestVariant, 10>>("tvs");
+  for (size_t i = 0; i < 10; ++i) {
+    switch (i%3) {
+    case 0:
+      tvs[i] = TestVariant::cars(i);
+      break;
+    case 1:
+      tvs[i] = TestVariant::dogs(i*3.14159);
+      break;
+    case 2:
+    default: {
+      IArr cs;
+      for (size_t i = 0; i < cs.size(); ++i) { cs[i] = i; }
+      tvs[i] = TestVariant::chickens(cs);
+      break;
+    }}
+  }
+
+  std::vector<TestStruct> vtss;
+  for (size_t i = 0; i < 100; ++i) {
+    TestStruct ts;
+    ts.x = 42*i;
+    ts.y = 3.14159*i;
+    for (size_t j = 0; j < ts.xs.size(); ++j) {
+      ts.xs[j] = i*j;
+    }
+    vtss.push_back(ts);
+  }
+  w.define("vtss", vtss);
+
+  auto& s = w.series<TestStruct>("stss",10);
+  for (size_t i = 0; i < 100; ++i) {
+    TestStruct ts;
+    ts.x = 42*i;
+    ts.y = 3.14159*i;
+    for (size_t j = 0; j < ts.xs.size(); ++j) {
+      ts.xs[j] = i*j;
+    }
+    s(ts);
+  }
+}
+
+void makeTestScript(const std::string& path) {
+  const char* script = R"SCRIPT(
+import fregion
+import sys
+f = fregion.FRegion(sys.argv[1])
+if (f.s != 42):
+  print("Expected f.s=42 but f.s="+str(f.s))
+  sys.exit(-1)
+if (f.ts.x != 42):
+  print("Expected f.ts.x=42 but f.ts.x="+str(f.ts.x))
+  sys.exit(-1)
+if (f.p[0] != 42):
+  print("Expected f.p[0]=42 but f.p[0]="+str(f.p[0]))
+  sys.exit(-1)
+if (f.tv.cn != 'cars' or f.tv.value != 42):
+  print("Expected f.tv=|cars=42| but f.tv="+str(f.tv))
+  sys.exit(-1)
+if (sum([sum(xs) for xs in f.mat]) != 2025):
+  print("Expected matrix to sum to 2025 but failed: "+str(f.mat))
+  sys.exit(-1)
+if (sum(map(lambda ts:ts.x,f.tss)) != 1890):
+  print("Expected .x over f.tss to sum to 1890 but failed: "+str(f.tss))
+  sys.exit(-1)
+if (sum([sum(x.value) for x in f.tvs if x.cn=='chickens']) != 135):
+  print("Expected chickens matched out of f.tvs to sum to 135 but failed: "+str(f.tvs))
+  sys.exit(-1)
+
+def smapInto(r,f,x):
+  if (x.cn==".f0"):
+    return r
+  else:
+    r.append(f(x.value[0]))
+    return smapInto(r,f,x.value[1])
+def smap(f,x):
+  r=[]
+  smapInto(r,f,x)
+  return r
+
+if (sum(smap(lambda vs: sum(map(lambda v:v.x, vs)),f.stss)) != 207900):
+  print("Expected .x over f.stss to sum to 207900 but failed: "+str(f.stss))
+  sys.exit(-1)
+
+sys.exit(0)
+  )SCRIPT";
+
+  std::ofstream f(path.c_str());
+  f << script;
+}
+
+TEST(Python, FRegion) {
+#if !defined(PYTHON_EXECUTABLE) or !defined(SCRIPT_DIR)
+  std::cout << "Warning: no python compatibility tests will be run" << std::endl;
+#else
+  auto db = mkFName("db");
+  auto py = mkFName("py");
+  try {
+    makeTestData(db);
+    makeTestScript(py);
+
+    PythonProc p(DEF_STR(PYTHON_EXECUTABLE), DEF_STR(SCRIPT_DIR), py, db);
+    EXPECT_EQ(p.run(), 0);
+
+    unlink(py.c_str());
+    unlink(db.c_str());
+  } catch (...) {
+    unlink(py.c_str());
+    unlink(db.c_str());
+    throw;
+  }
+#endif
+}
+


### PR DESCRIPTION
This change adds a python script equivalent to fregion.H for reading structured data.  The script is self-contained and implemented purely in python, so hopefully should be very easy to use.

The included test verifies compatibility between structured data produced from C++ (confirmed equivalent to hobbes in other tests) and python with a variety of common data structures.

The API from python is very similar to the API from hobbes, natural "dot syntax" for accessing data and metadata.  As well, type analysis is done just at load-time to minimize the work necessary to read data later.

As an example of what a file looks like in the python shell, I have loaded and printed the summary of the file produced by the test program (which gives a good overview of the type structures tested):

```
$ python
Python 2.7.10 (default, Aug 17 2018, 17:41:52)
[GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.0.42)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import fregion
>>> f = fregion.FRegion("./test.db")
>>> f
c    :: char
b    :: byte
e    :: float
d    :: double
f    :: bool
i    :: int
stss :: ^x.(()+(carray({x:int, y:double, xs:[:int|10:]}, 10)@?*x@?))@?
vtss :: [{x:int, y:double, xs:[:int|10:]}]@?
ts   :: {x:int, y:double, xs:[:int|10:]}
tvs  :: [:|cars:int, dogs:double, chickens:[:int|10:]||10:]
p    :: (int*double)
s    :: short
tv   :: |cars:int, dogs:double, chickens:[:int|10:]|
xs   :: [:int|10:]
tss  :: [:{x:int, y:double, xs:[:int|10:]}|10:]
mat  :: [:[:int|10:]|10:]
>>>
```