### PR TITLE
accelerate equivalent DFA states using simpler graph algorithm

### DIFF
--- a/include/hobbes/util/rmap.H
+++ b/include/hobbes/util/rmap.H
@@ -239,8 +239,6 @@ template <typename K, typename V, typename Ord>
       }
     }
 
-    size_t rangeSize() const { return this->rs.size(); }
-
     typedef std::vector<std::pair<range, V>> Mapping;
     Mapping mapping() const {
       Mapping r;


### PR DESCRIPTION
As a follow-up on issue #280, this change further improve the search for
equivalent DFA states with simpler graph traverse algorithm, given the
fact that finding equivalence classes in a graph is identical to looking
for connected components.