### PR TITLE
Register shm reader properly in hog local mode

### DIFF
--- a/bin/hog/local.C
+++ b/bin/hog/local.C
@@ -27,7 +27,7 @@ void recordLocalData(SessionGroup* sg, const hobbes::storage::QueueConnection& q
   };
 
   try {
-    storage::runReadProcessWithTimeout(qc, wp, initF, 0, timeoutF);
+    storage::runReadProcessWithTimeout(qc, wp, initF, 1e9, timeoutF);
   } catch (const ShutdownException& ex) {
     out() << ex.what() << std::endl;
   }


### PR DESCRIPTION
This fix allows hog to register shm reader for new connections
correctly (hence, still writing data in ordered sequence) in local mode.