### PR TITLE
support queries of reader/sender state in hog

### DIFF
--- a/bin/hog/stat.C
+++ b/bin/hog/stat.C
@@ -1,0 +1,19 @@
+#include "stat.H"
+
+#include <string>
+
+namespace hog {
+
+inline std::string statFilePrefix() {
+  return hobbes::storage::defaultStoreDir() + "/hogstat";
+}
+
+StatFile& StatFile::instance() {
+  static StatFile statFile;
+  return statFile;
+}
+
+StatFile::StatFile() : statFile(hobbes::fregion::uniqueFilename(statFilePrefix(), ".db")) {}
+
+}
+

--- a/bin/hog/stat.H
+++ b/bin/hog/stat.H
@@ -1,0 +1,78 @@
+#ifndef HOG_STAT_H_INCLUDED
+#define HOG_STAT_H_INCLUDED
+
+#include <mutex>
+
+#include <hobbes/hobbes.H>
+#include <hobbes/reflect.H>
+#include <hobbes/storage.H>
+#include <hobbes/fregion.H>
+
+namespace hog {
+
+DEFINE_ENUM(ReaderStatus,
+  (Started),
+  (Closed)
+);
+
+DEFINE_STRUCT(ReaderState,
+  (hobbes::datetimeT,           datetime),
+  (hobbes::storage::ProcThread, readerId),
+  (ReaderStatus,                status)
+);
+
+DEFINE_STRUCT(ReaderRegistration,
+  (hobbes::datetimeT,           datetime),
+  (hobbes::storage::ProcThread, writerId),
+  (hobbes::storage::ProcThread, readerId),
+  (std::string,                 shmname)
+);
+
+DEFINE_ENUM(SenderStatus,
+  (Suspended),
+  (Started),
+  (Closed)
+);
+
+DEFINE_STRUCT(SenderState,
+  (hobbes::datetimeT,           datetime),
+  (hobbes::storage::ProcThread, id),
+  (SenderStatus,                status)
+);
+
+DEFINE_STRUCT(SenderRegistration,
+  (hobbes::datetimeT,           datetime),
+  (hobbes::storage::ProcThread, readerId),
+  (hobbes::storage::ProcThread, senderId),
+  (std::string,                 directory),
+  (std::vector<std::string>,    senderqueue)
+);
+
+class StatFile {
+public:
+  static StatFile& instance();
+
+  template <typename T>
+  void log(T&& value) {
+    std::lock_guard<decltype(mutex)> _{mutex};
+    statFile.series<T>(T::_hmeta_struct_type_name())(std::forward<T>(value));
+  }
+
+  const std::string& filename() const {
+    return statFile.fileData()->path;
+  }
+
+private:
+  StatFile();
+  ~StatFile() = default;
+  StatFile(const StatFile&) = delete;
+  StatFile& operator=(const StatFile&) = delete;
+
+  hobbes::fregion::writer statFile;
+  std::mutex mutex;
+};
+
+}
+
+#endif
+

--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -2026,6 +2026,7 @@ public:
   }
 
   imagefile* fileData() { return this->f; }
+  const imagefile* fileData() const { return this->f; }
 private:
   typedef std::map<std::string, seriesi*> wseriess;
   imagefile* f;
@@ -2315,6 +2316,7 @@ public:
     }
 
   imagefile* fileData() { return this->f; }
+  const imagefile* fileData() const { return this->f; }
 private:
   typedef std::map<std::string, seriesi*> rseriess;
   imagefile* f;


### PR DESCRIPTION
This change resolves #209, so that connection/stats details are logged
in the generated structured file (the pathname will be indicated in the
stdout)