### PR TITLE
fix an error with const lifts under llvm 6 (when global values have no initializers)

### DIFF
--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -268,7 +268,7 @@ inline llvm::Constant* constant(llvm::Value* v, bool globalPtrRefs) {
       if (globalPtrRefs) {
         return gv;
       } else {
-        return gv->getInitializer();
+        return gv->hasInitializer() ? gv->getInitializer() : 0;
       }
     } else {
       return 0;


### PR DESCRIPTION
Fixes this issue that adam ran into:

https://github.com/Morgan-Stanley/hobbes/issues/358