### PR TITLE
disallow record and variant types with duplicate field/constructor names

### DIFF
--- a/test/Structs.C
+++ b/test/Structs.C
@@ -101,6 +101,26 @@ TEST(Structs, Bindings) {
   EXPECT_TRUE(c().compileFn<array<char>*()>("show(genstruct)") != 0);
 }
 
+TEST(Structs, NoDuplicateFieldNames) {
+  // reject outright construction of structs with duplicate field names
+  bool introExn = false;
+  try {
+    c().compileFn<int()>("{x=1, x='c'}.x");
+  } catch (std::exception&) {
+    introExn = true;
+  }
+  EXPECT_TRUE( introExn && "Expected rejection of record introduction with duplicate field names" );
+
+  // reject roundabout construction of structs with duplicate field names
+  introExn = false;
+  try {
+    c().compileFn<void()>("print(recordAppend({x=1},{x=2}))");
+  } catch (std::exception&) {
+    introExn = true;
+  }
+  EXPECT_TRUE( introExn && "Expected rejection of roundabout record introduction with duplicate field names" );
+}
+
 TEST(Structs, Assignment) {
   bool assignExn = false;
   try {
@@ -109,14 +129,6 @@ TEST(Structs, Assignment) {
     assignExn = true;
   }
   EXPECT_TRUE( assignExn && "Expected char assignment to int field to fail to compile (mistake in assignment compilation?)" );
-
-  bool introExn = false;
-  try {
-    c().compileFn<int()>("{x=1, x='c'}.x");
-  } catch (std::exception&) {
-    introExn = true;
-  }
-  EXPECT_TRUE( introExn && "Expected rejection of record introduction with duplicate field names" );
 
   c().compileFn<void()>("bob.x <- 90")();
   EXPECT_TRUE(c().compileFn<bool()>("bob.x == 90")());

--- a/test/Variants.C
+++ b/test/Variants.C
@@ -46,6 +46,16 @@ TEST(Variants, Basic) {
   EXPECT_EQ(c().compileFn<int()>("(\\v.(case v of |0:x=x| default 2))(|1='c'|::int+char)")(), 2);
 }
 
+TEST(Variants, NoDuplicateConstructorNames) {
+  bool introExn = false;
+  try {
+    c().compileFn<void()>("print(|foo=1|::|foo:int,foo:[char]|)");
+  } catch (std::exception&) {
+    introExn = true;
+  }
+  EXPECT_TRUE( introExn && "Expected rejection of variant introduction with duplicate constructor names" );
+}
+
 TEST(Variants, Destruct) {
   EXPECT_TRUE(c().compileFn<bool()>("show(|foo=9|::|foo:int,bar:double,baz:short|) == \"|foo=9|\"")());
 }


### PR DESCRIPTION
This fixes:

https://github.com/Morgan-Stanley/hobbes/issues/355

And introduces tests to verify it.