### PR TITLE
nix version: 2.0.4 -> 2.3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
     - os: linux
       compiler: g++
       language: nix
-      nix: 2.0.4
+      nix: 2.3.6
       group: deprecated-2017Q4
       script: nix-build
 

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,8 @@ pkgs.stdenv.mkDerivation {
   nativeBuildInputs = with pkgs; [
     ccls
     cmake
+    ninja
+    meson
     gcc8
     llvm_6
     ncurses


### PR DESCRIPTION
Fixes
```sh
$ nix-env --version
nix-env (Nix) 2.0.4
$ nix-instantiate --eval -E 'with import <nixpkgs> {}; lib.version or lib.nixpkgsVersion'
error: evaluation aborted with the following error message: '
This version of Nixpkgs requires Nix >= 2.2, please upgrade:
```

and add parallel builds for nix