### PR TITLE
add a test for keyed storage (storage of series by key, safe for concurrent reading from a skip-list map)

### DIFF
--- a/include/hobbes/db/series.H
+++ b/include/hobbes/db/series.H
@@ -183,38 +183,39 @@ template <typename T>
     StoredSeries storage;
   };
 
-template <typename K, typename V>
-  class keyseries {
+template <typename K>
+  class keyseriesdv {
   public:
-    keyseries(cc* c, writer* db, const std::string& name, size_t bsize = 10000, StoredSeries::StorageMode sm = StoredSeries::Raw) :
-      c(c), db(db), bsize(bsize), sm(sm),
-      pmap(name, db->fileData(), toTD(StoredSeries::seriesTypeDesc(sm, c, lift<V,true>::type(*c), bsize)))
+    keyseriesdv(cc* c, writer* db, const std::string& name, const MonoTypePtr& vty, size_t bsize = 10000, StoredSeries::StorageMode sm = StoredSeries::Raw) :
+      c(c), db(db), vty(vty), bsize(bsize), sm(sm),
+      pmap(name, db->fileData(), toTD(StoredSeries::seriesTypeDesc(sm, c, vty, bsize)))
     {
       for (const auto& pm : this->pmap) {
-        this->dmap[pm.first] = new StoredSeries(this->c, this->db, pm.second, lift<V,true>::type(*this->c), this->bsize, this->sm);
+        this->dmap[pm.first] = new StoredSeries(this->c, this->db, pm.second, vty, this->bsize, this->sm);
       }
     }
 
-    ~keyseries() {
+    ~keyseriesdv() {
       for (auto& d : this->dmap) {
         delete d.second;
       }
     }
 
-    void record(const K& k, const V& v, bool signal = true) {
+    void record(const K& k, const void* v, bool signal = true) {
       auto d = this->dmap.find(k);
       if (d != this->dmap.end()) {
-        d->second->record(&v, signal);
+        d->second->record(v, signal);
       } else {
-        auto* s = new StoredSeries(this->c, this->db, 0, lift<V,true>::type(*this->c), this->bsize, this->sm);
+        auto* s = new StoredSeries(this->c, this->db, 0, this->vty, this->bsize, this->sm);
         this->pmap.insert(k, s->rootRef());
         this->dmap[k] = s;
-        s->record(&v, signal);
+        s->record(v, signal);
       }
     }
   private:
     cc*                       c;
     writer*                   db;
+    MonoTypePtr               vty;
     size_t                    bsize;
     StoredSeries::StorageMode sm;
 
@@ -227,6 +228,18 @@ template <typename K, typename V>
       return ty::decode(b);
     }
   };
+
+template <typename K, typename V>
+  class keyseries : public keyseriesdv<K> {
+  public:
+    keyseries(cc* c, writer* db, const std::string& name, size_t bsize = 10000, StoredSeries::StorageMode sm = StoredSeries::Raw) : keyseriesdv<K>(c, db, name, lift<V,true>::type(*c), bsize, sm)
+    {
+    }
+    void record(const K& k, const V& v, bool signal = true) {
+      keyseriesdv<K>::record(k, reinterpret_cast<const void*>(&v), signal);
+    }
+  };
+
 
 }
 

--- a/include/hobbes/db/series.H
+++ b/include/hobbes/db/series.H
@@ -10,16 +10,26 @@
 #include <hobbes/db/cbindings.H>
 #include <hobbes/lang/tylift.H>
 #include <hobbes/util/time.H>
+#include <hobbes/slmap.H>
 #include <hobbes/util/perf.H>
 
 namespace hobbes {
 
+typedef uint64_t ufileref;
+
 class RawStoredSeries {
 public:
   RawStoredSeries(cc*, writer*, const std::string&, const MonoTypePtr&, size_t);
+  RawStoredSeries(cc*, writer*, ufileref, const MonoTypePtr&, size_t);
   ~RawStoredSeries();
 
-  // what type will actually be recorded?
+  // where has this series been placed?
+  ufileref rootRef() const;
+
+  // what would the whole sequence type look like for the given type?
+  static MonoTypePtr seriesTypeDesc(cc*, const MonoTypePtr&, size_t);
+
+  // what type is actually being recorded?
   const MonoTypePtr& storageType() const;
 
   // record a value in this series
@@ -37,6 +47,8 @@ public:
   // "clear" the data (just reset the root node, ignore old data)
   void clear(bool signal = true);
 private:
+  ufileref rootLoc;
+
   writer*     outputFile;
   MonoTypePtr recordType;
   MonoTypePtr storedType;
@@ -64,6 +76,7 @@ private:
 
 class CompressedStoredSeries {
 public:
+  CompressedStoredSeries(cc*, writer*, ufileref, const MonoTypePtr&, size_t);
   CompressedStoredSeries(cc*, writer*, const std::string&, const MonoTypePtr&, size_t);
   ~CompressedStoredSeries();
 
@@ -72,7 +85,13 @@ public:
   typedef void (*CPrepM)(UCWriter*,uint8_t*);
   typedef void (*CDeallocM)(uint8_t*);
 
-  // what type will actually be recorded?
+  // where has this series been placed?
+  ufileref rootRef() const;
+
+  // what would the whole compressed sequence type look like for the given type?
+  static MonoTypePtr seriesTypeDesc(cc*, const MonoTypePtr&, size_t);
+
+  // what type is actually being recorded?
   const MonoTypePtr& storageType() const;
   
   // record a value in this series
@@ -89,6 +108,7 @@ private:
   MonoTypePtr recordType;
   ModelTypes  modelTypes;
   MonoTypePtr seqType;
+  ufileref    rootLoc;
   UCWriter    w;
   uint8_t*    dynModel;
   region      dynModelMem;
@@ -106,11 +126,21 @@ public:
     Raw = 0,
     Compressed
   };
-
-  StoredSeries(cc*, writer*, const std::string&, const MonoTypePtr&, size_t, StorageMode sm = Raw);
   ~StoredSeries();
 
-  // what type will actually be recorded?
+  // create a stored series with a top-level variable binding
+  StoredSeries(cc*, writer*, const std::string&, const MonoTypePtr&, size_t, StorageMode sm = Raw);
+
+  // create an "anonymous" stored series at a predefined location (or if location==0, create at a new location)
+  StoredSeries(cc*, writer*, ufileref, const MonoTypePtr&, size_t, StorageMode sm = Raw);
+
+  // where has this series been placed?
+  ufileref rootRef() const;
+
+  // what would the whole sequence type look like if storing the given type?
+  static MonoTypePtr seriesTypeDesc(StorageMode, cc*, const MonoTypePtr&, size_t);
+
+  // what type is actually being recorded?
   const MonoTypePtr& storageType() const;
 
   // record a value in this series
@@ -151,6 +181,51 @@ template <typename T>
     }
   private:
     StoredSeries storage;
+  };
+
+template <typename K, typename V>
+  class keyseries {
+  public:
+    keyseries(cc* c, writer* db, const std::string& name, size_t bsize = 10000, StoredSeries::StorageMode sm = StoredSeries::Raw) :
+      c(c), db(db), bsize(bsize), sm(sm),
+      pmap(name, db->fileData(), toTD(StoredSeries::seriesTypeDesc(sm, c, lift<V,true>::type(*c), bsize)))
+    {
+      for (const auto& pm : this->pmap) {
+        this->dmap[pm.first] = new StoredSeries(this->c, this->db, pm.second, lift<V,true>::type(*this->c), this->bsize, this->sm);
+      }
+    }
+
+    ~keyseries() {
+      for (auto& d : this->dmap) {
+        delete d.second;
+      }
+    }
+
+    void record(const K& k, const V& v, bool signal = true) {
+      auto d = this->dmap.find(k);
+      if (d != this->dmap.end()) {
+        d->second->record(&v, signal);
+      } else {
+        auto* s = new StoredSeries(this->c, this->db, 0, lift<V,true>::type(*this->c), this->bsize, this->sm);
+        this->pmap.insert(k, s->rootRef());
+        this->dmap[k] = s;
+        s->record(&v, signal);
+      }
+    }
+  private:
+    cc*                       c;
+    writer*                   db;
+    size_t                    bsize;
+    StoredSeries::StorageMode sm;
+
+    slrefmap<K>                pmap;
+    std::map<K, StoredSeries*> dmap;
+
+    static ty::desc toTD(const MonoTypePtr& t) {
+      ty::bytes b;
+      encode(t, &b);
+      return ty::decode(b);
+    }
   };
 
 }

--- a/include/hobbes/slmap.H
+++ b/include/hobbes/slmap.H
@@ -235,7 +235,7 @@ template <typename K, typename V>
     size_t count;
     slnode<K,V> root;
 
-    static ty::desc type() {
+    static ty::desc type(const ty::desc& kty = fregion::store<K>::storeType(), const ty::desc& vty = fregion::store<V>::storeType()) {
       // slmap k v
       return
         ty::app(
@@ -245,8 +245,8 @@ template <typename K, typename V>
               ty::rec("count", -1, ty::prim("long"), "root", -1, slnode<K,V>::type(ty::var("k"), ty::var("v")))
             )
           ),
-          fregion::store<K>::storeType(),
-          fregion::store<V>::storeType()
+          kty,
+          vty
         );
     }
 
@@ -267,7 +267,7 @@ template <typename K, typename V>
     static const bool can_memcpy = store<K>::can_memcpy && store<V>::can_memcpy;
     static_assert(can_memcpy, "only maps with memcpyable types currently supported");
 
-    static ty::desc storeType() { return slmapdata<K,V>::type(); }
+    static ty::desc storeType(const ty::desc& kty = store<K>::storeType(), const ty::desc& vty = store<V>::storeType()) { return slmapdata<K,V>::type(kty, vty); }
     static size_t size() { return sizeof(slmapdata<K,V>); }
     static size_t alignment() { return alignof(slmapdata<K,V>); }
     static void write(imagefile*, void* p, const slmapdata<K,V>& x) { memcpy(p, &x, sizeof(x)); }
@@ -322,6 +322,57 @@ template <typename K, typename V>
     slmap();
     slmap(const slmap<K,V>&);
     slmap<K,V>& operator=(const slmap<K,V>&);
+  };
+
+template <typename K>
+  class slrefmap {
+  public:
+    typedef uint64_t ufileref;
+
+    slrefmap(const std::string& name, fregion::imagefile* f, const ty::desc& refType) {
+      this->f = f;
+
+      // allocate space for this structure and prepare to write
+      ty::desc mty = fregion::store<slmapdata<K,ufileref>>::storeType(fregion::store<K>::storeType(), refType);
+
+      auto b = this->f->bindings.find(name);
+      if (b == this->f->bindings.end()) {
+        // this structure is not yet defined, so define it and begin writing to it
+        size_t dloc = fregion::findSpace(this->f, fregion::pagetype::data, sizeof(slmapdata<K,ufileref>), alignof(slmapdata<K,ufileref>));
+        this->d = reinterpret_cast<slmapdata<K,ufileref>*>(fregion::mapFileData(this->f, dloc, sizeof(slmapdata<K,ufileref>)));
+        addBinding(this->f, name, ty::encoding(mty), dloc);
+      } else {
+        // the structure is already defined, make sure it has the right type def and then resume writing to it
+        if (b->second.type != ty::encoding(mty)) {
+          throw std::runtime_error("File already defines slmap '" + name + "' with type inconsistent with " + ty::show(mty));
+        } else {
+          this->d = reinterpret_cast<slmapdata<K,ufileref>*>(fregion::mapFileData(this->f, b->second.offset, sizeof(slmapdata<K,ufileref>)));
+        }
+      }
+    }
+
+    size_t size() const {
+      return this->d->count;
+    }
+
+    typedef sliterator<K,ufileref> iterator;
+    iterator end()   { return iterator(); }
+    iterator begin() { return (this->d->root.next.size==0 || this->d->root.next[0].index==0) ? end() : iterator(this->f, this->d->root.next[0].load(f)); }
+
+    void insert(const K& k, const ufileref& v) {
+      this->d->insert(this->f, k, v);
+    }
+
+    iterator find(const K& k) {
+      return iterator(this->f, this->d->lookup(this->f, k));
+    }
+  private:
+    fregion::imagefile* f;
+    slmapdata<K,ufileref>* d;
+  private:
+    slrefmap();
+    slrefmap(const slrefmap<K>&);
+    slrefmap<K>& operator=(const slrefmap<K>&);
   };
 
 }

--- a/lib/hobbes/db/series.C
+++ b/lib/hobbes/db/series.C
@@ -33,6 +33,19 @@ StoredSeries::StoredSeries(cc* c, writer* file, const std::string& name, const M
   }
 }
 
+StoredSeries::StoredSeries(cc* c, writer* file, const ufileref loc, const MonoTypePtr& ty, size_t n, StorageMode sm) : sm(sm) {
+  switch (this->sm) {
+  case StoredSeries::Raw:
+    new (this->storage.rss) RawStoredSeries(c, file, loc, ty, n);
+    break;
+  case StoredSeries::Compressed:
+    new (this->storage.css) CompressedStoredSeries(c, file, loc, ty, n);
+    break;
+  default:
+    throw std::runtime_error("Invalid/unsupported storage mode (" + describeStorageMode(this->sm) + ")");
+  }
+}
+
 StoredSeries::~StoredSeries() {
   switch (this->sm) {
   case StoredSeries::Raw:
@@ -46,7 +59,31 @@ StoredSeries::~StoredSeries() {
   }
 }
 
-// what type will actually be recorded?
+// where has this series been placed?
+ufileref StoredSeries::rootRef() const {
+  switch (this->sm) {
+  case StoredSeries::Raw:
+    return stripPunErr<RawStoredSeries>(this->storage.css)->rootRef();
+  case StoredSeries::Compressed:
+    return stripPunErr<CompressedStoredSeries>(this->storage.css)->rootRef();
+  default:
+    throw std::runtime_error("Invalid/unsupported storage mode (" + describeStorageMode(this->sm) + ")");
+  }
+}
+
+// what would the whole sequence type look like if storing the given type?
+MonoTypePtr StoredSeries::seriesTypeDesc(StorageMode sm, cc* c, const MonoTypePtr& t, size_t bsize) {
+  switch (sm) {
+  case StoredSeries::Raw:
+    return RawStoredSeries::seriesTypeDesc(c, t, bsize);
+  case StoredSeries::Compressed:
+    return CompressedStoredSeries::seriesTypeDesc(c, t, bsize);
+  default:
+    throw std::runtime_error("Invalid/unsupported storage mode (" + describeStorageMode(sm) + ")");
+  }
+}
+
+// what type is actually being recorded?
 const MonoTypePtr& StoredSeries::storageType() const {
   switch (this->sm) {
   case StoredSeries::Raw:
@@ -218,18 +255,57 @@ RawStoredSeries::RawStoredSeries(cc* c, writer* outputFile, const std::string& f
   this->batchStorageSize = storageSizeOf(this->batchType);
   this->storeFn          = reinterpret_cast<StoreFn>(storageFunction(c, ty, this->storedType, LexicalAnnotation::null()));
 
+  auto seriesTy = storedStreamOf(this->storedType, this->batchSize);
+
   if (this->outputFile->isDefined(fieldName)) {
     // load the existing stream state
-    this->headNodeRef = reinterpret_cast<uint64_t*>(this->outputFile->unsafeLookup(fieldName, storedStreamOf(this->storedType, this->batchSize)));
+    this->rootLoc     = this->outputFile->unsafeLookupOffset(fieldName, seriesTy);
+    this->headNodeRef = reinterpret_cast<uint64_t*>(this->outputFile->unsafeLoad(seriesTy, this->rootLoc));
+
     restartFromBatchNode();
   } else {
     // start a fresh batch -- we couldn't load anything
-    this->headNodeRef = reinterpret_cast<uint64_t*>(this->outputFile->unsafeDefine(fieldName, storedStreamOf(this->storedType, this->batchSize)));
+    this->headNodeRef = reinterpret_cast<uint64_t*>(this->outputFile->unsafeDefine(fieldName, seriesTy));
+    this->rootLoc     = this->outputFile->unsafeOffsetOf(seriesTy, this->headNodeRef);
+
+    consBatchNode(allocBatchNode(this->outputFile));
+  }
+}
+
+RawStoredSeries::RawStoredSeries(cc* c, writer* outputFile, ufileref root, const MonoTypePtr& ty, size_t batchSize) : outputFile(outputFile), recordType(ty), batchSize(batchSize) {
+  // determine the type of this stored stream in the file
+  this->storedType       = storeAs(c, ty);
+  this->storageSize      = storageSizeOf(this->storedType);
+  this->batchType        = carrayty(this->storedType, this->batchSize);
+  this->batchStorageSize = storageSizeOf(this->batchType);
+  this->storeFn          = reinterpret_cast<StoreFn>(storageFunction(c, ty, this->storedType, LexicalAnnotation::null()));
+
+  auto seriesTy = storedStreamOf(this->storedType, this->batchSize);
+
+  if (root != 0) {
+    // load the existing stream state
+    this->rootLoc     = root;
+    this->headNodeRef = reinterpret_cast<uint64_t*>(this->outputFile->unsafeLoad(seriesTy, this->rootLoc));
+
+    restartFromBatchNode();
+  } else {
+    // start a fresh batch -- we couldn't load anything
+    this->rootLoc     = findSpace(this->outputFile->fileData(), fregion::pagetype::data, storageSizeOf(seriesTy), alignment(seriesTy));
+    this->headNodeRef = reinterpret_cast<uint64_t*>(this->outputFile->unsafeLoad(seriesTy, this->rootLoc));
+
     consBatchNode(allocBatchNode(this->outputFile));
   }
 }
 
 RawStoredSeries::~RawStoredSeries() {
+}
+
+ufileref RawStoredSeries::rootRef() const {
+  return this->rootLoc;
+}
+
+MonoTypePtr RawStoredSeries::seriesTypeDesc(cc* c, const MonoTypePtr& ty, size_t batchSize) {
+  return storedStreamOf(storeAs(c, ty), batchSize);
 }
 
 const MonoTypePtr& RawStoredSeries::storageType() const {
@@ -430,6 +506,10 @@ MonoTypePtr decideCSeqType(cc* c, const MonoTypePtr& t, size_t n) {
   return decode(ty::encoding(storedCompressedSeqTypeDef(ty::decode(tenc), ty::decode(menc), n)));
 }
 
+size_t makeCRootRef(writer* file, const MonoTypePtr& cseqType) {
+  return fregion::findSpace(file->fileData(), fregion::pagetype::data, 3*sizeof(size_t), sizeof(size_t));
+}
+
 size_t makeCRootRef(writer* file, const std::string& fn, const MonoTypePtr& cseqType) {
   using namespace hobbes::fregion;
 
@@ -543,12 +623,34 @@ static CompressedStoredSeries::CDeallocM compressedMDeallocFn(cc* c, const MonoT
   }
 }
 
+CompressedStoredSeries::CompressedStoredSeries(cc* c, writer* file, ufileref rootRef, const MonoTypePtr& t, size_t n) :
+  outputFile(file),
+  recordType(t),
+  modelTypes(decideModelType(c, t)),
+  seqType(decideCSeqType(c, t, n)),
+  rootLoc(rootRef == 0 ? makeCRootRef(file, seqType) : rootRef),
+  w(file, rootLoc, n, sizeOf(modelTypes.first)),
+  dynModelMem(4096 /* default 4K page size but expandable for large models */),
+  writeFn(compressedWriteFunction(c, t)),
+  allocMFn(compressedMAllocFn(c, t)),
+  prepMFn(compressedMPrepFn(c, t)),
+  deallocMFn(compressedMDeallocFn(c, t))
+{
+  auto rid = addThreadRegion("cseq-region-" + freshName(), &this->dynModelMem);
+  auto oid = setThreadRegion(rid);
+  this->dynModel = this->allocMFn(file);
+  this->prepMFn(&this->w, this->dynModel);
+  setThreadRegion(oid);
+  removeThreadRegion(rid);
+}
+
 CompressedStoredSeries::CompressedStoredSeries(cc* c, writer* file, const std::string& fn, const MonoTypePtr& t, size_t n) :
   outputFile(file),
   recordType(t),
   modelTypes(decideModelType(c, t)),
   seqType(decideCSeqType(c, t, n)),
-  w(file, makeCRootRef(file, fn, seqType), n, sizeOf(modelTypes.first)),
+  rootLoc(makeCRootRef(file, fn, seqType)),
+  w(file, rootLoc, n, sizeOf(modelTypes.first)),
   dynModelMem(4096 /* default 4K page size but expandable for large models */),
   writeFn(compressedWriteFunction(c, t)),
   allocMFn(compressedMAllocFn(c, t)),
@@ -565,6 +667,14 @@ CompressedStoredSeries::CompressedStoredSeries(cc* c, writer* file, const std::s
 
 CompressedStoredSeries::~CompressedStoredSeries() {
   this->deallocMFn(this->dynModel);
+}
+
+ufileref CompressedStoredSeries::rootRef() const {
+  return this->rootLoc;
+}
+
+MonoTypePtr CompressedStoredSeries::seriesTypeDesc(cc* c, const MonoTypePtr& t, size_t bsize) {
+  return decideCSeqType(c, t, bsize);
 }
 
 // what type will actually be recorded?

--- a/lib/hobbes/db/series.C
+++ b/lib/hobbes/db/series.C
@@ -506,7 +506,7 @@ MonoTypePtr decideCSeqType(cc* c, const MonoTypePtr& t, size_t n) {
   return decode(ty::encoding(storedCompressedSeqTypeDef(ty::decode(tenc), ty::decode(menc), n)));
 }
 
-size_t makeCRootRef(writer* file, const MonoTypePtr& cseqType) {
+size_t makeCRootRef(writer* file, const MonoTypePtr&) {
   return fregion::findSpace(file->fileData(), fregion::pagetype::data, 3*sizeof(size_t), sizeof(size_t));
 }
 


### PR DESCRIPTION
This way of storing compressed data should give us better query performance when queries are primarily by key, because all decompression work will be productive (don't waste time decompressing data that's irrelevant) and also compression ratios should be improved (assuming per-key statistics are more accurate than aggregate statistics).