### PR TITLE
Disallow string record labels with leading .'s

### DIFF
--- a/lib/hobbes/read/pgen/hexpr.y
+++ b/lib/hobbes/read/pgen/hexpr.y
@@ -863,7 +863,11 @@ recfieldname: id         { $$ = $1; }
             | "return"   { $$ = autorelease(new std::string("return")); }
             | "fn"       { $$ = autorelease(new std::string("fn")); }
             | "intV"     { $$ = autorelease(new std::string(".f" + str::from($1))); }
-            | "stringV"  { $$ = autorelease(new std::string(str::unescape(str::trimq(*$1)))); }
+            | "stringV"  { std::string stringField = str::unescape(str::trimq(*$1));
+                           if (stringField.size() > 0 && stringField[0] == '.' ) {
+                             throw annotated_error(m(@1), "Cannot define record string label with leading '.'");
+                           }
+                           $$ = autorelease(new std::string(str::unescape(str::trimq(*$1)))); }
 
 recfieldpath: recfieldpath "." recfieldname { $$ = $1; $$->push_back(*$3); }
             | recfieldpath "tupSection"     { $$ = $1; str::seq x = tupSectionFields(*$2); $$->insert($$->end(), x.begin(), x.end()); }


### PR DESCRIPTION
Sorry, but my previous PR introduced the possibility of chaos, i.e. {".f1" = 1}, or worse {a=1, ".pa"=2}.  Given the wide-spread use of '.' internally, it is probably better to just directly disallow such labels or accessors directly.