### PR TITLE
Provide default report name

### DIFF
--- a/test/test.H
+++ b/test/test.H
@@ -15,6 +15,8 @@
 #include <hobbes/util/stream.H>
 
 struct Args final {
+  Args() : report("test_report.json") {}
+
   std::set<std::string> tests;
   const char* report;
 };


### PR DESCRIPTION
Running hobbes-test without any arguments will probably produce a filename with gibberish, could segfault, or with vanishingly small possibility overwrite something it shouldn't, as Args.report is an uninitialized pointer if --json is not provided.  This introduces a default value to stop that.