### PR TITLE
search for equivalent DFA states faster in compile-time

### DIFF
--- a/include/hobbes/util/rmap.H
+++ b/include/hobbes/util/rmap.H
@@ -239,6 +239,8 @@ template <typename K, typename V, typename Ord>
       }
     }
 
+    size_t rangeSize() const { return this->rs.size(); }
+
     typedef std::vector<std::pair<range, V>> Mapping;
     Mapping mapping() const {
       Mapping r;


### PR DESCRIPTION
This change resolves the issue #280, which uses a disjoint set to store
the equivalence DFA states found in the search and to reduce the total
number of iterations in compiling regex eventually.  Instead of looping
over all the combinations in DFA states in each run, the search space
shall shrink because the number of equivalence classes in the set are
getting smaller.

As a minor performance improvement, the range mapping is created only
when necessary in the search algorithm.