### PR TITLE
upgrade osx and llvm version on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ matrix:
   include:
     - os: osx
       compiler: clang
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       env:
-        - DEPS="${DEPS} readline llvm@4"
-        - LLVM_DIR=/usr/local/opt/llvm@4/lib/cmake/llvm/
+        - DEPS="${DEPS} readline llvm@6"
+        - LLVM_DIR=/usr/local/opt/llvm@6/lib/cmake/llvm/
         - ARGS=-V
     - os: linux
       compiler: g++
@@ -46,7 +46,7 @@ matrix:
         - ARGS=-V
 
 install:
-  - if [ $TRAVIS_OS_NAME = osx   ]; then brew update && brew install -v ${DEPS} && find /usr/local/opt/llvm@4/ | grep cmake; fi
+  - if [ $TRAVIS_OS_NAME = osx   ]; then brew update && brew install -v ${DEPS} && find /usr/local/opt/llvm@6/ | grep cmake; fi
   - if [ $TRAVIS_OS_NAME = linux ]; then cd docker/build && docker build . -f ./${DIST}.Dockerfile -t hobbes:build --build-arg DEPS; cd -; fi
 
 script:


### PR DESCRIPTION
this change moves to xcode9.4 and llvm@6 since llvm@4 is deleted from brew on travis-ci (unless creating a custom taps to keep llvm@4).