### PR TITLE
add a constraint to translate hobbes types to C++ types

### DIFF
--- a/bin/hi/evaluator.H
+++ b/bin/hi/evaluator.H
@@ -13,17 +13,17 @@ struct Args {
   typedef std::map<std::string, std::string> NameVals;
   typedef std::vector<std::string> strs;
 
-  ModuleFiles  mfiles;
-  std::string  evalExpr;
-  bool         showDbg;
-  bool         useDefColors;
-  bool         silent;
-  int          replPort;
-  int          httpdPort;
-  bool         exitAfterEval;
-  NameVals     scriptNameVals;
-  bool         machineREPL;    // should we structure console I/O for machine-reading?
-  strs         opts;
+  ModuleFiles              mfiles;
+  std::vector<std::string> evalExprs;
+  bool                     showDbg;
+  bool                     useDefColors;
+  bool                     silent;
+  int                      replPort;
+  int                      httpdPort;
+  bool                     exitAfterEval;
+  NameVals                 scriptNameVals;
+  bool                     machineREPL;    // should we structure console I/O for machine-reading?
+  strs                     opts;
 
   Args() : useDefColors(false), silent(false), replPort(-1), httpdPort(-1), exitAfterEval(false), machineREPL(false) {
   }

--- a/bin/hi/main.C
+++ b/bin/hi/main.C
@@ -604,7 +604,7 @@ Args processCommandLine(int argc, char** argv) {
         r.mfiles.push_back(arg);
         break;
       case 1:
-        r.evalExpr = arg;
+        r.evalExprs.push_back(arg);
         m = 0;
         break;
       case 2:
@@ -679,9 +679,9 @@ int main(int argc, char** argv) {
       }
     }
 
-    // should we evaluate some given expression?
-    if (!args.evalExpr.empty()) {
-      eval->evalExpr(args.evalExpr);
+    // should we evaluate some given expression(s)?
+    for (const auto& expr : args.evalExprs) {
+      eval->evalExpr(expr);
     }
 
     // finally, run some kind of REPL if requested

--- a/include/hobbes/lang/preds/cpptdesc.H
+++ b/include/hobbes/lang/preds/cpptdesc.H
@@ -1,0 +1,28 @@
+
+#ifndef HOBBES_LANG_TYPEPREDS_CPPTDESC_HPP_INCLUDED
+#define HOBBES_LANG_TYPEPREDS_CPPTDESC_HPP_INCLUDED
+
+#include <hobbes/lang/tyunqualify.H>
+#include <string>
+
+namespace hobbes {
+
+class CPPTypeDescP : public Unqualifier {
+public:
+  static std::string constraintName();
+
+  // unqualifier interface
+  bool        refine(const TEnvPtr&,const ConstraintPtr&,MonoTypeUnifier*,Definitions*);
+  bool        satisfied(const TEnvPtr&,const ConstraintPtr&,Definitions*)                const;
+  bool        satisfiable(const TEnvPtr&,const ConstraintPtr&,Definitions*)              const;
+  void        explain(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds, annmsgs* msgs);
+  ExprPtr     unqualify(const TEnvPtr&,const ConstraintPtr&,const ExprPtr&,Definitions*) const;
+  PolyTypePtr lookup   (const std::string& vn)                                           const;
+  SymSet      bindings ()                                                                const;
+  FunDeps     dependencies(const ConstraintPtr&)                                         const;
+};
+
+}
+
+#endif
+

--- a/include/hobbes/lang/typepreds.H
+++ b/include/hobbes/lang/typepreds.H
@@ -24,6 +24,7 @@
 #include <hobbes/lang/preds/data.H>
 #include <hobbes/lang/preds/typeof.H>
 #include <hobbes/lang/preds/sizeof.H>
+#include <hobbes/lang/preds/cpptdesc.H>
 #include <hobbes/ipc/process.H>
 
 #endif

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -113,6 +113,9 @@ cc::cc() :
   // support appending (appendable) types
   this->tenv->bind(AppendsToUnqualifier::constraintName(), UnqualifierPtr(new AppendsToUnqualifier()));
 
+  // support translation of hobbes type descs to C++ type descs
+  this->tenv->bind(CPPTypeDescP::constraintName(), UnqualifierPtr(new CPPTypeDescP()));
+
   // support connecting to remote processes
   initNetworkDefs(*this);
 

--- a/lib/hobbes/lang/preds/cpptdesc.C
+++ b/lib/hobbes/lang/preds/cpptdesc.C
@@ -86,7 +86,7 @@ struct defineCPPTy : public switchType<UnitV> {
 
   UnitV with(const FixedArray* v) const {
     if (const auto* n = is<TLong>(v->length())) {
-      *this->out << "typedef std::array<" << acc(this->tname+"_elem", v->type()) << ", " << n->value() << "> " << this->tname << "\n";
+      *this->out << "typedef std::array<" << acc(this->tname+"_elem", v->type()) << ", " << n->value() << "> " << this->tname << ";\n";
     } else {
       throw annotated_error(this->la, "Expected fixed array to have length as number.");
     }
@@ -94,7 +94,7 @@ struct defineCPPTy : public switchType<UnitV> {
   }
 
   UnitV with(const Array* v) const {
-    *this->out << "typedef hobbes::array<" << acc(this->tname+"_elem", v->type()) << ">* " << this->tname << "\n";
+    *this->out << "typedef hobbes::array<" << acc(this->tname+"_elem", v->type()) << ">* " << this->tname << ";\n";
     return unitv;
   }
 

--- a/lib/hobbes/lang/preds/cpptdesc.C
+++ b/lib/hobbes/lang/preds/cpptdesc.C
@@ -1,0 +1,275 @@
+
+#include <hobbes/lang/preds/cpptdesc.H>
+#include <hobbes/lang/preds/class.H>
+#include <hobbes/lang/typeinf.H>
+
+namespace hobbes {
+
+typedef std::vector<std::string> RDefs;
+static void describeCPPTypeMin(std::ostream*, const std::string& tname, const MonoTypePtr& ty, const LexicalAnnotation& la, RDefs*);
+
+struct defineCPPTy : public switchType<UnitV> {
+  std::ostream*     out;
+  std::string       tname;
+  LexicalAnnotation la;
+  RDefs*            rds;
+
+  defineCPPTy(std::ostream* out, const std::string& tname, const LexicalAnnotation& la, RDefs* rds) : out(out), tname(tname), la(la), rds(rds) { }
+
+  static std::string cppPrimName(const std::string& hprimName) {
+    if (hprimName == "byte") {
+      return "uint8_t";
+    } else if (hprimName == "int128") {
+      return "__int128";
+    } else if (hprimName == "unit") {
+      return "hobbes::unit";
+    } else {
+      return hprimName;
+    }
+  }
+
+  // recursively translate types to a given name
+  // but if the type is trivially named, ignore the acc name and just return the primitive name
+  std::string acc(const std::string& n, const MonoTypePtr& ty) const {
+    if (const auto* p = is<Prim>(ty)) {
+      if (!p->representation()) {
+        return cppPrimName(p->name());
+      }
+    }
+
+    // ok, we have to make an explicit name for this type
+    std::ostringstream ss;
+    switchOf(ty, defineCPPTy(&ss, n, this->la, this->rds));
+    this->rds->push_back(ss.str());
+    return n;
+  }
+  std::string acc(const std::string& pfx, const MonoTypes& ts) const {
+    std::ostringstream s;
+    if (ts.size() > 0) {
+      s << acc(pfx+"_0", ts[0]);
+      for (size_t i = 1; i < ts.size(); ++i) {
+        s << ", " << acc(pfx+"_"+str::from(i), ts[i]);
+      }
+    }
+    return s.str();
+  }
+
+  UnitV with(const Prim* v) const {
+    if (v->representation()) {
+      *this->out << "DEFINE_TYPE_ALIAS(" << this->tname << ", " << acc(this->tname+"_repr", v->representation()) << ");\n";
+    } else {
+      *this->out << "typedef " << cppPrimName(v->name()) << " " << this->tname << ";\n";
+    }
+    return unitv;
+  }
+
+  UnitV with(const OpaquePtr* v) const {
+    *this->out << "typedef " << v->name() << (v->storedContiguously() ? "" : "*") << " " << this->tname << ";\n";
+    return unitv;
+  }
+
+  UnitV with(const TVar* v) const {
+    throw annotated_error(this->la, "Can't translate type with variables to C++ type.");
+  }
+
+  UnitV with(const TGen* v) const {
+    throw annotated_error(this->la, "Can't translate polymorphic type to C++ type.");
+  }
+
+  UnitV with(const TAbs* v) const {
+    throw annotated_error(this->la, "Can't translate type abstraction to C++ type.");
+  }
+
+  UnitV with(const TApp* v) const {
+    throw annotated_error(this->la, "Can't translate type application to C++ type.");
+  }
+
+  UnitV with(const FixedArray* v) const {
+    if (const auto* n = is<TLong>(v->length())) {
+      *this->out << "typedef std::array<" << acc(this->tname+"_elem", v->type()) << ", " << n->value() << "> " << this->tname << "\n";
+    } else {
+      throw annotated_error(this->la, "Expected fixed array to have length as number.");
+    }
+    return unitv;
+  }
+
+  UnitV with(const Array* v) const {
+    *this->out << "typedef hobbes::array<" << acc(this->tname+"_elem", v->type()) << ">* " << this->tname << "\n";
+    return unitv;
+  }
+
+  UnitV with(const Variant* v) const {
+    if (v->members().size() == 0) {
+      throw annotated_error(this->la, "An empty variant is impossible to construct.");
+    } else if (v->isSum()) {
+      *this->out << "typedef hobbes::variant<" << acc(this->tname+"_0", v->members()[0].type);
+      for (size_t i = 1; i < v->members().size(); ++i) {
+        *this->out << ", " << acc(this->tname+"_"+str::from(i), v->members()[i].type);
+      }
+      *this->out << "> " << this->tname << ";\n";
+    } else {
+      *this->out << "DEFINE_VARIANT(\n"
+                 << "  " << this->tname << ",\n";
+      *this->out << "  (" << v->members()[0].selector << ", " << acc(this->tname+"_"+v->members()[0].selector, v->members()[0].type) << ")";
+      for (size_t i = 1; i < v->members().size(); ++i) {
+        *this->out << ",\n"
+                   << "  (" << v->members()[i].selector << ", " << acc(this->tname+"_"+v->members()[i].selector, v->members()[i].type) << ")";
+      }
+      *this->out << "\n);\n";
+    }
+    return unitv;
+  }
+
+  UnitV with(const Record* v) const {
+    if (v->members().size() == 0) {
+      *this->out << "typedef hobbes::unit " << this->tname << ";\n";
+    } else if (v->isTuple()) {
+      if (v->members().size() == 2) {
+        *this->out << "typedef std::pair<" << acc(this->tname+"_first", v->members()[0].type) << ", " << acc(this->tname+"_second", v->members()[1].type) << "> " << this->tname << ";\n";
+      } else {
+        *this->out << "typedef hobbes::tuple<" << acc(this->tname+"_0", v->members()[0].type);
+        for (size_t i = 1; i < v->members().size(); ++i) {
+          *this->out << ", " << acc(this->tname+"_"+str::from(i), v->members()[i].type);
+        }
+        *this->out << "> " << this->tname << ";\n";
+      }
+    } else {
+      *this->out << "DEFINE_STRUCT(\n"
+                 << "  " << this->tname << ",\n";
+      *this->out << "  (" << acc(this->tname+"_"+v->members()[0].field, v->members()[0].type) << ", " << v->members()[0].field << ")";
+      for (size_t i = 1; i < v->members().size(); ++i) {
+        *this->out << ",\n"
+                   << "  (" << acc(this->tname+"_"+v->members()[i].field, v->members()[i].type) << ", " << v->members()[i].field << ")";
+      }
+      *this->out << "\n);\n";
+    }
+    return unitv;
+  }
+
+  UnitV with(const Func* v) const {
+    if (const auto* p = is<Prim>(v->result())) {
+      if (p->name() == "unit") {
+        *this->out << "typedef void (*" << this->tname << ")(" << acc(this->tname, v->parameters()) << ");\n";
+        return unitv;
+      }
+    }
+    *this->out << "typedef " << acc(this->tname+"_r", v->result()) << " (*" << this->tname << ")(" << acc(this->tname, v->parameters()) << ");\n";
+    return unitv;
+  }
+
+  UnitV with(const Exists* v) const {
+    throw annotated_error(this->la, "Can't translate existential type to C++ type.");
+  }
+
+  UnitV with(const Recursive* v) const {
+    throw annotated_error(this->la, "Can't translate recursive type to C++ type.");
+  }
+
+  UnitV with(const TString* v) const {
+    throw annotated_error(this->la, "Can't translate type string to C++ type.");
+  }
+
+  UnitV with(const TLong* v) const {
+    throw annotated_error(this->la, "Can't translate type number to C++ type.");
+  }
+
+  UnitV with(const TExpr* v) const {
+    throw annotated_error(this->la, "Can't translate type expression to C++ type.");
+  }
+};
+
+static void describeCPPTypeMin(std::ostream* out, const std::string& tname, const MonoTypePtr& ty, const LexicalAnnotation& la, RDefs* rds) {
+  switchOf(ty, defineCPPTy(out, tname, la, rds));
+}
+
+static std::string describeCPPType(const std::string& tname, const MonoTypePtr& ty, const LexicalAnnotation& la) {
+  std::ostringstream td;
+  RDefs rds;
+  describeCPPTypeMin(&td, tname, ty, la, &rds);
+  
+  std::ostringstream o;
+  o << "//\n"
+    << "// begin generated C++ type description '" << tname << "'\n"
+    << "//   from hobbes type: " << show(ty) << "\n"
+    << "//\n"
+    << "//   (remember to #include <hobbes/reflect.H> to get reflective types)\n"
+    << "//\n";
+  for (const auto& rd : rds) {
+    o << rd;
+  }
+  o << td.str();
+  o << "// end generated C++ type description '" << tname << "'\n";
+  return o.str();
+}
+
+#define REF_CPPTDESC "cppType"
+
+std::string CPPTypeDescP::constraintName() {
+  return "CPPType";
+}
+
+bool CPPTypeDescP::refine(const TEnvPtr&, const ConstraintPtr& cst, MonoTypeUnifier* u, Definitions*) {
+  return false;
+}
+
+bool CPPTypeDescP::satisfied(const TEnvPtr&, const ConstraintPtr& cst, Definitions*) const {
+  if (cst->arguments().size() == 2 && !hasFreeVariables(cst->arguments()[0])) {
+    return is<TString>(cst->arguments()[0]);
+  }
+  return false;
+}
+
+bool CPPTypeDescP::satisfiable(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const {
+  return cst->arguments().size() == 2 && (hasFreeVariables(cst->arguments()[0]) || satisfied(tenv, cst, ds));
+}
+
+void CPPTypeDescP::explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*) {
+}
+
+struct CPPTypeDescUnqualify : public switchExprTyFn {
+  ConstraintPtr constraint;
+  std::string   tname;
+  MonoTypePtr   ty;
+
+  CPPTypeDescUnqualify(const ConstraintPtr& constraint) : constraint(constraint) {
+    this->tname = is<TString>(constraint->arguments()[0])->value();
+    this->ty    = constraint->arguments()[1];
+  }
+
+  QualTypePtr withTy(const QualTypePtr& qt) const {
+    return removeConstraint(this->constraint, qt);
+  }
+
+  ExprPtr with(const Var* vn) const {
+    if (vn->value() == REF_CPPTDESC) {
+      return ExprPtr(mkarray(describeCPPType(this->tname, this->ty, vn->la()), vn->la()));
+    } else {
+      return wrapWithTy(vn->type(), new Var(vn->value(), vn->la()));
+    }
+  }
+};
+
+ExprPtr CPPTypeDescP::unqualify(const TEnvPtr&, const ConstraintPtr& cst, const ExprPtr& e, Definitions*) const {
+  return switchOf(e, CPPTypeDescUnqualify(cst));
+}
+
+PolyTypePtr CPPTypeDescP::lookup(const std::string& vn) const {
+  if (vn == REF_CPPTDESC) {
+    return polytype(2, qualtype(list(ConstraintPtr(new Constraint(CPPTypeDescP::constraintName(), list(tgen(0), tgen(1))))), arrayty(primty("char"))));
+  } else {
+    return PolyTypePtr();
+  }
+}
+
+SymSet CPPTypeDescP::bindings() const {
+  SymSet r;
+  r.insert(REF_CPPTDESC);
+  return r;
+}
+
+FunDeps CPPTypeDescP::dependencies(const ConstraintPtr&) const {
+  return FunDeps();
+}
+
+}
+

--- a/lib/hobbes/lang/preds/cpptdesc.C
+++ b/lib/hobbes/lang/preds/cpptdesc.C
@@ -68,19 +68,19 @@ struct defineCPPTy : public switchType<UnitV> {
     return unitv;
   }
 
-  UnitV with(const TVar* v) const {
+  UnitV with(const TVar*) const {
     throw annotated_error(this->la, "Can't translate type with variables to C++ type.");
   }
 
-  UnitV with(const TGen* v) const {
+  UnitV with(const TGen*) const {
     throw annotated_error(this->la, "Can't translate polymorphic type to C++ type.");
   }
 
-  UnitV with(const TAbs* v) const {
+  UnitV with(const TAbs*) const {
     throw annotated_error(this->la, "Can't translate type abstraction to C++ type.");
   }
 
-  UnitV with(const TApp* v) const {
+  UnitV with(const TApp*) const {
     throw annotated_error(this->la, "Can't translate type application to C++ type.");
   }
 
@@ -157,23 +157,23 @@ struct defineCPPTy : public switchType<UnitV> {
     return unitv;
   }
 
-  UnitV with(const Exists* v) const {
+  UnitV with(const Exists*) const {
     throw annotated_error(this->la, "Can't translate existential type to C++ type.");
   }
 
-  UnitV with(const Recursive* v) const {
+  UnitV with(const Recursive*) const {
     throw annotated_error(this->la, "Can't translate recursive type to C++ type.");
   }
 
-  UnitV with(const TString* v) const {
+  UnitV with(const TString*) const {
     throw annotated_error(this->la, "Can't translate type string to C++ type.");
   }
 
-  UnitV with(const TLong* v) const {
+  UnitV with(const TLong*) const {
     throw annotated_error(this->la, "Can't translate type number to C++ type.");
   }
 
-  UnitV with(const TExpr* v) const {
+  UnitV with(const TExpr*) const {
     throw annotated_error(this->la, "Can't translate type expression to C++ type.");
   }
 };
@@ -208,7 +208,7 @@ std::string CPPTypeDescP::constraintName() {
   return "CPPType";
 }
 
-bool CPPTypeDescP::refine(const TEnvPtr&, const ConstraintPtr& cst, MonoTypeUnifier* u, Definitions*) {
+bool CPPTypeDescP::refine(const TEnvPtr&, const ConstraintPtr&, MonoTypeUnifier*, Definitions*) {
   return false;
 }
 


### PR DESCRIPTION
This feature will make it easier for us to back-port types determined in hobbes into C++ (e.g. if we get a data file with a complex type, this will automate most of the work of describing that type in C++).