### PR TITLE
allow ctrl-c to terminate expression evaluation in "hi"

### DIFF
--- a/include/hobbes/events/events.H
+++ b/include/hobbes/events/events.H
@@ -20,6 +20,7 @@ void addTimer(timerfunc f, int millisecInterval);
 void registerEventHandler(int fd, const std::function<void(int)>& fn, bool vn = false /* only used on BSD */);
 void registerEventHandler(int fd, eventhandler f, void* ud, bool vn = false /* only used on BSD */);
 void unregisterEventHandler(int fd);
+void registerInterruptHandler(const std::function<void()>& fn);
 
 // run a single-step or indefinite event loop
 bool stepEventLoop();

--- a/lib/hobbes/events/events.C
+++ b/lib/hobbes/events/events.C
@@ -232,7 +232,7 @@ void registerEventHandler(int fd, const std::function<void(int)>& fn, bool vn) {
 }
 
 void registerInterruptHandler(const std::function<void()>& fn) {
-  threadEPollFD();
+  threadKQFD();
   auto* c = new eventcbclosure(-1, [fn](int){fn();});
   (*kqClosures)[-1] = c;
 }

--- a/lib/hobbes/events/events.C
+++ b/lib/hobbes/events/events.C
@@ -85,6 +85,12 @@ void registerEventHandler(int fd, const std::function<void(int)>& fn, bool) {
   }
 }
 
+void registerInterruptHandler(const std::function<void()>& fn) {
+  threadEPollFD();
+  auto* c = new eventcbclosure(-1, [fn](int){fn();});
+  (*epClosures)[-1] = c;
+}
+
 bool stepEventLoop() {
   while (true) {
     int timeout = -1;
@@ -104,8 +110,15 @@ bool stepEventLoop() {
         (c->fn)(c->fd);
         resetMemoryPool();
       }
-    } else if (fds < 0 && errno != EINTR) {
-      status = false;
+    } else if (fds < 0) {
+      if (errno != EINTR) {
+        status = false;
+      } else if (epClosures) {
+        auto f = epClosures->find(-1);
+        if (f != epClosures->end()) {
+          f->second->fn(-1);
+        }
+      }
     } else if (!timers.empty()) {
       std::vector<timer> newTimers;
 
@@ -218,6 +231,12 @@ void registerEventHandler(int fd, const std::function<void(int)>& fn, bool vn) {
   }
 }
 
+void registerInterruptHandler(const std::function<void()>& fn) {
+  threadEPollFD();
+  auto* c = new eventcbclosure(-1, [fn](int){fn();});
+  (*kqClosures)[-1] = c;
+}
+
 bool stepEventLoop() {
   while (true) {
     struct kevent evts[64];
@@ -231,6 +250,11 @@ bool stepEventLoop() {
       return true;
     } else if (errno != EINTR) {
       return false;
+    } else if (kqClosures) {
+      auto f = kqClosures->find(-1);
+      if (f != kqClosures->end()) {
+        f->second->fn(-1);
+      }
     }
   }
 }

--- a/test/Python.C
+++ b/test/Python.C
@@ -51,9 +51,11 @@ private:
   std::vector<const char*> argv;
 };
 
+#if defined(PYTHON_EXECUTABLE) and defined(SCRIPT_DIR)
 static std::string mkFName(const std::string& ext = "db") {
   return hobbes::uniqueFilename("/tmp/hdb-unittest", "." + ext);
 }
+#endif
 
 typedef std::array<int, 10> IArr;
 DEFINE_STRUCT(


### PR DESCRIPTION
This way we can terminate expression evaluation without having to restart the shell process.