### PR TITLE
fix unintentional RVO break with fileref (and add a test for it)

### DIFF
--- a/include/hobbes/db/file.H
+++ b/include/hobbes/db/file.H
@@ -33,8 +33,7 @@ template <typename T>
 
     fileref(uint64_t index = 0) : index(index) {
     }
-    fileref(const fileref<T>& x) : index(x.index) {
-    }
+    fileref(const fileref<T>&) = default;
 
     bool operator==(const fileref<T>& rhs) const {
       return this->index == rhs.index;

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -144,6 +144,6 @@ TEST(Compiler, liftChronoTimespan) {
 TEST(Compiler, liftWithoutRVO) {
   typedef hobbes::fileref<const hobbes::array<char>*> strref;
 
-  EXPECT_EQ(c().compileFn<strref(int)>("x", "unsafeCast(42L)")(0).index, 42);
+  EXPECT_EQ(c().compileFn<strref(int)>("x", "unsafeCast(42L)")(0).index, strref(42UL).index);
 }
 

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -1,5 +1,6 @@
 #include <hobbes/hobbes.H>
 #include <hobbes/lang/tylift.H>
+#include <hobbes/db/file.H>
 #include <thread>
 #include "test.H"
 
@@ -137,5 +138,12 @@ std::ostream& operator<<(std::ostream& out, ctimespanT dt) {
 TEST(Compiler, liftChronoTimespan) {
   EXPECT_EQ(c().compileFn<ctimespanT()>("20ms")(), std::chrono::milliseconds(20));
   EXPECT_TRUE(c().compileFn<bool(ctimespanT)>("x", "x==20ms")(std::chrono::milliseconds(20)));
+}
+
+// verify that types are lifted as expected for values without "return value optimization" (or "copy elision")
+TEST(Compiler, liftWithoutRVO) {
+  typedef hobbes::fileref<const hobbes::array<char>*> strref;
+
+  EXPECT_EQ(c().compileFn<strref(int)>("x", "unsafeCast(42L)")(0).index, 42);
 }
 


### PR DESCRIPTION
Sorry for the headache Dan, this added test should prevent the same break from happening again.