### PR TITLE
build hobbes with llvm6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,6 @@ matrix:
         - DEPS="${DEPS} readline llvm@4"
         - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
         - ARGS=-V
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode8
-#      env:
-#        - DEPS="${DEPS} llvm@4"
-#        - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
-#        - ARGS=-V
     - os: linux
       compiler: g++
       root: required
@@ -27,6 +20,7 @@ matrix:
         - docker
       env:
         - DIST=xenial
+        - DEPS="llvm-3.7-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
         - ARGS=-V
     - os: linux
       compiler: g++
@@ -36,12 +30,13 @@ matrix:
       services:
         - docker
       env:
-        - DIST=xllvm4
+        - DIST=xenial
+        - DEPS="llvm-4.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
         - ARGS=-V
 
 install:
   - if [ $TRAVIS_OS_NAME = osx   ]; then brew update && brew install -v ${DEPS} && find /usr/local/opt/llvm@4/ | grep cmake; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then cd docker/build &&  docker build . -f ./${DIST}.Dockerfile -t hobbes:build; cd -; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then cd docker/build &&  docker build . -f ./${DIST}.Dockerfile -t hobbes:build --build-arg DEPS; cd -; fi
 
 script:
   - if [ $TRAVIS_OS_NAME = osx   ]; then mkdir build && cd build/ && cmake .. && make && make test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,21 @@ matrix:
         - DIST=xenial
         - DEPS="llvm-4.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
         - ARGS=-V
+    - os: linux
+      compiler: g++
+      root: required
+      dist: trusty
+      group: deprecated-2017Q4
+      services:
+        - docker
+      env:
+        - DIST=xenial
+        - DEPS="llvm-6.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+        - ARGS=-V
 
 install:
   - if [ $TRAVIS_OS_NAME = osx   ]; then brew update && brew install -v ${DEPS} && find /usr/local/opt/llvm@4/ | grep cmake; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then cd docker/build &&  docker build . -f ./${DIST}.Dockerfile -t hobbes:build --build-arg DEPS; cd -; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then cd docker/build && docker build . -f ./${DIST}.Dockerfile -t hobbes:build --build-arg DEPS; cd -; fi
 
 script:
   - if [ $TRAVIS_OS_NAME = osx   ]; then mkdir build && cd build/ && cmake .. && make && make test; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,20 +14,38 @@ if (${LLVM_PACKAGE_VERSION} VERSION_LESS "3.6")
 else()
   set(jit_lib mcjit)
 endif()
-# 'x86' module should have covered 'x86asmparser' and 'x86codegen' already, but using 'x86' alone didn't work
-llvm_map_components_to_libnames(llvm_libs x86asmparser x86codegen x86 ipo ${jit_lib})
+
+find_program(llvm-config llvm-config PATHS ${LLVM_TOOLS_BINARY_DIR})
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS "4.0")
+  execute_process(COMMAND ${llvm-config} --libs x86 ipo ${jit_lib}
+                  OUTPUT_VARIABLE llvm_libs
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${llvm-config} --ldflags
+                  OUTPUT_VARIABLE llvm_ldflags
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${llvm-config} --system-libs
+                  OUTPUT_VARIABLE sys_libs
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  execute_process(COMMAND ${llvm-config} --libs x86 ipo ${jit_lib} --link-static
+                  OUTPUT_VARIABLE llvm_libs
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${llvm-config} --ldflags
+                  OUTPUT_VARIABLE llvm_ldflags
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${llvm-config} --system-libs --ignore-libllvm
+                  OUTPUT_VARIABLE sys_libs
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+message(STATUS "llvm libs: ${llvm_libs}")
+message(STATUS "llvm ldflags: ${llvm_ldflags}")
+message(STATUS "llvm syslibs: ${sys_libs}")
 
 file(GLOB_RECURSE lib_headers lib/*.H)
 file(GLOB_RECURSE lib_source lib/*.C)
 set(lib_files ${lib_headers} ${lib_source})
 include_directories(include)
-
-add_library(hobbes STATIC ${lib_files})
-llvm_config(hobbes x86)
-target_link_libraries(hobbes ${llvm_libs} ${ZLIB_LIBRARIES})
-add_library(hobbes-pic STATIC ${lib_files})
-target_link_libraries(hobbes-pic ${llvm_libs} ${ZLIB_LIBRARIES})
-set_property(TARGET hobbes-pic PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
 file(GLOB test_files test/*.C)
 file(GLOB hi_files bin/hi/*.C)
@@ -38,13 +56,13 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(APPLE)
-  set(sys_libs pthread dl)
+  set(sys_libs ${sys_libs} pthread dl)
   set(cxx_flags "-Wreorder")
   include_directories(/usr/local/opt/readline/include)
   link_directories(/usr/local/opt/readline/lib)
 endif()
 if(LINUX)
-  set(sys_libs pthread dl rt)
+  set(sys_libs ${sys_libs} pthread dl rt)
   set(cxx_flags "-Werror=old-style-cast -Werror -Wall -Wextra -Winit-self -Wreturn-type -Wunused-variable -Wsign-compare -Warray-bounds -Wunknown-pragmas -Wuninitialized -Wstrict-aliasing -Wunused-value -Wunused-label -Wswitch -Wcast-align -Wctor-dtor-privacy -Wmissing-noreturn -Wunused-parameter -Wreorder")
 endif()
 
@@ -52,17 +70,20 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${cxx_flags}")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
+add_library(hobbes STATIC ${lib_files})
+target_link_libraries(hobbes PUBLIC ${llvm_ldflags} ${llvm_libs} ${ZLIB_LIBRARIES} ncurses ${sys_libs})
+add_library(hobbes-pic STATIC ${lib_files})
+target_link_libraries(hobbes-pic PUBLIC ${llvm_ldflags} ${llvm_libs} ${ZLIB_LIBRARIES} ncurses ${sys_libs})
+set_property(TARGET hobbes-pic PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
 add_executable(hi ${hi_files})
-llvm_config(hi codegen core executionengine instcombine ipo lto mc mcdisassembler mcjit passes runtimedyld scalaropts support target transformutils x86 x86asmparser x86asmprinter x86codegen x86desc x86disassembler x86info x86utils)
-target_link_libraries(hi hobbes ncurses readline ${sys_libs})
+target_link_libraries(hi PRIVATE hobbes readline)
 add_executable(hog ${hog_files})
-llvm_config(hog codegen core executionengine instcombine ipo lto mc mcdisassembler mcjit passes runtimedyld scalaropts support target transformutils x86 x86asmparser x86asmprinter x86codegen x86desc x86disassembler x86info x86utils)
-target_link_libraries(hog hobbes ncurses ${sys_libs})
+target_link_libraries(hog PRIVATE hobbes)
 
 enable_testing()
 add_executable(hobbes-test ${test_files})
-llvm_config(hobbes-test codegen core executionengine instcombine ipo lto mc mcdisassembler mcjit passes runtimedyld scalaropts support target transformutils x86 x86asmparser x86asmprinter x86codegen x86desc x86disassembler x86info x86utils)
-target_link_libraries(hobbes-test hobbes ncurses ${sys_libs})
+target_link_libraries(hobbes-test PRIVATE hobbes)
 add_test(hobbes-test hobbes-test)
 include(FindPythonInterp)
 set_property(TARGET hobbes-test PROPERTY COMPILE_FLAGS "-DPYTHON_EXECUTABLE=\"${PYTHON_EXECUTABLE}\" -DSCRIPT_DIR=\"${CMAKE_SOURCE_DIR}/scripts/\"")

--- a/docker/build/xenial.Dockerfile
+++ b/docker/build/xenial.Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:xenial
+ARG  DEPS
 ENV  ARGS -V
 RUN  apt update
-RUN  apt install -y cmake libedit-dev g++ llvm-3.7-dev libncurses5-dev zlib1g-dev libreadline-dev python2.7
-CMD  mkdir -p /build && cd /build && cmake /src && make -j2 && make test
+RUN  apt install -y ${DEPS}
+CMD  mkdir -p /build && cd /build && cmake /src && VERBOSE=1 make -j2 && make test

--- a/docker/build/xllvm4.Dockerfile
+++ b/docker/build/xllvm4.Dockerfile
@@ -1,5 +1,0 @@
-FROM ubuntu:xenial
-ENV  ARGS -V
-RUN  apt update
-RUN  apt install -y cmake libedit-dev g++ llvm-4.0-dev libncurses5-dev zlib1g-dev libreadline-dev python2.7
-CMD  mkdir -p /build && cd /build && cmake /src && make -j2 && make test

--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -126,7 +126,7 @@ private:
   typedef std::vector<llvm::Module*> Modules;
   Modules modules;
 
-#if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
   llvm::legacy::PassManager* mpm;
 
   // the set of allocated execution engines (each will own a finalized module from the set of modules)

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -11,7 +11,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if LLVM_VERSION_MAJOR != 3 && LLVM_VERSION_MAJOR != 4
+#if LLVM_VERSION_MAJOR != 3 && LLVM_VERSION_MAJOR != 4 && LLVM_VERSION_MAJOR != 6 && LLVM_VERSION_MAJOR != 8
 #error "I don't know how to use this version of LLVM"
 #endif
 
@@ -29,7 +29,7 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/Signals.h>
-#if LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
 #include <llvm/Bitcode/BitstreamReader.h>
 #include <llvm/Bitcode/BitstreamWriter.h>
 #else
@@ -43,7 +43,7 @@
 #if LLVM_VERSION_MINOR == 3
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/PassManager.h>
-#elif LLVM_VERSION_MINOR >= 5 || LLVM_VERSION_MAJOR == 4
+#elif LLVM_VERSION_MINOR >= 5 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
 #include <llvm/IR/Verifier.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/LegacyPassManager.h>
@@ -318,10 +318,10 @@ inline Constants liftAsGlobalRefs(llvm::Module* m, const Constants& cs) {
 inline llvm::Constant* constArray(llvm::Module* m, const Constants& cs, llvm::Type* elemTy, bool boxAsGlobalRefs = false) {
   llvm::ArrayType*  aty  = arrayType(elemTy, cs.size());
   llvm::StructType* saty = varArrayType(elemTy, cs.size());
-  
+
   long      arrayLen = cs.size();
   Constants ncs      = elemTy->isVoidTy() ? Constants() : cs;
-  
+
   if (boxAsGlobalRefs) {
     ncs = liftAsGlobalRefs(m, ncs);
   }
@@ -471,14 +471,14 @@ inline llvm::Value* structOffset(llvm::IRBuilder<>* b, llvm::Value* p, unsigned 
 #if LLVM_VERSION_MINOR == 7
   // don't pass nullptr? (http://reviews.llvm.org/rL233938)
   return b->CreateStructGEP(nullptr, p, fieldOffset);
-#elif LLVM_VERSION_MINOR >= 8 || LLVM_VERSION_MAJOR == 4
+#elif LLVM_VERSION_MINOR >= 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
   return b->CreateStructGEP(reinterpret_cast<llvm::PointerType*>(p->getType())->getElementType(), p, fieldOffset);
 #else
   return b->CreateStructGEP(p, fieldOffset);
 #endif
 }
 
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
 inline llvm::ExecutionEngine* makeExecutionEngine(llvm::Module* m, llvm::SectionMemoryManager* smm) {
   std::string err;
   llvm::ExecutionEngine* ee =
@@ -547,7 +547,7 @@ inline llvm::Function* cloneFunction(llvm::Function *f, llvm::Module *targetMod)
 }
 
 inline llvm::Value* fncall(llvm::IRBuilder<>* b, llvm::Value* vfn, const Values& args) {
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
   llvm::Module* thisMod = b->GetInsertBlock()->getParent()->getParent();
 
   llvm::Function* fn = llvm::dyn_cast<llvm::Function>(vfn);


### PR DESCRIPTION
This change enables llvm6 with minimal changes in the code base.  The cmake build configurations now relies on the `llvm-config` output and the `llvm-config` executable is inferred from `LLVM_DIR` environment variable specified by the user.