### PR TITLE
support compressed storage for opaque alias types via the C++ API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ CMakeFiles/
 /doc/en/_build/
 /doc/building.txt
 .vscode/
+.gitmessage

--- a/include/hobbes/cfregion.H
+++ b/include/hobbes/cfregion.H
@@ -697,6 +697,7 @@ template <> struct compress<long>     : public compressByteSeq<long>     { };
 template <> struct compress<__int128> : public compressByteSeq<__int128> { };
 
 #if defined(__APPLE__) && defined(__MACH__)
+template <> struct compress<int64_t>  : public compressByteSeq<int64_t>  { };
 template <> struct compress<size_t> : public compressByteSeq<size_t> { };
 #endif
 
@@ -936,6 +937,17 @@ template <typename T>
     static void init(const PModel& pm, CModel* cm)                            { compress<VT>::init(pm, cm); }
     static void write(cwbitstream* bits,  PModel* pm, CModel* cm, const T& t) { compress<VT>::write(bits, pm, cm, *reinterpret_cast<const VT*>(&t)); }
     static void read (crbitstream* rbits, PModel* pm, CModel* cm, T* t)       { compress<VT>::read(rbits, pm, cm,  reinterpret_cast<VT*>(t)); }
+  };
+
+template <typename T>
+  struct compress<T, typename tbool<T::is_hmeta_alias>::type> {
+    typedef typename T::type RT;
+    typedef typename compress<RT>::PModel PModel;
+    typedef typename compress<RT>::CModel CModel;
+
+    static void init(const PModel& pm, CModel* cm)                            { compress<RT>::init(pm, cm); }
+    static void write(cwbitstream* bits,  PModel* pm, CModel* cm, const T& t) { compress<RT>::write(bits, pm, cm, *reinterpret_cast<const RT*>(&t)); }
+    static void read (crbitstream* rbits, PModel* pm, CModel* cm, T* t)       { compress<RT>::read(rbits, pm, cm,  reinterpret_cast<RT*>(t)); }
   };
 
 /*******************************************************
@@ -1297,4 +1309,3 @@ private:
 }}
 
 #endif
-

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -762,6 +762,45 @@ TEST(Storage, CFRegion_H2C) {
   }
 }
 
+DEFINE_STRUCT(
+  CFTypeTest,
+  (datetimeT, t)
+);
+
+TEST(Storage, CFRegion_CTypes) {
+  std::string fname = mkFName();
+  try {
+    auto t = hobbes::now();
+
+    // write some compressed data
+    {
+      hobbes::fregion::cwriter w(fname);
+      auto& xs = w.series<CFTypeTest>("cts");
+      for (size_t i = 0; i < 100; ++i) {
+        CFTypeTest s;
+        s.t = t;
+        xs(s);
+      }
+    }
+
+    // verify that it reads back correctly
+    {
+      hobbes::fregion::creader r(fname);
+      auto& xs = r.series<CFTypeTest>("cts");
+      CFTypeTest s;
+      while (xs.next(&s)) {
+        EXPECT_TRUE(s.t.value == t.value);
+      }
+    }
+
+    unlink(fname.c_str());
+  } catch (...) {
+    unlink(fname.c_str());
+    throw;
+  }
+}
+
+
 TEST(Storage, FRegionCArrays) {
   std::string fname = mkFName();
   try {


### PR DESCRIPTION
(The hobbes API already supports this same method of storing compressed opaque alias types.)