### PR TITLE
export symbols from "hi" so that .so modules it loads can bind to its compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(hobbes-pic PUBLIC ${llvm_ldflags} ${llvm_libs} ${ZLIB_LIBR
 set_property(TARGET hobbes-pic PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
 add_executable(hi ${hi_files})
-target_link_libraries(hi PRIVATE hobbes ${Readline_LIBRARIES})
+target_link_libraries(hi PUBLIC "-rdynamic" PRIVATE hobbes ${Readline_LIBRARIES})
 add_executable(hog ${hog_files})
 target_link_libraries(hog PRIVATE hobbes)
 


### PR DESCRIPTION
I tested this manually (defining a symbol in "hi" and leaving it extern in a .so that is loaded by "hi" to observe the late binding back into "hi").

This is important for complex .so modules where we want to dynamically compile functions out of the "hi" host compiler.