### PR TITLE
support gcc 9

### DIFF
--- a/include/hobbes/db/file.H
+++ b/include/hobbes/db/file.H
@@ -33,6 +33,8 @@ template <typename T>
 
     fileref(uint64_t index = 0) : index(index) {
     }
+    fileref(const fileref<T>& x) : index(x.index) {
+    }
 
     bool operator==(const fileref<T>& rhs) const {
       return this->index == rhs.index;


### PR DESCRIPTION
To compile with gcc 9, I just had to add this explicit copy constructor to this definition of the `fileref` type.  I think we can't use LLVM 6 with gcc 9 though, it has similar problems.