### PR TITLE
Issue #225 - Add automatic recovery feature to Hog

### DIFF
--- a/bin/hog/README.md
+++ b/bin/hog/README.md
@@ -1,0 +1,95 @@
+# Hog - Hobbes-based logging facilities
+
+## Automatic Fault Detection & Recovery
+
+Automatic fault detection and recovery features are available in Hog by default.
+At the moment only batchsend mode recovery is supported. These features are
+enabled by default, are fully automated, and can be disabled via the 
+`--no-recovery` flag. The main goal of the feature is to allow automatic fault
+recovery within batch send mode with as little blocking of resumption of normal operations 
+as is possible without compromising data ordering guarantees.
+
+
+NOTE: Recovery will not work if the following conditions aren't present
+
+ * Shared memory regions must still be available (not persistent across system restarts).
+ * Hog statistics log (e.g. hogstat.db) must be accessible in the specified directory.
+
+### Abstract Recovery Process
+
+The process works as follows:
+ 
+ * The Hog batchsend application starts.
+ * The statistics log file is scanned to see if any shared memory regions &
+   destinations didn't have their data sent to an associated receieve Hog
+   session before terminating unexpectedly.
+ * The information for any such "faulty" sessions is collected.
+ * The new Hog instance attempts to (in chronological order) start of these
+   sessions. Recovery can only complete for any given shared memory
+   region/destination once, and will only be classed as completed when all data
+   has been successfully sent to all required destinations.
+ * Once recovery has started, blocking on draining shared memory regions as
+   necessary, sending logic is left to complete concurrently, and the Hog
+   instance continues to run given the options specified on the command line.
+ * Operations as normal.
+
+Sending of data happens in parallel to normal operation, but ordering is 
+maintained correctly.
+
+Following are some potential failure scenarios that (with this feature) Hog can
+handle appropriately:
+
+### Scenario - Send Failure
+
+ * Batch receive, batch send and logging process all start.
+ * Send connects to logging process and begins draining shm to disk.
+ * Send connects to receive and begins sending data segments over the network.
+ * Send terminates unexpectedly.
+ * Send is restarted with the same parameters.
+ * Recovery kicks in, starts draining the previous shared memory
+   region to disk, and also starts concurrently sending data to the receive
+   instance. 
+ * Once the reading process catches up to the end of log, it terminates, and
+   then Hog resumes normal operation, connecting with the logging process again.
+ * The sending process continues as normal.
+
+### Scenario - Engine Failure
+
+ * Batch receive, batch send and logging process all start.
+ * Send connects to logging process and begins draining shm to disk.
+ * Send connects to receive and begins sending data segments over the network.
+ * Logging process terminates unexpectedly.
+ * Logging process is restarted.
+ * Recovery doesn't need to kick in - send appropriately renegotiates a
+   connection with the loggin process and reads shared memory and sends that
+   information over the network to receive as expected.
+
+### Scenario - Receive Failure
+
+ * Batch receive, batch send and logging process all start.
+ * Send connects to logging process and begins draining shared memory to disk.
+ * Send connects to receive and begins sending data segments over the network.
+ * Send terminates unexpectedly.
+ * Send is restarted with the same parameters.
+ * Recovery doesn't need to kick in - send appropriately continues reading the
+   shared memory region to disk, reconnecting to batch recv where possible.
+   If send terminates before doing so, this session will be automatically
+   recovered upon future attempts at running Hog in send mode.
+
+
+### Scenario - Logging Process & Send Failure
+
+ * Batch receive, batch send and logging process all start.
+ * Send connects to logging process and begins draining shm to disk.
+ * Send connects to receive and begins sending data segments over the network.
+ * Send terminates unexpectedly.
+ * Logging process terminates unexpectedly.
+ * Send is restarted with the same parameters.
+ * Logging process is restarted.
+ * Recovery kicks in, starts draining the previous shared memory
+   region to disk, and also starts concurrently sending data to the receive
+   instance. 
+ * Once the reading process catches up to the end of log, it terminates, and
+   then Hog resumes normal operation, connecting with the logging process again.
+ * The sending process continues as normal.
+

--- a/bin/hog/batchsend.C
+++ b/bin/hog/batchsend.C
@@ -12,12 +12,14 @@
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <functional>
 #include <vector>
 #include <memory>
 
 #include <glob.h>
 #include <zlib.h>
 
+#include "batchsend.H"
 #include "network.H"
 #include "session.H"
 #include "stat.H"
@@ -197,19 +199,19 @@ void connect(std::vector<Destination>& destinations) {
   }
 }
 
-void runSegmentSendingProcess(const std::string groupName, std::vector<Destination>& destinations, ReadyFn readyFn, IdleFn idleFn) {
+void runSegmentSendingProcess(const std::string& sessionHash, const std::string groupName, std::vector<Destination>& destinations, ReadyFn readyFn, IdleFn idleFn) {
   if (destinations.empty()) {
     out() << "no batchsend host specified, compressed segment files will accumulate locally" << std::endl;
   } else {
     const auto id = hobbes::storage::thisProcThread();
-    StatFile::instance().log(SenderState{hobbes::now(), id, SenderStatus::Enum::Suspended});
+    StatFile::instance().log(SenderState{hobbes::now(), sessionHash, id, SenderStatus::Enum::Suspended});
 
     while (!readyFn()) {
       out() << "batchsend not ready, waiting on other sender(s)" << std::endl;
       sleep(10);
     }
 
-    StatFile::instance().log(SenderState{hobbes::now(), id, SenderStatus::Enum::Started});
+    StatFile::instance().log(SenderState{hobbes::now(), sessionHash, id, SenderStatus::Enum::Started});
     out() << "running segment sending process publishing to " << destinations << std::endl;
 
     while (true) {
@@ -217,7 +219,7 @@ void runSegmentSendingProcess(const std::string groupName, std::vector<Destinati
         connect(destinations);
         runConnectedSegmentSendingProcess(groupName, destinations, idleFn);
       } catch (const ShutdownException& ex) {
-        StatFile::instance().log(SenderState{hobbes::now(), id, SenderStatus::Enum::Closed});
+        StatFile::instance().log(SenderState{hobbes::now(), sessionHash, id, SenderStatus::Enum::Closed});
         out() << ex.what() << std::endl;
         return;
       } catch (std::exception& ex) {
@@ -247,12 +249,19 @@ struct BatchSendSession {
   std::thread              sendingThread;
   std::atomic<bool>        readerAlive;
   std::vector<const BatchSendSession*> detached;
+  std::function<void()>    finalizer;
 
-  BatchSendSession(const std::string& groupName, const std::string& dir, size_t clevel, const std::vector<std::string>& sendto, const std::vector<const BatchSendSession*> detached)
-    : buffer(0), c(0), sz(0), dir(dir), readerAlive(true), detached(detached) {
+  BatchSendSession(const std::string& sessionHash, const std::string& groupName, const std::string& dir, size_t clevel, const std::vector<std::string>& sendto, const std::vector<const BatchSendSession*> detached, const std::function<void()> finalizer)
+    : buffer(0), c(0), sz(0), dir(dir), readerAlive(true), detached(detached), finalizer(finalizer) {
     for (const auto & hostport : sendto) {
       auto localdir = ensureDirExists(dir + "/" + hostport + "/");
       destinations.push_back(Destination{localdir, hostport});
+    }
+
+    // start from last segment in directory 
+    const auto paths = hobbes::str::paths(dir + "*/segment-*.gz");
+    if (paths.size() > 0) {
+      this->c = std::stoi(hobbes::str::rsplit(hobbes::str::rsplit(paths.back(), ".gz").first, "segment-").second);
     }
 
     this->clevel       = std::min<size_t>(9, std::max<size_t>(clevel, 1));
@@ -271,25 +280,32 @@ struct BatchSendSession {
       if (++count % 16) return; // not checking on each idle cycle
 
       if (!readerAlive && completed()) {
+        this->finalizer();
         throw ShutdownException("Sender shutting down, group name: " + groupName + ", directory: " + this->dir);
       }
     };
 
     const auto readerId = hobbes::storage::thisProcThread();
-    this->sendingThread = std::thread([this, groupName, dir, readerId, readyFn, idleFn]() {
+    this->sendingThread = std::thread([this, sessionHash, groupName, dir, readerId, readyFn, idleFn]() {
       const auto senderId = hobbes::storage::thisProcThread();
       std::vector<std::string> senderqueue;
       for (auto s : this->detached) {
         senderqueue.push_back(s->dir);
       }
-      StatFile::instance().log(SenderRegistration{hobbes::now(), readerId, senderId, this->dir, senderqueue});
-      runSegmentSendingProcess(groupName, destinations, readyFn, idleFn);
+      StatFile::instance().log(SenderRegistration{hobbes::now(), sessionHash, readerId, senderId, this->dir, senderqueue});
+      runSegmentSendingProcess(sessionHash, groupName, destinations, readyFn, idleFn);
     });
   }
 
   void allocFile() {
-    this->buffer = reinterpret_cast<gzFile_s*>(gzopen(this->tempfilename.c_str(), ("wb" + str::from(this->clevel)).c_str()));
-    this->sz     = 0;
+    struct stat st;
+    if (::stat(this->tempfilename.c_str(), &st) == 0) {
+      this->sz     = st.st_size;
+      this->buffer = reinterpret_cast<gzFile_s*>(gzopen(this->tempfilename.c_str(), ("ab" + str::from(this->clevel)).c_str()));
+    } else {
+      this->sz     = 0;
+      this->buffer = reinterpret_cast<gzFile_s*>(gzopen(this->tempfilename.c_str(), ("wb" + str::from(this->clevel)).c_str()));
+    }
   }
 
   void stepFile() {
@@ -383,13 +399,14 @@ struct SenderGroup {
   static std::vector<const BatchSendSession*> detached;
   static std::mutex mutex;
 
-  static BatchSendSession* create(const std::string& name, const std::string& dir, size_t clevel, const std::vector<std::string>& sendto) {
+  static BatchSendSession* create(const std::string& sessionHash, const std::string& name, const std::string& dir, size_t clevel, const std::vector<std::string>& sendto, const std::function<void()>& finalizeSenderF) {
     std::lock_guard<std::mutex> _{mutex};
 
     auto it = std::find_if_not(detached.begin(), detached.end(), [](const BatchSendSession* s) { return s->completed(); });
     detached.erase(detached.begin(), it);
 
-    senders.push_back(std::unique_ptr<BatchSendSession>(new BatchSendSession{name, dir, clevel, sendto, detached}));
+    senders.push_back(std::unique_ptr<BatchSendSession>(new BatchSendSession{sessionHash, name, dir, clevel, sendto, detached, finalizeSenderF}));
+
     return senders.back().get();
   }
 
@@ -404,11 +421,10 @@ std::vector<std::unique_ptr<BatchSendSession>> SenderGroup::senders;
 std::vector<const BatchSendSession*> SenderGroup::detached;
 std::mutex SenderGroup::mutex;
 
-void pushLocalData(const storage::QueueConnection& qc, const std::string& groupName, const std::string& dir, size_t clevel, size_t batchsendsize, long batchsendtime, const std::vector<std::string>& sendto, const hobbes::storage::WaitPolicy wp, std::atomic<bool>& conn) {
-  auto pt = hobbes::storage::thisProcThread();
-  auto sn = SenderGroup::create(groupName, dir + "/tmp_" + str::from(pt.first) + "-" + str::from(pt.second) + "/", clevel, sendto);
-  batchsendtime *= 1000;
-  batchsendsize = std::max<size_t>(10*1024*1024, batchsendsize);
+void pushLocalData(const hobbes::storage::QueueConnection& qc, const std::string& sessionHash, const std::string& groupName, const std::string& partialDir, const std::string& fullDir, const hobbes::storage::ProcThread& readerId, const hobbes::storage::WaitPolicy wp, const RunMode& runMode, std::atomic<bool>& conn, const std::function<void()>& finalizeSenderF) {
+  auto sn = SenderGroup::create(sessionHash, groupName, fullDir, runMode.clevel, runMode.sendto, finalizeSenderF);
+  const long batchsendtime = runMode.batchsendtime * 1000;
+  const size_t batchsendsize = std::max<size_t>(10*1024*1024, runMode.batchsendsize);
   long t0 = hobbes::time();
 
   std::function<void()> batchCheckF;
@@ -429,7 +445,7 @@ void pushLocalData(const storage::QueueConnection& qc, const std::string& groupN
       // if we are here, the client is disconnected and the queue is drained
       // detach tcp send session synchronously and shut down the reader
       SenderGroup::detach(sn);
-      StatFile::instance().log(ReaderState{hobbes::now(), pt, ReaderStatus::Enum::Closed});
+      StatFile::instance().log(ReaderState{hobbes::now(), sessionHash, readerId, ReaderStatus::Enum::Closed});
       throw ShutdownException("SHM reader shutting down, name: " + qc.shmname);
     } else {
       batchCheckF();
@@ -437,7 +453,7 @@ void pushLocalData(const storage::QueueConnection& qc, const std::string& groupN
   };
 
   auto initFn = [&](storage::PipeQOS qos, storage::CommitMethod cm, const storage::statements& ss) {
-    initNetSession(sn, groupName, dir, qos, cm, ss);
+    initNetSession(sn, groupName, partialDir, qos, cm, ss);
     return [&](storage::Transaction& txn) {
       write(sn, txn.size());
       write(sn, txn.ptr(), txn.size());
@@ -445,7 +461,7 @@ void pushLocalData(const storage::QueueConnection& qc, const std::string& groupN
     };
   };
 
-  StatFile::instance().log(ReaderState{hobbes::now(), pt, ReaderStatus::Enum::Started});
+  StatFile::instance().log(ReaderState{hobbes::now(), sessionHash, readerId, ReaderStatus::Enum::Started});
 
   try {
     storage::runReadProcessWithTimeout(qc, wp, initFn, batchsendtime, timeoutF);

--- a/bin/hog/batchsend.H
+++ b/bin/hog/batchsend.H
@@ -14,7 +14,7 @@
 
 namespace hog {
 
-void pushLocalData(const hobbes::storage::QueueConnection& qc, const std::string& sessionHash, const std::string& groupName, const std::string& partialDir, const std::string& fullDir, const hobbes::storage::ProcThread& readerId, const hobbes::storage::WaitPolicy wp, const RunMode& runMode, std::atomic<bool>& conn, const std::function<void()>& finalizeSenderF = []() {});
+void pushLocalData(const hobbes::storage::QueueConnection& qc, const size_t sessionHash, const std::string& groupName, const std::string& partialDir, const std::string& fullDir, const hobbes::storage::ProcThread& readerId, const hobbes::storage::WaitPolicy wp, const RunMode& runMode, std::atomic<bool>& conn, const std::function<void()>& finalizeSenderF = []() {});
 
 }
 

--- a/bin/hog/batchsend.H
+++ b/bin/hog/batchsend.H
@@ -5,13 +5,17 @@
 #ifndef HOG_BATCHSEND_H_INCLUDED
 #define HOG_BATCHSEND_H_INCLUDED
 
-#include <string>
-#include <vector>
 #include <atomic>
+#include <functional>
+#include <string>
 #include <hobbes/storage.H>
 
+#include "config.H"
+
 namespace hog {
-void pushLocalData(const hobbes::storage::QueueConnection&, const std::string& groupName, const std::string& dir, size_t clevel, size_t batchsendsize, long batchsendtimeInMicros, const std::vector<std::string>& sendto, const hobbes::storage::WaitPolicy, std::atomic<bool>& conn);
+
+void pushLocalData(const hobbes::storage::QueueConnection& qc, const std::string& sessionHash, const std::string& groupName, const std::string& partialDir, const std::string& fullDir, const hobbes::storage::ProcThread& readerId, const hobbes::storage::WaitPolicy wp, const RunMode& runMode, std::atomic<bool>& conn, const std::function<void()>& finalizeSenderF = []() {});
+
 }
 
 #endif

--- a/bin/hog/config.C
+++ b/bin/hog/config.C
@@ -1,0 +1,162 @@
+#include <string>
+#include <ostream>
+#include <stdexcept>
+#include <vector>
+#include <hobbes/db/series.H>
+#include <hobbes/util/str.H>
+
+#include "config.H"
+
+namespace hog {
+
+std::ostream& operator<<(std::ostream& o, const RunMode& m) {
+  switch (m.t) {
+  case RunMode::local:
+    o << "|local={ dir=\"" << m.dir << "\", serverDir=\"" << m.groupServerDir << "\", groups=" << m.groups << " }|";
+    break;
+  case RunMode::batchsend:
+    o << "|batchsend={ dir=\"" << m.dir << "\", serverDir=\"" << m.groupServerDir << "\", clevel=" << m.clevel << ", batchsendsize=" << m.batchsendsize << "B, batchsendtime=" << m.batchsendtime << "microsec, sendto=" << m.sendto << ", groups=" << m.groups << " }|";
+    break;
+  case RunMode::batchrecv:
+    o << "|batchrecv={ dir=\"" << m.dir << "\", localport=" << m.localport << " }|";
+    break;
+  default:
+    o << "|unknown={ }|";
+  }
+  return o;
+}
+
+size_t sizeInBytes(const std::string& s) {
+  if (hobbes::str::endsWith(s, "GB")) {
+    return 1024 * 1024 * 1024 * hobbes::str::to<size_t>(s);
+  } else if (hobbes::str::endsWith(s, "MB")) {
+    return 1024 * 1024 * hobbes::str::to<size_t>(s);
+  } else if (hobbes::str::endsWith(s, "KB")) {
+    return 1024 * hobbes::str::to<size_t>(s);
+  } else {
+    return hobbes::str::to<size_t>(s);
+  }
+}
+
+void showUsage() {
+  std::cout
+  <<
+    "hog : record structured data locally or to a remote process\n"
+    "\n"
+    "  usage: hog [-d <dir>] [-g group+] [-p t s host:port+] [-s port] [-c] [-m <dir>] [-z]\n"
+    "where\n"
+    "  -d <dir>          : decides where structured data (or temporary data) is stored\n"
+    "  -g group+         : decides which data to record from memory on this machine\n"
+    "  -p t s host:port+ : decides to send data to remote process(es) every t time units or every s uncompressed bytes written\n"
+    "  -s port           : decides to receive data on the given port\n"
+    "  -c                : decides to store equally-typed data across processes in a single file\n"
+    "  -m <dir>          : decides where to place the domain socket for producer registration and hog stat file (default: " << hobbes::storage::defaultStoreDir() << ")\n"
+    "  -z                : store data compressed\n"
+    "  --no-recovery     : turns off automated recovery mode which is active by default when run in batchsend mode\n"
+  << std::endl;
+}
+
+RunMode config(int argc, const char** argv) {
+  RunMode r;
+  r.t              = RunMode::local;
+  r.dir            = "./$GROUP/$DATE/data";
+  r.groupServerDir = hobbes::storage::defaultStoreDir();
+  r.consolidate    = false;
+  r.skipRecovery   = false;
+  r.storageMode    = hobbes::StoredSeries::Raw;
+  // batchsend
+  r.clevel         = 6;
+  r.batchsendsize  = 1024;
+  r.batchsendtime  = 2;
+  // batchrecv
+  r.localport = "";
+
+  if (argc == 1) {
+    showUsage();
+    exit(0);
+  }
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string& arg = argv[i];
+    if (arg == "-?" || arg == "--help") {
+      showUsage();
+      exit(0);
+    } else if (arg == "--no-recovery") {
+      r.skipRecovery = true;
+    } else if (arg == "-d") {
+      ++i;
+      if (i < argc) {
+        r.dir = argv[i];
+      } else {
+        throw std::runtime_error("no directory specified");
+      }
+    } else if (arg == "-g") {
+      ++i;
+      while (i < argc && argv[i][0] != '-') {
+        r.groups.insert(argv[i]);
+        ++i;
+      }
+      --i;
+    } else if (arg == "-p") {
+      if (i+2 < argc) {
+        r.clevel = 6;
+
+        ++i;
+        r.batchsendtime = hobbes::readTimespan(argv[i]);
+
+        ++i;
+        r.batchsendsize = sizeInBytes(argv[i]);
+      } else {
+        throw std::runtime_error("need delay time and max size to push data");
+      }
+
+      ++i;
+      while (i < argc && argv[i][0] != '-') {
+        r.sendto.push_back(argv[i]);
+        ++i;
+      }
+      --i;
+
+      if (r.sendto.empty()) {
+        throw std::runtime_error("need remote host:port to push data");
+      } else {
+        r.t = RunMode::batchsend;
+      }
+    } else if (arg == "-s") {
+      ++i;
+      if (i < argc) {
+        r.localport = argv[i];
+      } else {
+        throw std::runtime_error("need port to receive remote data");
+      }
+      r.t = RunMode::batchrecv;
+    } else if (arg == "-c") {
+      r.consolidate = true;
+    } else if (arg == "-m") {
+      ++i;
+      if (i < argc) {
+        r.groupServerDir = argv[i];
+        StatFile::directory = argv[i];
+      } else {
+        throw std::runtime_error("need domain socket directory for producer registration");
+      }
+    } else if (arg == "-z") {
+      r.storageMode = hobbes::StoredSeries::Compressed;
+    } else {
+      throw std::runtime_error("invalid argument: " + arg);
+    }
+  }
+
+  if (r.t == RunMode::local || r.t == RunMode::batchsend) {
+    if (r.groups.size() == 0) {
+      throw std::runtime_error("can't record data because no groups have been specified");
+    }
+    if (::access(r.groupServerDir.c_str(), W_OK) != 0) {
+      throw std::runtime_error("can't record domain socket for producer registration (" + std::string(strerror(errno)) + "): " + r.groupServerDir);
+    }
+  }
+
+  return r;
+}
+
+}

--- a/bin/hog/config.H
+++ b/bin/hog/config.H
@@ -1,0 +1,77 @@
+/*
+ * config.H : functions for configuring from command line parameters and
+ * validating configuration.
+ */
+
+#ifndef HOG_CONFIG_H_INCLUDED
+#define HOG_CONFIG_H_INCLUDED
+
+#include <ostream>
+#include <set>
+#include <string>
+#include <vector>
+#include <hobbes/db/series.H>
+#include <hobbes/util/str.H>
+
+#include "stat.H"
+
+namespace hog {
+
+struct RunMode {
+  enum type { local, batchsend, batchrecv };
+  // common / local
+  type t;
+  std::string dir;
+  std::string groupServerDir;
+  std::set<std::string> groups;
+  bool consolidate;
+  bool skipRecovery;
+  hobbes::StoredSeries::StorageMode storageMode;
+
+  // batchsend
+  size_t clevel;
+  size_t batchsendsize;
+  long batchsendtime;
+  std::vector<std::string> sendto;
+
+  // batchrecv
+  std::string localport;
+};
+
+template <typename T>
+inline std::ostream& operator<<(std::ostream& o, const std::vector<T>& xs) {
+  o << "[";
+  if (xs.size() > 0) {
+    auto x = xs.cbegin();
+    o << "\"" << *x << "\"";
+    ++x;
+    for (; x != xs.cend(); ++x) {
+      o << ", \"" << *x << "\"";
+    }
+  }
+  o << "]";
+  return o;
+}
+
+template <typename T>
+inline std::ostream& operator<<(std::ostream& o, const std::set<T>& xs) {
+  o << "{";
+  if (xs.size() > 0) {
+    auto x = xs.cbegin();
+    o << "\"" << *x << "\"";
+    ++x;
+    for (; x != xs.cend(); ++x) {
+      o << ", \"" << *x << "\"";
+    }
+  }
+  o << "}";
+  return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const RunMode& m);
+
+RunMode config(int argc, const char** argv);
+
+}
+
+#endif

--- a/bin/hog/main.C
+++ b/bin/hog/main.C
@@ -3,16 +3,15 @@
 #include <hobbes/util/codec.H>
 #include <hobbes/util/time.H>
 
-#include <thread>
-#include <mutex>
 #include <atomic>
-#include <condition_variable>
 #include <stdexcept>
-#include <vector>
+#include <string>
 
+#include "config.H"
 #include "local.H"
 #include "batchsend.H"
 #include "batchrecv.H"
+#include "recovery.H"
 #include "session.H"
 #include "stat.H"
 #include "path.H"
@@ -21,192 +20,6 @@
 #include <signal.h>
 
 namespace hog {
-
-// we can run in one of three modes
-struct RunMode {
-  enum type { local, batchsend, batchrecv };
-  type                              t;
-  std::string                       dir;
-  std::string                       groupServerDir;
-  std::set<std::string>             groups;
-  bool                              consolidate;
-  hobbes::StoredSeries::StorageMode storageMode;
-
-  // batchsend
-  size_t                   clevel;
-  size_t                   batchsendsize;
-  long                     batchsendtime;
-  std::vector<std::string> sendto;
-
-  // batchrecv
-  std::string localport;
-};
-
-std::ostream& operator<<(std::ostream& o, const std::set<std::string>& xs) {
-  o << "{";
-  if (xs.size() > 0) {
-    auto x = xs.begin();
-    o << "\"" << *x << "\"";
-    ++x;
-    for (; x != xs.end(); ++x) {
-      o << ", \"" << *x << "\"";
-    }
-  }
-  o << "}";
-  return o;
-}
-
-std::ostream& operator<<(std::ostream& o, const std::vector<std::string>& xs) {
-  o << "[";
-  if (xs.size() > 0) {
-    auto x = xs.begin();
-    o << "\"" << *x << "\"";
-    ++x;
-    for (; x != xs.end(); ++x) {
-      o << ", \"" << *x << "\"";
-    }
-  }
-  o << "]";
-  return o;
-}
-
-std::ostream& operator<<(std::ostream& o, const RunMode& m) {
-  switch (m.t) {
-  case RunMode::local:
-    o << "|local={ dir=\"" << m.dir << "\", serverDir=\"" << m.groupServerDir << "\", groups=" << m.groups << " }|";
-    break;
-  case RunMode::batchsend:
-    o << "|batchsend={ dir=\"" << m.dir << "\", serverDir=\"" << m.groupServerDir << "\", clevel=" << m.clevel << ", batchsendsize=" << m.batchsendsize << "B, batchsendtime=" << m.batchsendtime << "microsec, sendto=" << m.sendto << ", groups=" << m.groups << " }|";
-    break;
-  case RunMode::batchrecv:
-    o << "|batchrecv={ dir=\"" << m.dir << "\", localport=" << m.localport << " }|";
-    break;
-  }
-  return o;
-}
-
-size_t sizeInBytes(const std::string& s) {
-  if (hobbes::str::endsWith(s, "GB")) {
-    return 1024 * 1024 * 1024 * hobbes::str::to<size_t>(s);
-  } else if (hobbes::str::endsWith(s, "MB")) {
-    return 1024 * 1024 * hobbes::str::to<size_t>(s);
-  } else if (hobbes::str::endsWith(s, "KB")) {
-    return 1024 * hobbes::str::to<size_t>(s);
-  } else {
-    return hobbes::str::to<size_t>(s);
-  }
-}
-
-void showUsage() {
-  std::cout
-  <<
-    "hog : record structured data locally or to a remote process\n"
-    "\n"
-    "  usage: hog [-d <dir>] [-g group+] [-p t s host:port+] [-s port] [-c] [-m <dir>] [-z]\n"
-    "where\n"
-    "  -d <dir>          : decides where structured data (or temporary data) is stored\n"
-    "  -g group+         : decides which data to record from memory on this machine\n"
-    "  -p t s host:port+ : decides to send data to remote process(es) every t time units or every s uncompressed bytes written\n"
-    "  -s port           : decides to receive data on the given port\n"
-    "  -c                : decides to store equally-typed data across processes in a single file\n"
-    "  -m <dir>          : decides where to place the domain socket for producer registration and hog stat file (default: " << hobbes::storage::defaultStoreDir() << ")\n"
-    "  -z                : store data compressed\n"
-  << std::endl;
-}
-
-RunMode config(int argc, const char** argv) {
-  RunMode r;
-  r.t              = RunMode::local;
-  r.dir            = "./$GROUP/$DATE/data";
-  r.groupServerDir = hobbes::storage::defaultStoreDir();
-  r.consolidate    = false;
-  r.storageMode    = hobbes::StoredSeries::Raw;
-
-  if (argc == 1) {
-    showUsage();
-    exit(0);
-  }
-
-  for (int i = 1; i < argc; ++i) {
-    std::string arg = argv[i];
-    
-    if (arg == "-?" || arg == "--help") {
-      showUsage();
-      exit(0);
-    } else if (arg == "-d") {
-      ++i;
-      if (i < argc) {
-        r.dir = argv[i];
-      } else {
-        throw std::runtime_error("no directory specified");
-      }
-    } else if (arg == "-g") {
-      ++i;
-      while (i < argc && argv[i][0] != '-') {
-        r.groups.insert(argv[i]);
-        ++i;
-      }
-      --i;
-    } else if (arg == "-p") {
-      if (i+2 < argc) {
-        r.clevel = 6;
-
-        ++i;
-        r.batchsendtime = hobbes::readTimespan(argv[i]);
-
-        ++i;
-        r.batchsendsize = sizeInBytes(argv[i]);
-      } else {
-        throw std::runtime_error("need delay time and max size to push data");
-      }
-
-      ++i;
-      while (i < argc && argv[i][0] != '-') {
-        r.sendto.push_back(argv[i]);
-        ++i;
-      }
-      --i;
-
-      if (r.sendto.empty()) {
-        throw std::runtime_error("need remote host:port to push data");
-      } else {
-        r.t = RunMode::batchsend;
-      }
-    } else if (arg == "-s") {
-      ++i;
-      if (i < argc) {
-        r.localport = argv[i];
-      } else {
-        throw std::runtime_error("need port to receive remote data");
-      }
-      r.t = RunMode::batchrecv;
-    } else if (arg == "-c") {
-      r.consolidate = true;
-    } else if (arg == "-m") {
-      ++i;
-      if (i < argc) {
-        r.groupServerDir = argv[i];
-        StatFile::directory = argv[i];
-      } else {
-        throw std::runtime_error("need domain socket directory for producer registration");
-      }
-    } else if (arg == "-z") {
-      r.storageMode = hobbes::StoredSeries::Compressed;
-    } else {
-      throw std::runtime_error("invalid argument: " + arg);
-    }
-  }
-
-  if (r.t == RunMode::local || r.t == RunMode::batchsend) {
-    if (r.groups.size() == 0) {
-      throw std::runtime_error("can't record data because no groups have been specified");
-    }
-    if (::access(r.groupServerDir.c_str(), W_OK) != 0) {
-      throw std::runtime_error("can't record domain socket for producer registration (" + std::string(strerror(errno)) + "): " + r.groupServerDir);
-    }
-  }
-  return r;
-}
 
 struct RegInfo {
   std::atomic<bool> connected;
@@ -222,7 +35,7 @@ void cleanup(RegInfo& reg) {
   reg.readers.clear();
 }
 
-void evalGroupHostConnection(SessionGroup* sg, const std::string& groupName, const RunMode& m, int c, RegInfo& reg) {
+void evalGroupHostConnection(SessionGroup* sg, const std::string& sessionHash, const std::string& groupName, const RunMode& m, int c, RegInfo& reg) {
   try {
     uint8_t cmd=0;
     hobbes::fdread(c, reinterpret_cast<char*>(&cmd), sizeof(cmd));
@@ -235,21 +48,24 @@ void evalGroupHostConnection(SessionGroup* sg, const std::string& groupName, con
     out() << "queue registered for group '" << groupName << "' from " << pid << ":" << tid << ", cmd " << static_cast<int>(cmd) << std::endl;
   
     const hobbes::storage::ProcThread writerId {pid, tid};
-    auto qc = hobbes::storage::consumeGroup(groupName, writerId);
 
-    std::string d = instantiateDir(groupName, m.dir);
+    auto qc = hobbes::storage::consumeGroup(groupName, writerId);
+    auto d = instantiateDir(groupName, m.dir);
+
     switch (m.t) {
     case RunMode::local:
       reg.readers.emplace_back([=, &reg]() {
-        StatFile::instance().log(ReaderRegistration{hobbes::now(), writerId, hobbes::storage::thisProcThread(), qc.shmname});
+        StatFile::instance().log(ReaderRegistration{hobbes::now(), sessionHash, writerId, hobbes::storage::thisProcThread(), qc.shmname, groupName});
         recordLocalData(sg, qc, d, wp, reg.connected);
       });
       break;
     case RunMode::batchsend:
-      reg.readers.emplace_back([=, &reg]() {
-        StatFile::instance().log(ReaderRegistration{hobbes::now(), writerId, hobbes::storage::thisProcThread(), qc.shmname});
-        pushLocalData(qc, groupName, ensureDirExists(d), m.clevel, m.batchsendsize, m.batchsendtime, m.sendto, wp, reg.connected);
-      });
+      reg.readers.emplace_back(([=, &reg]() {
+        const hobbes::storage::ProcThread pt = hobbes::storage::thisProcThread();
+        StatFile::instance().log(ReaderRegistration{hobbes::now(), sessionHash, writerId, pt, qc.shmname, groupName});
+        const std::string procIdDir = d + "/tmp_" + hobbes::str::from(pt.first) + "-" + hobbes::str::from(pt.second) + "/";
+        pushLocalData(qc, sessionHash, groupName, ensureDirExists(d), ensureDirExists(procIdDir), pt, wp, m, reg.connected);
+      }));
       break;
     default:
       break;
@@ -262,12 +78,12 @@ void evalGroupHostConnection(SessionGroup* sg, const std::string& groupName, con
   }
 }
 
-void runGroupHost(const std::string& groupName, const RunMode& m, std::map<int, RegInfo>& reg) {
+void runGroupHost(const std::string& sessionHash, const std::string& groupName, const RunMode& m, std::map<int, RegInfo>& reg) {
   SessionGroup* sg = makeSessionGroup(m.consolidate, m.storageMode);
 
   hobbes::registerEventHandler(
     hobbes::storage::makeGroupHost(groupName, m.groupServerDir),
-    [sg,groupName,&m,&reg](int s) {
+    [sg,groupName,&sessionHash,&m,&reg](int s) {
       out() << "new connection for '" << groupName << "'" << std::endl;
 
       int c = accept(s, 0, 0);
@@ -281,8 +97,8 @@ void runGroupHost(const std::string& groupName, const RunMode& m, std::map<int, 
           } else {
             out() << "registering client connection for '" << groupName << "' from fd " << c << std::endl;
             reg[c].connected = true;
-            hobbes::registerEventHandler(c, [sg, groupName, &m, &reg](int c) {
-              evalGroupHostConnection(sg, groupName, m, c, reg[c]);
+            hobbes::registerEventHandler(c, [sg, groupName, &sessionHash, &m, &reg](int c) {
+              evalGroupHostConnection(sg, sessionHash, groupName, m, c, reg[c]);
             });
           }
         } catch (std::exception& ex) {
@@ -294,38 +110,54 @@ void runGroupHost(const std::string& groupName, const RunMode& m, std::map<int, 
   );
 }
 
-void run(const RunMode& m) {
+void run(const RunMode& m, const std::vector<std::string>& args) {
   out() << "hog running in mode : " << m << std::endl;
+  const auto sessionHash = createSessionHash(hobbes::now(), hobbes::storage::thisProcThread());
   if (m.t == RunMode::batchrecv) {
     StatFile::directory = "./";
-    StatFile::instance().log(ProcessEnvironment{hobbes::now(), hobbes::string::from(m)});
     out() << "hog stat file : " << StatFile::instance().filename() << std::endl;
+    hog::StatFile::instance().log(hog::ProcessEnvironment{hobbes::now(), sessionHash, hobbes::string::from(m), args, hog::SessionType::Enum::Normal});
     pullRemoteDataT(m.dir, m.localport, m.consolidate, m.storageMode).join();
   } else if (m.groups.size() > 0) {
-    StatFile::instance().log(ProcessEnvironment{hobbes::now(), hobbes::string::from(m)});
     out() << "hog stat file : " << StatFile::instance().filename() << std::endl;
+    hog::StatFile::instance().log(hog::ProcessEnvironment{hobbes::now(), sessionHash, hobbes::string::from(m), args, hog::SessionType::Enum::Normal});
     std::map<std::string, std::map<int, RegInfo>> registry;
-
-    signal(SIGPIPE, SIG_IGN);
 
     for (auto g : m.groups) {
       try {
         out() << "install a monitor for the '" << g << "' group" << std::endl;
-        runGroupHost(g, m, registry[g]);
+        runGroupHost(sessionHash, g, m, registry[g]);
       } catch (std::exception& ex) {
         out() << "error while installing a monitor for '" << g << "': " << ex.what() << std::endl;
         throw;
       }
     }
+
     hobbes::runEventLoop();
   }
 }
 
 }
 
+static std::vector<std::string> argvToStrings(const char** ts, const int count) {
+  std::vector<std::string> args;
+  for (int i = 0; i < count; ++i) {
+    args.emplace_back(std::string{ts[i]});
+  }
+  return args;
+}
+
 int main(int argc, const char** argv) {
+  signal(SIGPIPE, SIG_IGN);
   try {
-    hog::run(hog::config(argc, argv));
+    auto m = hog::config(argc, argv);
+    // Presumably we don't want to automatically recover and perform batchsend
+    // when someone is trying to run local/batchrecv on a machine
+    if (!m.skipRecovery && m.t == hog::RunMode::batchsend) {
+      hog::detectFaultAndRecover();
+    }
+    hog::run(m, argvToStrings(argv, argc));
+
     return 0;
   } catch (std::exception& ex) {
     std::cerr << ex.what() << std::endl;

--- a/bin/hog/main.C
+++ b/bin/hog/main.C
@@ -35,7 +35,7 @@ void cleanup(RegInfo& reg) {
   reg.readers.clear();
 }
 
-void evalGroupHostConnection(SessionGroup* sg, const std::string& sessionHash, const std::string& groupName, const RunMode& m, int c, RegInfo& reg) {
+void evalGroupHostConnection(SessionGroup* sg, const size_t sessionHash, const std::string& groupName, const RunMode& m, int c, RegInfo& reg) {
   try {
     uint8_t cmd=0;
     hobbes::fdread(c, reinterpret_cast<char*>(&cmd), sizeof(cmd));
@@ -78,7 +78,7 @@ void evalGroupHostConnection(SessionGroup* sg, const std::string& sessionHash, c
   }
 }
 
-void runGroupHost(const std::string& sessionHash, const std::string& groupName, const RunMode& m, std::map<int, RegInfo>& reg) {
+void runGroupHost(const size_t sessionHash, const std::string& groupName, const RunMode& m, std::map<int, RegInfo>& reg) {
   SessionGroup* sg = makeSessionGroup(m.consolidate, m.storageMode);
 
   hobbes::registerEventHandler(

--- a/bin/hog/recovery.C
+++ b/bin/hog/recovery.C
@@ -1,0 +1,318 @@
+#include <ostream>
+#include <thread>
+#include <vector>
+#include <utility>
+#include <string>
+#include <hobbes/storage.H>
+#include <hobbes/fregion.H>
+#include <hobbes/reflect.H>
+#include <hobbes/util/time.H>
+
+#include "batchsend.H"
+#include "config.H"
+#include "out.H"
+#include "recovery.H"
+#include "stat.H"
+
+namespace hog {
+
+DEFINE_STRUCT(SessionRecovered,
+  (hobbes::datetimeT, datetime),
+  (std::string, sessionHash),
+  (hobbes::storage::ProcThread, senderId),
+  (hobbes::storage::ProcThread, readerId),
+  (hobbes::datetimeT, originalSessionTime)
+);
+
+struct RecoveredDetails {
+  using ReaderSenderRegistration = std::pair<ReaderRegistration, SenderRegistration>;
+
+  template<typename T>
+  using StateMap = std::map<hobbes::storage::ProcThread, std::vector<T>>;
+  using SenderStateMap = StateMap<SenderState>;
+  using ReaderStateMap = StateMap<ReaderState>;
+
+  ProcessEnvironment processEnvironment;
+  std::vector<ReaderSenderRegistration> readerSenderRegs;
+  SenderStateMap senderStates;
+  ReaderStateMap readerStates;
+  std::vector<SessionRecovered> sessionsRecovered;
+};
+
+template<typename T>
+static std::vector<T> retrieveFromStats(hobbes::fregion::reader& r) {
+  std::vector<T> ts;
+
+  auto& data = r.series<T>(T::_hmeta_struct_type_name().c_str());
+  T t;
+  while (data.next(&t)) {
+    ts.emplace_back(std::move(t));
+  }
+
+  return ts;
+}
+
+template<typename T>
+static void addStateToStatesMap(const T& state, RecoveredDetails::StateMap<T>& statesMap) {
+  if (statesMap.find(state.id) != statesMap.end()) {
+    statesMap[state.id].push_back(state);
+  } else {
+    statesMap.insert(std::make_pair(state.id, std::vector<T>{ state }));
+  }
+}
+
+template <typename T>
+static std::vector<typename std::vector<T>::const_iterator> findRelatedData(const std::string& sessionHash, const std::vector<T>& ts) {
+  std::vector<typename std::vector<T>::const_iterator> foundIterators;
+  for (auto it = ts.cbegin(); it != ts.cend(); ++it) {
+    if (it->sessionHash == sessionHash) {
+      foundIterators.push_back(it);
+    }
+  }
+  return foundIterators;
+}
+
+static std::vector<RecoveredDetails> recoverSessionInformation() {
+  // algorithmic complexity of this pretty poor, but this should be a one-time
+  // startup cost, and thus reasonable.
+  std::vector<RecoveredDetails> allDetails;
+  auto reader = hobbes::fregion::reader(StatFile::instance().filename());
+
+  const std::vector<ProcessEnvironment> allProcessEnvironments = retrieveFromStats<ProcessEnvironment>(reader);
+  const std::vector<SenderRegistration> allSenderRegistrations = retrieveFromStats<SenderRegistration>(reader);
+  const std::vector<ReaderRegistration> allReaderRegistrations = retrieveFromStats<ReaderRegistration>(reader);
+  const std::vector<SenderState> allSenderStates = retrieveFromStats<SenderState>(reader);
+  const std::vector<ReaderState> allReaderStates = retrieveFromStats<ReaderState>(reader);
+  const std::vector<SessionRecovered> allSessionsRecovered = retrieveFromStats<SessionRecovered>(reader);
+  for (const ProcessEnvironment& processEnvironment : allProcessEnvironments) {
+    // we don't care about previous recovery sessions
+    if (SessionType::Enum::Recovery == processEnvironment.sessionType) {
+      continue;
+    }
+    RecoveredDetails details;
+    details.processEnvironment = processEnvironment;
+
+    const auto& sessionHash = processEnvironment.sessionHash;
+    const auto senderRegistrations = findRelatedData(sessionHash, allSenderRegistrations);
+    const auto readerRegistrations = findRelatedData(sessionHash, allReaderRegistrations);
+    const auto senderStates = findRelatedData(sessionHash, allSenderStates);
+    const auto readerStates = findRelatedData(sessionHash, allReaderStates);
+    const auto sessionsRecovered = findRelatedData(sessionHash, allSessionsRecovered);
+
+    for (const std::vector<SenderState>::const_iterator& ss : senderStates) {
+      addStateToStatesMap(*ss, details.senderStates);
+    }
+
+    for (const std::vector<ReaderState>::const_iterator& rs : readerStates) {
+      addStateToStatesMap(*rs, details.readerStates);
+    }
+
+    for (const std::vector<SenderRegistration>::const_iterator& sr : senderRegistrations) {
+      for (const std::vector<ReaderRegistration>::const_iterator& rr : readerRegistrations) {
+        if (sr->readerId == rr->readerId) {
+          // pair together reader and sender regs with matching reader ids
+          details.readerSenderRegs.push_back(std::make_pair(*rr, *sr));
+        }
+      }
+    }
+
+    for (const std::vector<SessionRecovered>::const_iterator& sr : sessionsRecovered) {
+      details.sessionsRecovered.push_back(*sr);
+    }
+    
+    allDetails.push_back(details);
+  }
+  
+  return allDetails;
+}
+
+static RunMode resumeConfig(const std::vector<std::string>& args) {
+  std::vector<const char*> converted;
+  converted.reserve(args.size());
+  for (const std::string& arg : args) {
+    converted.push_back(arg.c_str());
+  }
+  return config(converted.size(), converted.data());
+}
+
+static bool hasBeenRecovered(const std::vector<SessionRecovered>& sessionRecoveredLogs, const RecoveredDetails::ReaderSenderRegistration& readerSenderReg) {
+  for (const SessionRecovered& sessionRecoveredLog : sessionRecoveredLogs) {
+    if (sessionRecoveredLog.senderId == readerSenderReg.second.senderId && sessionRecoveredLog.readerId == readerSenderReg.second.readerId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool hasBeenCorrectlyClosed(const std::vector<SenderState>& senderStates) {
+  // Sender states should be temporally ordered earliest->latest
+  return senderStates.size() == 0 ? false : senderStates.back().status.value == SenderStatus::Enum::Closed;
+}
+
+struct RecoveryTask {
+  const hobbes::storage::ProcThread writerId;
+  const hobbes::storage::ProcThread readerId;
+  const hobbes::storage::ProcThread senderId;
+  const std::string shmName;
+  const std::string groupName;
+  const std::string processDateDirectory;
+  const std::vector<std::string> senderQueue;
+};
+
+struct RecoveryTaskGroup {
+  const hog::RunMode runMode;
+  const std::string sessionHash;
+  const std::vector<std::string> argv;
+  const hobbes::datetimeT startTime;
+  const std::vector<RecoveryTask> recoveryTasks;
+};
+
+static std::ostream& operator<<(std::ostream& os, const hobbes::storage::ProcThread& pt) {
+  os << "( "
+    << pt.first << ":" << pt.second
+    << " )";
+
+  return os;
+}
+
+static std::ostream& operator<<(std::ostream& os, const RecoveryTask& recoveryTask) {
+  os << "RecoveryTask { "
+    << "Writer Id: " << recoveryTask.writerId
+    << ", Reader Id: " << recoveryTask.readerId
+    << ", Sender Id: " << recoveryTask.senderId
+    << ", Group Name: " << recoveryTask.groupName
+    << ", SHM Name: " << recoveryTask.shmName
+    << ", Directory: " << recoveryTask.processDateDirectory
+    << ", Sender Queue: " << recoveryTask.senderQueue
+    << " }";
+
+  return os;
+}
+
+static std::ostream& operator<<(std::ostream& os, const RecoveryTaskGroup& recoveryTaskGroup) {
+  os << "RecoveryTaskGroup { "
+    << "Run Mode: " << recoveryTaskGroup.runMode
+    << ", Session Hash: " << recoveryTaskGroup.sessionHash
+    << ", Argv: " << recoveryTaskGroup.argv
+    << ", Start Time: " << hobbes::showDateTime(recoveryTaskGroup.startTime.value)
+    << ", Recovery Tasks: " << recoveryTaskGroup.recoveryTasks
+    << " }";
+
+  return os;
+}
+
+std::vector<RecoveryTask> getTasksRequiringRecovery(const RecoveredDetails& recoveredDetails) {
+  std::vector<RecoveryTask> tasks;
+
+  for (const RecoveredDetails::ReaderSenderRegistration& readerSenderReg : recoveredDetails.readerSenderRegs) {
+    const ReaderRegistration& readerReg = readerSenderReg.first;
+    const SenderRegistration& senderReg = readerSenderReg.second;
+
+    // is eligible for recovery
+    if (!hasBeenCorrectlyClosed(recoveredDetails.senderStates.find(senderReg.senderId)->second) && !hasBeenRecovered(recoveredDetails.sessionsRecovered, readerSenderReg)) {
+      tasks.emplace_back(RecoveryTask{
+        readerReg.writerId,
+        senderReg.readerId, 
+        senderReg.senderId, 
+        readerReg.shmname, 
+        readerReg.groupName, 
+        senderReg.directory,
+        senderReg.senderqueue}); 
+    }
+  }
+
+  return tasks;
+}
+
+static void restartReaderSender(const RecoveryTask& recoveryTask, const RunMode& runMode, const std::function<void()>& finalizeSender) {
+  std::atomic<bool> isConnected;
+  isConnected = false;
+
+  hobbes::storage::QueueConnection qc = hobbes::storage::consumeQueue(recoveryTask.shmName);
+
+  const auto sessionHash = createSessionHash(hobbes::now(), hobbes::storage::thisProcThread());
+  StatFile::instance().log(ReaderRegistration{hobbes::now(), sessionHash, recoveryTask.writerId, recoveryTask.readerId, qc.shmname, recoveryTask.groupName});
+
+  pushLocalData(qc, sessionHash, recoveryTask.groupName, recoveryTask.processDateDirectory, recoveryTask.processDateDirectory, recoveryTask.readerId, hobbes::storage::Platform, runMode, isConnected, finalizeSender);
+}
+
+static void performGroupRecovery(const std::vector<RecoveryTaskGroup>& recoveryTaskGroups) {
+  const auto currentSessionHash = createSessionHash(hobbes::now(), hobbes::storage::thisProcThread());
+  // Do all grouped tasks in parallel, but each group serially
+  for (const auto& recoveryTaskGroup : recoveryTaskGroups) {
+    out() << "Recovering " << recoveryTaskGroup << std::endl;
+    hog::StatFile::instance().log(hog::ProcessEnvironment{hobbes::now(), currentSessionHash, hobbes::string::from(recoveryTaskGroup.runMode), recoveryTaskGroup.argv, SessionType::Enum::Recovery});
+
+    std::vector<std::thread> groupThreads;
+    const auto waitForReaderCompletion = [&groupThreads]() {
+      // block until all readers are done for this group
+      for (auto& t : groupThreads) {
+        t.join();
+      }
+      groupThreads.clear();
+    };
+    for (const auto& recoveryTask : recoveryTaskGroup.recoveryTasks) {
+      // if the senders were originally dependent on the completion of other
+      // senders (dumb logic, can eventually be replaced with smart logic)
+      if (!recoveryTask.senderQueue.empty()) {
+        // block until outstanding readers in this group are done in order to
+        // ensure intrasession ordering
+        waitForReaderCompletion();
+      }
+      groupThreads.emplace_back([&recoveryTask, &recoveryTaskGroup] () {
+        const auto& startTime = recoveryTaskGroup.startTime;
+        const auto& recoveredSessionHash = recoveryTaskGroup.sessionHash;
+        const auto& runMode = recoveryTaskGroup.runMode;
+        // the copy-captures in the below lambda are important as sender outlives this scope
+        restartReaderSender(recoveryTask, runMode, [recoveryTask, startTime, recoveredSessionHash]() {
+          // log that this session was recovered so later recovery session don't repeat
+          StatFile::instance().log(SessionRecovered{hobbes::now(), recoveredSessionHash, recoveryTask.senderId, recoveryTask.readerId, startTime});
+        });
+      });
+    }
+
+    waitForReaderCompletion();
+  }
+}
+
+void detectFaultAndRecover() {
+  // Ensure that the statfile has the type information we assume is present
+  // (prevents a spurious exception being thrown in the reader later)
+  StatFile::instance().ensureAvailable<ProcessEnvironment>();
+  StatFile::instance().ensureAvailable<ReaderRegistration>();
+  StatFile::instance().ensureAvailable<SenderRegistration>();
+  StatFile::instance().ensureAvailable<ReaderState>();
+  StatFile::instance().ensureAvailable<SenderState>();
+  StatFile::instance().ensureAvailable<SessionRecovered>();
+
+  // in temporal order, recover run info and attempt to finish all
+  // readers/senders that were not properly completed
+  const std::vector<RecoveredDetails> allRecoveredDetails = recoverSessionInformation();
+
+  // group the recovery tasks into sets of independent tasks (reader/sender pair) in temporal order
+  std::vector<RecoveryTaskGroup> recoveryTaskGroups;
+  for (const RecoveredDetails& recoveredDetails : allRecoveredDetails) {
+    // reconfigure
+    RunMode runMode = resumeConfig(recoveredDetails.processEnvironment.argv);
+
+    // we only care about batchsend session info (for now)
+    if (runMode.t != RunMode::batchsend) {
+      continue;
+    }
+
+    const std::vector<RecoveryTask> tasks = getTasksRequiringRecovery(recoveredDetails);
+    // ignore groups with no associable tasks
+    if (tasks.size() > 0) {
+      recoveryTaskGroups.emplace_back(RecoveryTaskGroup{runMode,
+        recoveredDetails.processEnvironment.sessionHash,
+        recoveredDetails.processEnvironment.argv,
+        recoveredDetails.processEnvironment.startTime,
+        tasks});
+    }
+  }
+  
+  performGroupRecovery(recoveryTaskGroups);
+}
+
+}
+

--- a/bin/hog/recovery.C
+++ b/bin/hog/recovery.C
@@ -18,7 +18,7 @@ namespace hog {
 
 DEFINE_STRUCT(SessionRecovered,
   (hobbes::datetimeT, datetime),
-  (std::string, sessionHash),
+  (size_t, sessionHash),
   (hobbes::storage::ProcThread, senderId),
   (hobbes::storage::ProcThread, readerId),
   (hobbes::datetimeT, originalSessionTime)
@@ -62,7 +62,7 @@ static void addStateToStatesMap(const T& state, RecoveredDetails::StateMap<T>& s
 }
 
 template <typename T>
-static std::vector<typename std::vector<T>::const_iterator> findRelatedData(const std::string& sessionHash, const std::vector<T>& ts) {
+static std::vector<typename std::vector<T>::const_iterator> findRelatedData(const size_t sessionHash, const std::vector<T>& ts) {
   std::vector<typename std::vector<T>::const_iterator> foundIterators;
   for (auto it = ts.cbegin(); it != ts.cend(); ++it) {
     if (it->sessionHash == sessionHash) {
@@ -161,7 +161,7 @@ struct RecoveryTask {
 
 struct RecoveryTaskGroup {
   const hog::RunMode runMode;
-  const std::string sessionHash;
+  const size_t sessionHash;
   const std::vector<std::string> argv;
   const hobbes::datetimeT startTime;
   const std::vector<RecoveryTask> recoveryTasks;

--- a/bin/hog/recovery.H
+++ b/bin/hog/recovery.H
@@ -1,0 +1,16 @@
+/*
+ * recovery.H : provides utilities to recover information from the hogstat log,
+ * detect potential faults, and to attempt to complete/recover operations
+ */
+
+#ifndef HOG_RECOVERY_H_INCLUDED
+#define HOG_RECOVERY_H_INCLUDED
+
+namespace hog {
+
+void detectFaultAndRecover();
+
+}
+
+#endif
+

--- a/bin/hog/stat.C
+++ b/bin/hog/stat.C
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <hobbes/util/hash.H>
+
 namespace hog {
 
 std::string StatFile::directory = hobbes::storage::defaultStoreDir();
@@ -12,6 +14,14 @@ StatFile& StatFile::instance() {
 }
 
 StatFile::StatFile() : statFile(StatFile::directory + "/hogstat.db") {}
+
+std::string createSessionHash(const hobbes::datetimeT& timestamp, const hobbes::storage::ProcThread& pt) {
+  const hobbes::genHash<std::string> hasher;
+  size_t hashed = hasher(hobbes::showDateTime(timestamp.value));
+  hobbes::hashAppend(hashed, pt.first);
+  hobbes::hashAppend(hashed, pt.second);
+  return std::to_string(hashed);
+}
 
 }
 

--- a/bin/hog/stat.C
+++ b/bin/hog/stat.C
@@ -15,12 +15,12 @@ StatFile& StatFile::instance() {
 
 StatFile::StatFile() : statFile(StatFile::directory + "/hogstat.db") {}
 
-std::string createSessionHash(const hobbes::datetimeT& timestamp, const hobbes::storage::ProcThread& pt) {
-  const hobbes::genHash<std::string> hasher;
-  size_t hashed = hasher(hobbes::showDateTime(timestamp.value));
+size_t createSessionHash(const hobbes::datetimeT& timestamp, const hobbes::storage::ProcThread& pt) {
+  const hobbes::genHash<decltype(timestamp.value)> hasher;
+  size_t hashed = hasher(timestamp.value);
   hobbes::hashAppend(hashed, pt.first);
   hobbes::hashAppend(hashed, pt.second);
-  return std::to_string(hashed);
+  return hashed;
 }
 
 }

--- a/bin/hog/stat.H
+++ b/bin/hog/stat.H
@@ -11,7 +11,6 @@
 #include <hobbes/storage.H>
 #include <hobbes/fregion.H>
 #include <hobbes/util/time.H>
-#include <hobbes/util/hash.H>
 
 namespace hog {
 
@@ -22,7 +21,7 @@ DEFINE_ENUM(SessionType,
 
 DEFINE_STRUCT(ProcessEnvironment,
   (hobbes::datetimeT,           startTime),
-  (std::string,                 sessionHash),
+  (size_t,                      sessionHash),
   (std::string,                 runMode),
   (std::vector<std::string>,    argv),
   (SessionType,                 sessionType)
@@ -35,14 +34,14 @@ DEFINE_ENUM(ReaderStatus,
 
 DEFINE_STRUCT(ReaderState,
   (hobbes::datetimeT,           datetime),
-  (std::string,                 sessionHash),
+  (size_t,                      sessionHash),
   (hobbes::storage::ProcThread, id),
   (ReaderStatus,                status)
 );
 
 DEFINE_STRUCT(ReaderRegistration,
   (hobbes::datetimeT,           datetime),
-  (std::string,                 sessionHash),
+  (size_t,                      sessionHash),
   (hobbes::storage::ProcThread, writerId),
   (hobbes::storage::ProcThread, readerId),
   (std::string,                 shmname),
@@ -57,14 +56,14 @@ DEFINE_ENUM(SenderStatus,
 
 DEFINE_STRUCT(SenderState,
   (hobbes::datetimeT,           datetime),
-  (std::string,                 sessionHash),
+  (size_t,                      sessionHash),
   (hobbes::storage::ProcThread, id),
   (SenderStatus,                status)
 );
 
 DEFINE_STRUCT(SenderRegistration,
   (hobbes::datetimeT,           datetime),
-  (std::string,                 sessionHash),
+  (size_t,                      sessionHash),
   (hobbes::storage::ProcThread, readerId),
   (hobbes::storage::ProcThread, senderId),
   (std::string,                 directory),
@@ -102,7 +101,7 @@ private:
   std::mutex mutex;
 };
 
-std::string createSessionHash(const hobbes::datetimeT& timestamp, const hobbes::storage::ProcThread& pt);
+size_t createSessionHash(const hobbes::datetimeT& timestamp, const hobbes::storage::ProcThread& pt);
 
 }
 

--- a/bin/hog/stat.H
+++ b/bin/hog/stat.H
@@ -2,17 +2,30 @@
 #define HOG_STAT_H_INCLUDED
 
 #include <mutex>
+#include <vector>
+#include <functional>
+#include <string>
 
 #include <hobbes/hobbes.H>
 #include <hobbes/reflect.H>
 #include <hobbes/storage.H>
 #include <hobbes/fregion.H>
+#include <hobbes/util/time.H>
+#include <hobbes/util/hash.H>
 
 namespace hog {
 
+DEFINE_ENUM(SessionType,
+  (Normal),
+  (Recovery)
+);
+
 DEFINE_STRUCT(ProcessEnvironment,
-  (hobbes::datetimeT, startTime),
-  (std::string,       runMode)
+  (hobbes::datetimeT,           startTime),
+  (std::string,                 sessionHash),
+  (std::string,                 runMode),
+  (std::vector<std::string>,    argv),
+  (SessionType,                 sessionType)
 );
 
 DEFINE_ENUM(ReaderStatus,
@@ -22,15 +35,18 @@ DEFINE_ENUM(ReaderStatus,
 
 DEFINE_STRUCT(ReaderState,
   (hobbes::datetimeT,           datetime),
-  (hobbes::storage::ProcThread, readerId),
+  (std::string,                 sessionHash),
+  (hobbes::storage::ProcThread, id),
   (ReaderStatus,                status)
 );
 
 DEFINE_STRUCT(ReaderRegistration,
   (hobbes::datetimeT,           datetime),
+  (std::string,                 sessionHash),
   (hobbes::storage::ProcThread, writerId),
   (hobbes::storage::ProcThread, readerId),
-  (std::string,                 shmname)
+  (std::string,                 shmname),
+  (std::string,                 groupName)
 );
 
 DEFINE_ENUM(SenderStatus,
@@ -41,12 +57,14 @@ DEFINE_ENUM(SenderStatus,
 
 DEFINE_STRUCT(SenderState,
   (hobbes::datetimeT,           datetime),
+  (std::string,                 sessionHash),
   (hobbes::storage::ProcThread, id),
   (SenderStatus,                status)
 );
 
 DEFINE_STRUCT(SenderRegistration,
   (hobbes::datetimeT,           datetime),
+  (std::string,                 sessionHash),
   (hobbes::storage::ProcThread, readerId),
   (hobbes::storage::ProcThread, senderId),
   (std::string,                 directory),
@@ -61,6 +79,11 @@ public:
   void log(T&& value) {
     std::lock_guard<decltype(mutex)> _{mutex};
     statFile.series<T>(T::_hmeta_struct_type_name())(std::forward<T>(value));
+  }
+
+  template <typename T>
+  void ensureAvailable() {
+    (void)(statFile.series<T>(T::_hmeta_struct_type_name()));
   }
 
   const std::string& filename() const {
@@ -78,6 +101,8 @@ private:
   hobbes::fregion::writer statFile;
   std::mutex mutex;
 };
+
+std::string createSessionHash(const hobbes::datetimeT& timestamp, const hobbes::storage::ProcThread& pt);
 
 }
 

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -912,6 +912,11 @@ public:
       } else {
         // there's nothing to read, switch into reader-wait mode
         switch (xchg(waitState(), PRIV_HSTORE_STATE_READER_WAITING)) {
+          case PRIV_HSTORE_STATE_READER_WAITING:
+          // for some reason (e.g. resuming on a shm block which was being operated
+          // upon by an writer/reader instance that unnaturally terminated)
+          // this reader is in this state but not waiting as in the UNBLOCKED
+          // case. Just do UNBLOCKED case to resolve the potential infinite loop.
           case PRIV_HSTORE_STATE_UNBLOCKED:
             // we previously were unblocked
             // make sure that we still need to block the reader (in case the write index moved while we were getting here)


### PR DESCRIPTION
Add capabilities for automatically detecting unfinished batchsend sessions and recover them via logging to the `StatFile`. Turned off via --no-recovery, but on by default when the user runs a Hog session in batchsend mode. Recovery will not occur if run in any other mode (at the moment - potentially simple to implement). 

The recovery process may delay how long it takes for the Hog application to start accepting connections from logging processes, and increase the active thread count for every reader/sender needed to be recovered. As this is a sort of breaking functional behavior change, it is recommended to run Hog with --no-recovery unless this behavior is specifically needed (for instance when Hog processes are spawned for automated tests etc.). 

Additionally, the information stored in the `StatFile` has been enriched, potentially allowing for more tooling around querying Hog status and statistics.