### PR TITLE
catch format string var refs immediately joined

### DIFF
--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -1988,7 +1988,7 @@ template <size_t N>
                        :                   maxVarRefS(fmt, i+1, 0, 0,   maxvr))
            :           ((fmt[i] >= '0' && fmt[i] <= '9') ?
                            maxVarRefS(fmt, i+1, 1, vri, maxvr)
-                         : maxVarRefS(fmt, i+1, 0, 0,   maxV(maxvr, 1+readInt(fmt, vri, i, 0))));
+                         : maxVarRefS(fmt, i,   0, 0,   maxV(maxvr, 1+readInt(fmt, vri, i, 0))));
   }
 
 template <size_t N>

--- a/include/hobbes/util/time.H
+++ b/include/hobbes/util/time.H
@@ -111,7 +111,7 @@ inline long readTime(const std::string& x) {
   int h = h_msu.first.empty() ? 0 : str::to<int>(h_msu.first);
   int m = m_su.first.empty()  ? 0 : str::to<int>(m_su.first);
   int s = s_u.first.empty()   ? 0 : str::to<int>(s_u.first);
-  int u = s_u.second.empty()  ? 0 : str::to<int>(s_u.second);
+  int u = s_u.second.empty()  ? 0 : (str::to<int>(s_u.second) * (s_u.second.size()==3?1000:1));
 
   return mkTime(h,m,s,u);
 }
@@ -119,6 +119,10 @@ inline long readTime(const std::string& x) {
 inline std::string showTime(long x) {
   int64_t s  = x / (1000 * 1000);
   int64_t us = x % (1000 * 1000);
+  if (us < 0) {
+    s -= 1;
+    us += 1000L * 1000L;
+  }
 
   static char buf[256];
   strftime(buf, sizeof(buf), "%H:%M:%S", localtime(reinterpret_cast<time_t*>(&s)));
@@ -194,7 +198,7 @@ inline long readDateTime(const std::string& x) {
   int h   = h_msu.first.empty() ? 0 : str::to<int>(h_msu.first);
   int min = m_su.first.empty()  ? 0 : str::to<int>(m_su.first);
   int s   = s_u.first.empty()   ? 0 : str::to<int>(s_u.first);
-  int u   = s_u.second.empty()  ? 0 : str::to<int>(s_u.second);
+  int u   = s_u.second.empty()  ? 0 : (str::to<int>(s_u.second) * (s_u.second.size()==3?1000:1));
 
   return mkDateTime(y, mon, d, h, min, s, u);
 }
@@ -202,6 +206,10 @@ inline long readDateTime(const std::string& x) {
 inline std::string showDateTime(long x) {
   int64_t s  = x / (1000L * 1000L);
   int64_t us = x % (1000L * 1000L);
+  if (us < 0) {
+    s -= 1;
+    us += 1000L * 1000L;
+  }
 
   static char buf[256];
   strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", localtime(reinterpret_cast<time_t*>(&s)));


### PR DESCRIPTION
Where we use `HLOG` with format strings that have variable references back to back, this change fixes the check for valid references so that the second reference is checked correctly.

e.g. previously, you would have been allowed to write `HLOG(G, n, "test $0$9", 42)` and now it will fail such calls correctly (catching the trailing invalid `$9` reference).

There's no runtime problem here, just a fix to block this odd case of invalid format strings from getting accepted.  We have always blocked invalid format strings otherwise.