### PR TITLE
use fallocate to extend map files rather than ftruncate

### DIFF
--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -213,11 +213,16 @@ inline off_t filePosition(const imagefile* f) {
 }
 
 inline void allocPages(imagefile* f, size_t pages) {
-  size_t nsz = f->file_size + pages * f->page_size;
-  if (::ftruncate(f->fd, nsz) == -1) {
-    raiseSysError("Can't resize file", f->path);
+  off_t dsz = pages * f->page_size;
+  int r = ::posix_fallocate(f->fd, f->file_size, dsz);
+  if (r != 0) {
+    if (r == ENOSPC) {
+      raiseSysError("Can't resize file, no space available", f->path);
+    } else {
+      raiseSysError("Can't resize file", f->path);
+    }
   }
-  f->file_size = nsz;
+  f->file_size += dsz;
 }
 
 inline void allocPage(imagefile* f) {

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -24,6 +24,25 @@
 #include <type_traits>
 #include <cxxabi.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+#include <fcntl.h>
+#include <unistd.h>
+
+// macOS doesn't support fallocate, simulate it
+inline int posix_fallocate(int fd, off_t o, off_t dsz) {
+  fstore_t store = {F_ALLOCATECONTIG, F_PEOFPOSMODE, 0, o+dsz, 0};
+  int r = ::fcntl(fd, F_PREALLOCATE, &store);
+  if (r == -1) {
+    store.fst_flags = F_ALLOCATEALL;
+    r = fcntl(fd, F_PREALLOCATE, &store);
+  }
+  if (r != -1) {
+    r = ftruncate(fd, o+dsz);
+  }
+  return (r!=-1) ? 0 : -1;
+}
+#endif
+
 namespace hobbes {
 
 // basic string utilities used here

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -48,7 +48,6 @@ namespace hobbes { namespace storage { namespace internal {
 //  * available waiting strategy in shared memory
 //  * default waiting strategy
 #if defined(__APPLE__) && defined(__MACH__)
-
 // macOS doesn't support this flag to mmap so we can just 0 it out
 #ifndef MAP_POPULATE
 #define MAP_POPULATE 0

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -2155,8 +2155,14 @@ private:
   size_t   ri;
 
   void truncMapFile(size_t sz) {
-    if (::ftruncate(this->fd, sz) == -1) {
-      throw std::runtime_error("Failed to expand transaction persistence file");
+    off_t dsz = sz - this->file_size;
+    int r = ::posix_fallocate(this->fd, this->file_size, dsz);
+    if (r != 0) {
+      if (r == ENOSPC) {
+        throw std::runtime_error("Failed to expand transaction persistence file (no space available)");
+      } else {
+        throw std::runtime_error("Failed to expand transaction persistence file");
+      }
     }
     this->file_size = sz;
 


### PR DESCRIPTION
This will allow us to identify disk exhaustion earlier than is currently done (due to ftruncate creating sparse files which are not actually allocated until later).