### PR TITLE
fix a bug with carray size determination

### DIFF
--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -1191,7 +1191,7 @@ template <typename T, size_t N>
     // data carray t n = {avail:long, buffer:[:t|n:]}
     static ty::desc storeType() { return ty::app(prim("carray", ty::fn("t", "c", ty::rec("avail", 0, ty::prim("long"), "buffer", sizeof(size_t), ty::array(ty::var("t"), ty::var("c"))))), store<T>::storeType(), ty::nat(N)); }
 
-    static size_t size()      { static const size_t sz=align(sizeof(size_t), alignment())+store<T>::size()*N; return sz; }
+    static size_t size()      { static const size_t sz=align(align(sizeof(size_t), alignment())+store<T>::size()*N, alignment()); return sz; }
     static size_t alignment() { static const size_t a =std::max<size_t>(sizeof(size_t), store<T>::alignment()); return a; }
   };
 
@@ -1478,9 +1478,9 @@ struct defStructF {
 
   template <typename T>
     void visit(const char* fname) {
-      size_t i = align<size_t>(this->offset, store<T>::alignment());
-      this->fs->push_back(ty::Struct::Field(fname, i, store<T>::storeType()));
-      this->offset = i + store<T>::size();
+      this->offset = align<size_t>(this->offset, store<T>::alignment());
+      this->fs->push_back(ty::Struct::Field(fname, this->offset, store<T>::storeType()));
+      this->offset += store<T>::size();
     }
 };
 

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -937,6 +937,21 @@ template <typename T, size_t N>
     const T& operator[](size_t i) const { return this->data[i]; }
           T& operator[](size_t i)       { return this->data[i]; }
   };
+template <size_t N>
+  struct carray<char,N> {
+    size_t size;
+    char   data[N];
+
+    const char& operator[](size_t i) const { return this->data[i]; }
+          char& operator[](size_t i)       { return this->data[i]; }
+
+    carray<char,N>& operator=(const char* s) {
+      size_t n = std::min<size_t>(N, strlen(s));
+      memcpy(this->data, s, n);
+      this->size = n;
+      return *this;
+    }
+  };
 
 template <typename T, size_t N> const T* begin(const carray<T,N>* d) { return d->data; }
 template <typename T, size_t N> const T* end  (const carray<T,N>* d) { return d->data + d->size; }


### PR DESCRIPTION
The definition of 'store<carray<T,N>>' did not take trailing padding into account correctly.