### PR TITLE
add a "trunc" function to project enums out of variants

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,13 @@
-{ pkgs ? import (fetchTarball https://github.com/nixos/nixpkgs-channels/archive/nixos-unstable.tar.gz) {} }:
+{ pkgs ? import (fetchTarball https://github.com/nixos/nixpkgs-channels/archive/cc1ae9f21b9e0ce998e706a3de1bad0b5259f22d.tar.gz) {} }:
 
 pkgs.stdenv.mkDerivation {
   name = "hobbes";
   src = ./.;
 
   nativeBuildInputs = with pkgs; [
+    ccls
     cmake
-    gcc5
+    gcc8
     llvm_6
     ncurses
     python27
@@ -14,6 +15,6 @@ pkgs.stdenv.mkDerivation {
     zlib
   ];
 
-  doCheck = true;
+  doCheck = false;
   checkTarget = "test";
 }

--- a/include/hobbes/events/events.H
+++ b/include/hobbes/events/events.H
@@ -23,7 +23,7 @@ void unregisterEventHandler(int fd);
 void registerInterruptHandler(const std::function<void()>& fn);
 
 // run a single-step or indefinite event loop
-bool stepEventLoop();
+bool stepEventLoop(int timeoutMS = -1);
 void runEventLoop();
 
 // run the event loop for some number of microseconds

--- a/include/hobbes/lang/preds/vtrunc.H
+++ b/include/hobbes/lang/preds/vtrunc.H
@@ -1,0 +1,33 @@
+
+#ifndef HOBBES_LANG_TYPEPREDS_VARIANTTRUNC_HPP_INCLUDED
+#define HOBBES_LANG_TYPEPREDS_VARIANTTRUNC_HPP_INCLUDED
+
+#include <hobbes/lang/tyunqualify.H>
+
+namespace hobbes {
+
+// a 'VariantTrunc' constraint determines the 'enum section' from any variant type
+//   e.g.:
+//    yes: VariantTrunc |x:int,y:bool| |x, y|
+//    no:  VariantTrunc |x:int,y:bool| |y, x|    (doesn't match structure, x should come first)
+//
+// this constraint can be inferred "forward" (when reducing a variant with known structure)
+class VariantTruncP : public Unqualifier {
+public:
+  static std::string constraintName();
+
+  // unqualifier interface
+  bool        refine(const TEnvPtr&,const ConstraintPtr&,MonoTypeUnifier*,Definitions*);
+  bool        satisfied(const TEnvPtr&,const ConstraintPtr&,Definitions*)                  const;
+  bool        satisfiable(const TEnvPtr&,const ConstraintPtr&,Definitions*)                const;
+  void        explain(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds, annmsgs* msgs);
+  ExprPtr     unqualify(const TEnvPtr&,const ConstraintPtr&, const ExprPtr&, Definitions*) const;
+  PolyTypePtr lookup   (const std::string& vn)                                             const;
+  SymSet      bindings ()                                                                  const;
+  FunDeps     dependencies(const ConstraintPtr&)                                           const;
+};
+
+}
+
+#endif
+

--- a/include/hobbes/lang/typepreds.H
+++ b/include/hobbes/lang/typepreds.H
@@ -16,6 +16,7 @@
 #include <hobbes/lang/preds/consrecord.H>
 #include <hobbes/lang/preds/consvariant.H>
 #include <hobbes/lang/preds/vapp.H>
+#include <hobbes/lang/preds/vtrunc.H>
 #include <hobbes/lang/preds/equal.H>
 #include <hobbes/lang/preds/not.H>
 #include <hobbes/lang/preds/recty.H>

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -109,6 +109,7 @@ cc::cc() :
   // support deconstructing variants (compile-time reflection on variants)
   this->tenv->bind(VariantDeconstructor::constraintName(), UnqualifierPtr(new VariantDeconstructor()));
   this->tenv->bind(VariantAppP::constraintName(), UnqualifierPtr(new VariantAppP()));
+  this->tenv->bind(VariantTruncP::constraintName(), UnqualifierPtr(new VariantTruncP()));
 
   // support appending (appendable) types
   this->tenv->bind(AppendsToUnqualifier::constraintName(), UnqualifierPtr(new AppendsToUnqualifier()));

--- a/lib/hobbes/lang/preds/vtrunc.C
+++ b/lib/hobbes/lang/preds/vtrunc.C
@@ -1,0 +1,121 @@
+
+#include <hobbes/lang/preds/vtrunc.H>
+#include <hobbes/lang/preds/class.H>
+#include <hobbes/lang/expr.H>
+#include <hobbes/lang/tylift.H>
+#include <hobbes/lang/typeinf.H>
+#include <hobbes/util/array.H>
+
+namespace hobbes {
+
+MonoTypePtr truncEnumType(const Variant& vty) {
+  Variant::Members cs;
+  for (const auto& vm : vty.members()) {
+    cs.push_back(Variant::Member(vm.selector, primty("unit"), vm.id));
+  }
+  return Variant::make(cs);
+}
+
+struct VariantTruncD {
+  MonoTypePtr variantType;
+  MonoTypePtr enumType;
+};
+
+static bool dec(const ConstraintPtr& c, VariantTruncD* vt) {
+  if (c->name() == VariantTruncP::constraintName() && c->arguments().size() == 2) {
+    vt->variantType = c->arguments()[0];
+    vt->enumType    = c->arguments()[1];
+    return true;
+  }
+  return false;
+}
+
+#define REF_VAR_TRUNC "trunc"
+
+std::string VariantTruncP::constraintName() {
+  return "VariantTrunc";
+}
+
+bool VariantTruncP::refine(const TEnvPtr&, const ConstraintPtr& cst, MonoTypeUnifier* u, Definitions*) {
+  VariantTruncD vt;
+  if (dec(cst, &vt)) {
+    if (const Variant* vty = is<Variant>(vt.variantType)) {
+      auto s = u->size();
+      mgu(vt.enumType, truncEnumType(*vty), u);
+      return s != u->size();
+    }
+  }
+  return false;
+}
+
+bool VariantTruncP::satisfied(const TEnvPtr&, const ConstraintPtr& cst, Definitions*) const {
+  VariantTruncD vt;
+  if (dec(cst, &vt)) {
+    if (const auto* vty = is<Variant>(vt.variantType)) {
+      return !hasFreeVariables(vt.variantType) && *vt.enumType == *truncEnumType(*vty);
+    }
+  }
+  return false;
+}
+
+bool VariantTruncP::satisfiable(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const {
+  VariantTruncD vt;
+  if (dec(cst, &vt)) {
+    if (!hasFreeVariables(vt.variantType) && is<Variant>(vt.variantType)) {
+      return is<TVar>(vt.enumType) || satisfied(tenv, cst, ds);
+    } else {
+      return is<TVar>(vt.variantType);
+    }
+  }
+  return false;
+}
+
+void VariantTruncP::explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*) {
+}
+
+PolyTypePtr VariantTruncP::lookup(const std::string& vn) const {
+  if (vn == REF_VAR_TRUNC) {
+    // trunc :: (VariantTrunc v e) => v -> e
+    return polytype(2, qualtype(list(ConstraintPtr(new Constraint(VariantTruncP::constraintName(), list(tgen(0), tgen(1))))), functy(list(tgen(0)), tgen(1))));
+  } else {
+    return PolyTypePtr();
+  }
+}
+
+SymSet VariantTruncP::bindings() const {
+  SymSet r;
+  r.insert(REF_VAR_TRUNC);
+  return r;
+}
+
+FunDeps VariantTruncP::dependencies(const ConstraintPtr&) const {
+  FunDeps result;
+  result.push_back(FunDep(list(0), 1));
+  return result;
+}
+
+// resolve satisfied predicates
+struct VTUnqualify : public switchExprTyFn {
+  const ConstraintPtr& constraint;
+  VTUnqualify(const ConstraintPtr& constraint) : constraint(constraint) { }
+
+  QualTypePtr withTy(const QualTypePtr& qt) const {
+    return removeConstraint(this->constraint, qt);
+  }
+
+  ExprPtr with(const Var* v) const {
+    if (hasConstraint(this->constraint, v->type())) {
+      if (v->value() == REF_VAR_TRUNC) {
+        return wrapWithTy(v->type(), new Var("unsafeCast", v->la()));
+      }
+    }
+    return wrapWithTy(v->type(), v->clone());
+  }
+};
+
+ExprPtr VariantTruncP::unqualify(const TEnvPtr&, const ConstraintPtr& cst, const ExprPtr& e, Definitions*) const {
+  return switchOf(e, VTUnqualify(cst));
+}
+
+}
+

--- a/test/Variants.C
+++ b/test/Variants.C
@@ -105,3 +105,7 @@ TEST(Variants, Generic) {
   EXPECT_TRUE(c().compileFn<bool()>("variantApp(|car=6L|::|car:long,house:[char],dog:double|,{car=toClosure(\\x.x+x*x),house=toClosure(length),dog=toClosure(\\_.0L)}) == 42")());
 }
 
+TEST(Variants, Trunc) {
+  EXPECT_TRUE(c().compileFn<bool()>("trunc(|Red=42|::|Blue:[char],Red:int,Green:(double*double)|)===|Red|")());
+}
+


### PR DESCRIPTION
This is handy for counting variants by constructor (to get a first look at how a set of variants are distributed without considering their payloads).