### PR TITLE
fix a discrepency between hobbes-generated fregion files and fregion.H reader/series expectation

### DIFF
--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -1781,8 +1781,12 @@ template <typename T>
         addBinding(this->f, this->seqname, ty::encoding(this->stdef), dloc);
       } else {
         // the sequence is already defined, make sure it has the right type def and then resume writing to it
-        if (b->second.type != ty::encoding(this->stdef)) {
-          throw std::runtime_error("File already defines series '" + this->seqname + "' with type inconsistent with " + ty::show(store<T>::storeType()));
+        if (!equivModOffset(ty::decode(b.second.type), this->stdef)) {
+          throw std::runtime_error(
+            "File defines series '" + seqname + "' with inconsistent type:\n" + 
+            "  Expected: " + ty::show(this->stdef) + "\n" +
+            "  Actual:   " + ty::show(ty::decode(b->second.type))
+          );
         } else {
           this->headNodeRef = reinterpret_cast<uint64_t*>(mapFileData(this->f, b->second.offset, sizeof(size_t)));
           restartFromBatchNode();
@@ -2055,8 +2059,12 @@ template <typename T>
       // determine value and sequence types
       this->stdef = storedSeqType(this->tdef, this->batchSize);
 
-      if (b.type != encoding(this->stdef)) {
-        throw std::runtime_error("File defines series '" + seqname + "' with type inconsistent with " + ty::show(store<T>::storeType()));
+      if (!equivModOffset(ty::decode(b.type), this->stdef)) {
+        throw std::runtime_error(
+          "File defines series '" + seqname + "' with inconsistent type:\n" + 
+          "  Expected: " + ty::show(this->stdef) + "\n" +
+          "  Actual:   " + ty::show(ty::decode(b.type))
+        );
       }
 
       // load all nodes, prepare to walk in-order
@@ -2111,7 +2119,7 @@ template <typename T>
     void loadReadState(uint64_t root) {
       while (root != 0) {
         uint64_t* d = reinterpret_cast<uint64_t*>(mapFileData(this->f, root, 3*sizeof(uint64_t)));
-        if (d[0] == 0) {
+        if (static_cast<uint32_t>(d[0]) == 0) {
           root = 0;
         } else {
           this->batches.push(d[1]);

--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -1781,7 +1781,7 @@ template <typename T>
         addBinding(this->f, this->seqname, ty::encoding(this->stdef), dloc);
       } else {
         // the sequence is already defined, make sure it has the right type def and then resume writing to it
-        if (!equivModOffset(ty::decode(b.second.type), this->stdef)) {
+        if (!equivModOffset(ty::decode(b->second.type), this->stdef)) {
           throw std::runtime_error(
             "File defines series '" + seqname + "' with inconsistent type:\n" + 
             "  Expected: " + ty::show(this->stdef) + "\n" +

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -1461,7 +1461,7 @@ inline desc decode(const bytes& bs) {
   return decodeFrom(bs, &i);
 }
 
-void print(std::ostream& o, const bytes& bs) {
+inline void print(std::ostream& o, const bytes& bs) {
   o << "0x";
   for (auto b : bs) {
     static const char nybs[] = "0123456789abcdef";

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -1461,6 +1461,15 @@ inline desc decode(const bytes& bs) {
   return decodeFrom(bs, &i);
 }
 
+void print(std::ostream& o, const bytes& bs) {
+  o << "0x";
+  for (auto b : bs) {
+    static const char nybs[] = "0123456789abcdef";
+    o << nybs[(b>>4)%16];
+    o << nybs[(b&0x0f)%16];
+  }
+}
+
 // describe a type description for human consumption
 inline void describe(const desc& t, std::ostream& o) {
   const D*         pd   = t.get();


### PR DESCRIPTION
Type structures can be written with "don't care" offsets for record fields, and also we should blank out the padding bytes when reading variant tags in the reader.