### PR TITLE
use constant memory in unionfind path compression

### DIFF
--- a/include/hobbes/util/unionfind.H
+++ b/include/hobbes/util/unionfind.H
@@ -104,10 +104,19 @@ template <typename K, typename V, typename KVLift, typename VPlus>
     nodes_t nodes;
 
     static node_t* findRepresentative(node_t* n) {
-      if (n != n->representative) {
-        n->representative = findRepresentative(n->representative);
+      // first find the root
+      auto* root = n;
+      while (root != root->representative) {
+        root = root->representative;
       }
-      return n->representative;
+
+      // then update all nodes along the way (they all have the same representative)
+      while (n != root) {
+        auto* s = n->representative;
+        n->representative = root;
+        n = s;
+      }
+      return root;
     }
 
     node_t* findNode(const K& k) {


### PR DESCRIPTION
This will perform better with very deep chains.  Typically we don't see such chains in type inference, but this data structure can be useful in other places where such chains are possible.