### PR TITLE
Add frontend support for xpedite profiling probes

### DIFF
--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -16,6 +16,8 @@
 
 namespace hobbes {
 
+struct InjectedProbeMetadata;
+
 // an operation, which can emit some specialized assembly code
 class jitcc;
 struct op {
@@ -111,6 +113,14 @@ public:
 
   // allocate some global data attached to this JIT
   void* memalloc(size_t, size_t);
+
+  // register a performance probe's metadata with the compiler
+  void addProbeMapping(const InjectedProbeMetadata&);
+  // register an emitted stackmap with the compiler
+  void updateStackMapLocations(const unsigned char* stackMapBytes, const size_t size);
+  // adjust the locations of all registered probes via all registered stackmaps
+  void updateProbeLocations();
+
 private:
   TEnvPtr tenv;
 
@@ -216,6 +226,13 @@ private:
   // (in case we want to inline them later)
   typedef std::map<std::string, ExprPtr> GlobalExprs;
   GlobalExprs globalExprs;
+
+  // keep track of compiled probe information for later usage
+  typedef std::vector<InjectedProbeMetadata> Probes;
+  Probes probes;
+
+  typedef std::map<const unsigned char*, const size_t> StackMaps;
+  StackMaps stackMaps;
 };
 
 // shorthand for compilation over a sequence of expressions

--- a/include/hobbes/eval/probes.H
+++ b/include/hobbes/eval/probes.H
@@ -1,0 +1,29 @@
+
+#ifndef HOBBES_EVAL_PROBES_HPP_INCLUDED
+#define HOBBES_EVAL_PROBES_HPP_INCLUDED
+
+#include <cstdint>
+#include <string>
+
+namespace hobbes {
+
+class cc;
+
+void initProbeDefs(cc&);
+
+struct InjectedProbeMetadata {
+  size_t id;
+  std::string name;
+  std::string file;
+  size_t line;
+  std::string function;
+  void* callSite;
+  void* returnSite;
+
+  static constexpr uint64_t typeTag = static_cast<uint64_t>(0x01) << 56;
+  static constexpr size_t caveSize = 5;
+};
+
+}
+
+#endif

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -21,6 +21,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/InlineAsm.h>
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Vectorize.h>
@@ -568,6 +570,210 @@ inline llvm::Value* fncall(llvm::IRBuilder<>* b, llvm::Value* vfn, const Values&
 inline llvm::Value* fncall(llvm::IRBuilder<>* b, llvm::Value* fn, llvm::Value* arg) {
   return fncall(b, fn, list(arg));
 }
+
+
+// LLVM version [5, 9) don't support parsing the version of stackmaps emitted
+// by that same version. Implement just enough parsing to read stackmaps
+template <llvm::support::endianness Endianness = llvm::support::native>
+class StackMapV3Parser {
+  class Function {
+  public:
+    Function(const uint8_t* const data) : data(data) {}
+    ~Function() = default;
+    Function(const Function&) = default;
+    Function(Function&&) = default;
+    Function& operator=(const Function&) = default;
+    Function& operator=(Function&&) = default;
+
+    uint64_t address() const {
+      return read<uint64_t>(data + addressOffset);
+    }
+
+    uint64_t stackSize() const {
+      return read<uint64_t>(data + stackSizeOffset);
+    }
+
+    uint64_t recordCount() const {
+      return read<uint64_t>(data + recordCountOffset);
+    }
+
+    size_t byteSize() const {
+      return sizeof(uint64_t) * 3;
+    }
+
+    const uint8_t* getBase() const {
+      return data;
+    }
+
+    const uint8_t* next() const {
+      return data + byteSize();
+    }
+
+  private:
+    static constexpr size_t addressOffset = 0;
+    static constexpr size_t stackSizeOffset = addressOffset + sizeof(uint64_t);
+    static constexpr size_t recordCountOffset = stackSizeOffset + sizeof(uint64_t);
+
+    const uint8_t* const data;
+  };
+
+  class Constant {
+  public:
+    Constant(const uint8_t* const data) : data(data) {}
+    ~Constant() = default;
+    Constant(const Constant&) = default;
+    Constant(Constant&&) = default;
+    Constant& operator=(const Constant&) = default;
+    Constant& operator=(Constant&&) = default;
+
+    uint64_t largeConstant() const {
+      return read<uint64_t>(data + largeConstantOffset);
+    }
+
+    size_t byteSize() const {
+      return sizeof(uint64_t);
+    }
+
+    const uint8_t* getBase() const {
+      return data;
+    }
+
+    const uint8_t* next() const {
+      return data + byteSize();
+    }
+
+  private:
+    static constexpr size_t largeConstantOffset = 0;
+
+    const uint8_t* const data;
+  };
+
+  class Record {
+  public:
+    Record(const uint8_t* const data) : data(data) {}
+    ~Record() = default;
+    Record(const Record&) = default;
+    Record(Record&&) = default;
+    Record& operator=(const Record&) = default;
+    Record& operator=(Record&&) = default;
+
+    uint64_t patchpointID() const {
+      return read<uint64_t>(data + patchpointIDOffset);
+    }
+
+    uint64_t instructionOffset() const {
+      return read<uint64_t>(data + instructionOffsetOffset);
+    }
+
+    uint16_t locationCount() const {
+      return read<uint16_t>(data + numLocationsOffset);
+    }
+
+    uint16_t liveOutCount() const {
+      return read<uint16_t>(data + numLiveOutsOffset(locationCount()));
+    }
+
+    const uint8_t* getBase() const {
+      return data;
+    }
+
+    size_t byteSize() const {
+      const size_t numLiveOutsOffsetV = numLiveOutsOffset(locationCount());
+      const size_t liveOutSize = sizeof(uint16_t) + sizeof(uint8_t)*2;
+      const size_t numLiveOuts = liveOutCount();
+      const size_t liveOutsEndOffset = numLiveOutsOffsetV + sizeof(uint16_t) + liveOutSize*numLiveOuts;
+      // Record size must be aligned to 8 bytes
+      return alignOffset(liveOutsEndOffset, 8);
+    }
+
+    const uint8_t* next() const {
+      return data + byteSize();
+    }
+  private:
+    static constexpr size_t patchpointIDOffset = 0;
+    static constexpr size_t instructionOffsetOffset = patchpointIDOffset + sizeof(uint64_t);
+    static constexpr size_t numLocationsOffset = instructionOffsetOffset + sizeof(uint32_t) + sizeof(uint16_t);
+
+    static size_t numLiveOutsOffset(const size_t numLocations) {
+      const size_t locationsBaseOffset = numLocationsOffset + sizeof(uint16_t);
+      const size_t locationSize = sizeof(uint8_t)*2 + sizeof(uint16_t)*3 + sizeof(int32_t);
+      // Offset of numLiveOuts needs to be aligned to 8, so there may be padding
+      const size_t paddingOffset = locationsBaseOffset + locationSize*numLocations;
+      const size_t paddingSize = alignOffset(paddingOffset, 8) - paddingOffset;
+      return paddingOffset + paddingSize;
+    }
+
+    const uint8_t* const data;
+  };
+
+public:
+  StackMapV3Parser(llvm::ArrayRef<uint8_t> section) : section(section) {
+    size_t constantsListOffset = functionListOffset + functionCount() * functionSize;
+    if (read<uint32_t>(&section[0]) != 3) {
+      // We can't handle this version so don't bother finishing parse
+      return;
+    }
+    populate<Function>(&functionRefs, functionCount(), functionListOffset);
+    populate<Constant>(&constantRefs, constantCount(), constantsListOffset);
+    populate<Record>(&recordRefs, recordCount(), constantsListOffset + constantCount()*constantSize);
+  }
+  ~StackMapV3Parser() = default;
+  StackMapV3Parser(const StackMapV3Parser&) = default;
+  StackMapV3Parser(StackMapV3Parser&&) = default;
+  StackMapV3Parser& operator=(const StackMapV3Parser&) = default;
+  StackMapV3Parser& operator=(StackMapV3Parser&&) = default;
+
+  const std::vector<Function>& functions() const { return functionRefs; }
+  const std::vector<Constant>& constants() const { return constantRefs; }
+  const std::vector<Record>& records() const { return recordRefs; }
+
+private:
+  uint32_t functionCount() const {
+    return read<uint32_t>(&section[numFunctionsOffset]);
+  }
+
+  uint32_t constantCount() const {
+    return read<uint32_t>(&section[numConstantsOffset]);
+  }
+
+  uint32_t recordCount() const {
+    return read<uint32_t>(&section[numRecordsOffset]);
+  }
+
+  template<typename EntryType>
+  void populate(std::vector<EntryType>* const collection, const uint32_t count, const size_t baseOffset) {
+    const uint8_t* currentBase = &section[0] + baseOffset;
+    collection->reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+      const auto currentEntry = EntryType(currentBase);
+      currentBase = currentEntry.next();
+      collection->push_back(currentEntry);
+    }
+  }
+
+  template <typename T>
+  static T read(const uint8_t* const data) {
+    return llvm::support::endian::read<T, Endianness>(data);
+  }
+
+  static constexpr size_t alignOffset(const size_t offset, const size_t alignment) {
+    return (offset + (alignment - 1)) & ~(alignment - 1);
+  }
+
+  static constexpr size_t headerOffset = 0;
+  static constexpr size_t numFunctionsOffset = headerOffset + sizeof(uint8_t)*2 + sizeof(uint16_t);
+  static constexpr size_t numConstantsOffset = numFunctionsOffset + sizeof(uint32_t);
+  static constexpr size_t numRecordsOffset = numConstantsOffset + sizeof(uint32_t);
+  static constexpr size_t functionListOffset = numRecordsOffset + sizeof(uint32_t);
+
+  static constexpr size_t functionSize = sizeof(uint64_t)*3;
+  static constexpr size_t constantSize = sizeof(uint64_t);
+
+  llvm::ArrayRef<uint8_t> section;
+  std::vector<Function> functionRefs;
+  std::vector<Constant> constantRefs;
+  std::vector<Record> recordRefs;
+};
 
 }
 

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -16,6 +16,9 @@
 // structured file support
 #include <hobbes/db/bindings.H>
 
+// probe support
+#include <hobbes/eval/probes.H>
+
 // network IPC
 #include <hobbes/ipc/nbindings.H>
 
@@ -130,6 +133,9 @@ cc::cc() :
 
   // initialize structured storage support
   initStorageFileDefs(fv, *this);
+
+  // initialize xpedite probe injection support
+  initProbeDefs(*this);
 
   // boot
   compileBootCode(*this);

--- a/lib/hobbes/eval/probes.C
+++ b/lib/hobbes/eval/probes.C
@@ -1,0 +1,270 @@
+
+#include <hobbes/db/bindings.H>
+#include <hobbes/lang/tyunqualify.H>
+#include <hobbes/eval/probes.H>
+#include <hobbes/eval/cc.H>
+#include <hobbes/eval/jitcc.H>
+
+#include <atomic>
+
+namespace hobbes {
+
+static std::atomic<uint32_t> probeIdCtr{0};
+static uint64_t freshProbeId() noexcept {
+  return InjectedProbeMetadata::typeTag | static_cast<uint64_t>(probeIdCtr++);
+}
+
+struct injectProbeF : public op {
+  llvm::Value* apply(jitcc* c, const MonoTypes& tys, const MonoTypePtr& /*rty*/, const Exprs& es) {
+    // Requires us to be able to fully evaluate the argument to the compile-time string
+    MkArray* probeNameArr = is<MkArray>(stripAssumpHead(es[0]));
+    if (!probeNameArr) {
+      throw annotated_error(*es[0], "injectProbe intrinsic expected compile-time [char] as argument" + show(tys[0]));
+    }
+    if (probeNameArr->values().size() == 0) {
+      throw annotated_error(*es[0], "injectProbe intrinsic expected compile-time [char] as argument" + show(tys[0]));
+    }
+    std::string probeName = "";
+    for (auto v : probeNameArr->values()) {
+      Char* casted = is<Char>(v);
+      if (!casted) {
+        throw annotated_error(*es[0], "injectProbe intrinsic expected compile-time [char] as argument" + show(tys[0]));
+      }
+      probeName += casted->value();
+    }
+
+    const uint64_t probeId = freshProbeId();
+    constexpr uint32_t caveSize = 5; // Size in bytes of the nop to insert at patchpoint. Xpedite expects 5
+
+    // we need to register the probe (id and name) with the compiler such that the stackmap
+    // can be walked and probe location extracted & dumped to disk for xpedite.
+    c->addProbeMapping(
+      InjectedProbeMetadata{
+        probeId,
+        probeName,
+        es[0]->la().filename(),
+        es[0]->la().p0.first,  // lineno
+        "N/A",  // function name
+        reinterpret_cast<void*>(0), // callsite - to be filled later
+        reinterpret_cast<void*>(0), // returnsite - to be filled later
+      }
+    );
+
+    // patchpoints are utterly broken in patchpoint followed by call scenarios under x86_64
+    // instead we use stackmap followed by a manual inline asm 5 byte nop
+    llvm::InlineAsm* multibyteNop = llvm::InlineAsm::get(
+      llvm::FunctionType::get(c->builder()->getVoidTy(), false /* isVarArg */),
+      "nopl 0(%eax, %eax, 1)", // 5 byte nop
+      "", // clobbers
+      false, // HasSideEffect
+      false, // IsAlignStack
+      llvm::InlineAsm::AD_ATT);
+
+    llvm::SmallVector<llvm::Value*, 2> args;
+    args.push_back(c->builder()->getInt64(probeId));
+    args.push_back(c->builder()->getInt32(caveSize));
+
+    llvm::CallInst* stackMapCall = c->builder()->CreateCall(
+      llvm::Intrinsic::getDeclaration(c->module(), llvm::Intrinsic::experimental_stackmap),
+      llvm::ArrayRef<llvm::Value*>(args)
+    );
+    c->builder()->CreateCall(multibyteNop);
+
+    return stackMapCall;
+  }
+
+  PolyTypePtr type(typedb&) const {
+    return polytype(intrinsicType());
+  }
+
+private:
+  // injectProbe :: [char] -> ()
+  static MonoTypePtr intrinsicType() {
+    return functy(list(arrayty(primty("char"))), primty("unit"));
+  }
+};
+
+class ProbeP : public Unqualifier {
+  struct ConstraintArgs {
+    std::string probeName;
+  };
+
+  static ConstraintArgs extractConstraintArgs(const ConstraintPtr& c) {
+    ConstraintArgs args;
+    args.probeName = is<TString>(c->arguments()[0])->value();
+    return args;
+  }
+
+public:
+  ProbeP() = default;
+  ~ProbeP() = default;
+  ProbeP(const ProbeP&) = default;
+  ProbeP(ProbeP&&) = default;
+  ProbeP& operator=(const ProbeP&) = default;
+  ProbeP& operator=(ProbeP&&) = default;
+
+  static std::string constraintName() {
+    return "Probe";
+  }
+
+  bool refine(const TEnvPtr&, const ConstraintPtr&, MonoTypeUnifier*, Definitions*) {
+    return false;
+  }
+
+  bool satisfied(const TEnvPtr&, const ConstraintPtr& c, Definitions*) const {
+    TString* typedName = nullptr;
+    if (c->name() == constraintName() && c->arguments().size() == 1 && !hasFreeVariables(c->arguments()[0])) {
+      typedName = is<TString>(c->arguments()[0]);
+      if (typedName != nullptr && typedName->value() != "") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool satisfiable(const TEnvPtr&, const ConstraintPtr&, Definitions*) const {
+    return true;
+  }
+
+  void explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*) {
+  }
+
+  struct insertProbeF : public switchExprTyFn {
+    // Do a transform of:
+    // e :: (Probe "probeName") => T
+    //    =>
+    // (do { injectProbe("probeName.start"); let x = e; injectProbe("probeName.end"); return e; }) :: T
+    //    => desugaring to
+    // (let freshSymbol1 = injectProbe("probeName.start") in
+    //   (let freshSymbol2 = e in
+    //     (let freshSymbol3 = injectProbe("probeName.end") in
+    //       freshSymbol2))) :: T
+    // where probeName.start and probeName.end are two named 5 byte nop patchpoints
+    // with locational information being emitted to the .llvm.stackmap data section
+    const TEnvPtr& tenv;
+    const ConstraintPtr& constraint;
+    Definitions* ds;
+    const std::string& probeName;
+
+    insertProbeF(const TEnvPtr& tenv, const ConstraintPtr& constraint, Definitions* ds, const std::string& probeName)
+      : tenv(tenv), constraint(constraint), ds(ds), probeName(probeName) {}
+    ~insertProbeF() = default;
+    insertProbeF(const insertProbeF&) = default;
+    insertProbeF(insertProbeF&&) = default;
+    insertProbeF& operator=(const insertProbeF&) = default;
+    insertProbeF& operator=(insertProbeF&&) = default;
+
+    ExprPtr wrapWithProbes(const ExprPtr e) const {
+      const std::string expressionName = ".probe.expr" + freshName();
+      const std::string probeStartName = ".probe.start" + freshName();
+      const std::string probeEndName = ".probe.end" + freshName();
+      const std::string injectProbeFuncName = "injectProbe";
+
+      const MonoTypePtr charT = primty("char");
+      const MonoTypePtr arrayCharT = arrayty(charT);
+      const MonoTypePtr unitT = primty("unit");
+      const MonoTypePtr injectProbeFuncType = functy(list(arrayCharT), unitT);
+
+      ExprPtr probeStartArg = ExprPtr(mkarray(probeName + ".start", e->la()));
+      ExprPtr probeEndArg = ExprPtr(mkarray(probeName + ".end", e->la()));
+      ExprPtr injectProbeExpr = var(injectProbeFuncName,
+        qualtype(injectProbeFuncType),
+        e->la()
+      );
+      injectProbeExpr->type(qualtype(injectProbeFuncType));
+
+      ExprPtr injectProbeStartCall = fncall(
+        injectProbeExpr,
+        list(probeStartArg),
+        e->la()
+      );
+      injectProbeStartCall->type(qualtype(unitT));
+
+      ExprPtr injectProbeEndCall = fncall(
+        injectProbeExpr,
+        list(probeEndArg),
+        e->la()
+      );
+      injectProbeEndCall->type(qualtype(unitT));
+
+      ExprPtr finalResultReference = var(expressionName, e->la());
+      finalResultReference->type(e->type());
+
+      ExprPtr injectProbeEndBinding = let(probeEndName,
+        injectProbeEndCall,
+        finalResultReference,
+        e->la()
+      );
+      injectProbeEndBinding->type(finalResultReference->type());
+
+      ExprPtr letBindingsWrapper = let(probeStartName,
+        injectProbeStartCall,
+        let(expressionName,
+          e,
+          injectProbeEndBinding,
+          e->la()
+        ),
+        e->la()
+      );
+      letBindingsWrapper->type(e->type());
+
+      return letBindingsWrapper;
+    }
+
+    QualTypePtr withTy(const QualTypePtr& qt) const override {
+      return removeConstraint(this->constraint, qt);
+    }
+
+    ExprPtr wrapWithTy(const QualTypePtr& qty, Expr* e) const override {
+      ExprPtr result(e);
+      result->type(withTy(qty));
+      return result;
+    }
+
+    ExprPtr with(const Assump* v) const override {
+      if (hasConstraint(this->constraint, v->type()) && !hasConstraint(this->constraint, v->expr()->type())) {
+        return wrapWithTy(v->type(), new Assump(wrapWithProbes(switchOf(v->expr(), *this)), withTy(v->ty()), v->la()));
+      } else {
+        return wrapWithTy(v->type(), new Assump(switchOf(v->expr(), *this), withTy(v->ty()), v->la()));
+      }
+    }
+  };
+
+  ExprPtr unqualify(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds) const {
+    auto args = extractConstraintArgs(cst);
+
+    if (hasConstraint(cst, e->type())) {
+      return switchOf(e, insertProbeF(tenv, cst, ds, args.probeName));
+    } else {
+      return e;
+    }
+  }
+
+  PolyTypePtr lookup(const std::string& vn) const {
+    if (vn == constraintName()) {
+      return polytype(2, qualtype(list(ConstraintPtr(new Constraint(constraintName(), list(tgen(0))))), tgen(1)));
+    } else {
+      return PolyTypePtr{};
+    }
+  }
+
+  SymSet bindings() const {
+    SymSet r;
+    r.insert(constraintName());
+    return r;
+  }
+
+  FunDeps dependencies(const ConstraintPtr&) const {
+    return FunDeps{};
+  }
+};
+
+// load definitions for working with code caves for profiler instrumentation into compiler context
+void initProbeDefs(cc& c) {
+  c.typeEnv()->bind("Probe", UnqualifierPtr(new ProbeP()));
+  c.bindLLFunc("injectProbe", new injectProbeF());
+}
+
+}
+

--- a/test/Probes.C
+++ b/test/Probes.C
@@ -1,0 +1,19 @@
+
+#include <hobbes/hobbes.H>
+#include "test.H"
+
+using namespace hobbes;
+static cc& c() { static __thread cc* x = 0; if (!x) { x = new cc(); } return *x; }
+
+TEST(Probes, Basic) {
+  // Simple test: i.e. does the Probe TString unqualifier and injectProbe op compile
+  // and not break the wrapped code?
+  c().define("a000",
+    "do { injectProbe(\"a000\"); return 123 }");
+  c().define("factorial",
+    "(\\x. (if (x == 0) then 1 else (x * factorial(x - 1))) :: (Probe \"fact\")=>a)");
+
+  EXPECT_TRUE(c().compileFn<bool()>("a000 == 123")());
+  EXPECT_TRUE(c().compileFn<bool()>("factorial(10) == 3628800")());
+}
+


### PR DESCRIPTION
Adds some basic plumbing to allow for injecting known no-op caves into
Hobbes code for instrumentation purposes (profiling, crazy code injection and so on).

Supports the following:
 * `injectProbe :: ([char]) -> ()` 5 byte nop cave emission (also emits
   metadata to stackmap section of executable blob) op.
 * `Probe TString` unqualifier that wraps constrained expression to have
   named .start and .end probes injected around code-gen.
   Doesn't compile when used on all expressions (e.g. lambda definitions)
 * Registering of information about injected probes with compiler.
 * Parsing the LLVM stackmaps as far as needed for this feature.

Does not currently support:
 * Dumping cave locations in such a way that some external
   instrumentation can be done via the code caves.
 * Full source location information of probes.
 * Support for multiple defined probes of the same name is untested.
 * Non-x86_64 platforms. LLVM only support stackmaps under a handful of 64-bit platforms. We 
   explicitly use inline assembly to insert the no-op to work around LLVM bugginess, which is platform 
   specific.

Notes:
 * llvm patchpoints are utterly broken for x86_64 on llvm v6+. Use
   platform specific stackmap into inline asm 5-byte nop instead.
 * llvm5+ doesn't support parsing the very stackmaps it emits.
   This is not fixed until 9.

Originally intended to allow injection of instrumentation into Hobbes generated code for [Xpedite](https://github.com/Morgan-Stanley/Xpedite), but the remaining work for integration has been left out. Only the more general implementation has been left as integrating with Xpedite would likely require pulling it in as a dependency at the moment due to some usage requirements. LLVMs JIT instrumentation support is fairly derelict in recent years & generally sub-par, so I am unsure as to the forward maintainability of this code, but the injection of and registering of named code caves works as of now, even if nothing is actually done with that feature.