### PR TITLE
add support for llvm@8 / llvm@9 / llvm@10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,39 +45,39 @@ matrix:
         - DIST=xenial
         - DEPS="llvm-6.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
         - ARGS=-V
-    - os: linux
-      compiler: g++
-      root: required
-      dist: trusty
-      group: deprecated-2017Q4
-      services:
-        - docker
-      env:
-        - DIST=xenial
-        - DEPS="llvm-8.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
-        - ARGS=-V
-    - os: linux
-      compiler: g++
-      root: required
-      dist: trusty
-      group: deprecated-2017Q4
-      services:
-        - docker
-      env:
-        - DIST=xenial
-        - DEPS="llvm-9.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
-        - ARGS=-V
-    - os: linux
-      compiler: g++
-      root: required
-      dist: trusty
-      group: deprecated-2017Q4
-      services:
-        - docker
-      env:
-        - DIST=xenial
-        - DEPS="llvm-10.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
-        - ARGS=-V
+    # - os: linux
+    #   compiler: g++
+    #   root: required
+    #   dist: trusty
+    #   group: deprecated-2017Q4
+    #   services:
+    #     - docker
+    #   env:
+    #     - DIST=xenial
+    #     - DEPS="llvm-8.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+    #     - ARGS=-V
+    # - os: linux
+    #   compiler: g++
+    #   root: required
+    #   dist: trusty
+    #   group: deprecated-2017Q4
+    #   services:
+    #     - docker
+    #   env:
+    #     - DIST=xenial
+    #     - DEPS="llvm-9.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+    #     - ARGS=-V
+    # - os: linux
+    #   compiler: g++
+    #   root: required
+    #   dist: trusty
+    #   group: deprecated-2017Q4
+    #   services:
+    #     - docker
+    #   env:
+    #     - DIST=xenial
+    #     - DEPS="llvm-10.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+    #     - ARGS=-V
     - os: linux
       compiler: g++
       language: nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ env:
     - DEPS=""
 matrix:
   include:
-    - os: osx
-      compiler: clang
-      osx_image: xcode9.4
-      env:
-        - DEPS="${DEPS} readline llvm@6"
-        - LLVM_DIR=/usr/local/opt/llvm@6/lib/cmake/llvm/
-        - ARGS=-V
+    # Temporarilly disable osx => https://git.io/JLp7U
+    # - os: osx
+    #   compiler: clang
+    #   osx_image: xcode9.4
+    #   env:
+    #     - DEPS="${DEPS} readline llvm@6"
+    #     - LLVM_DIR=/usr/local/opt/llvm@6/lib/cmake/llvm/
+    #     - ARGS=-V
     - os: linux
       compiler: g++
       root: required
@@ -43,6 +44,39 @@ matrix:
       env:
         - DIST=xenial
         - DEPS="llvm-6.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+        - ARGS=-V
+    - os: linux
+      compiler: g++
+      root: required
+      dist: trusty
+      group: deprecated-2017Q4
+      services:
+        - docker
+      env:
+        - DIST=xenial
+        - DEPS="llvm-8.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+        - ARGS=-V
+    - os: linux
+      compiler: g++
+      root: required
+      dist: trusty
+      group: deprecated-2017Q4
+      services:
+        - docker
+      env:
+        - DIST=xenial
+        - DEPS="llvm-9.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
+        - ARGS=-V
+    - os: linux
+      compiler: g++
+      root: required
+      dist: trusty
+      group: deprecated-2017Q4
+      services:
+        - docker
+      env:
+        - DIST=xenial
+        - DEPS="llvm-10.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
         - ARGS=-V
     - os: linux
       compiler: g++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(hobbes)
-set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -17,6 +16,12 @@ include_directories(${CURSES_INCLUDE_DIRS})
 find_package(LLVM REQUIRED CONFIG)
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
+
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS "10.0")
+  set(CMAKE_CXX_STANDARD 11)
+else()
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 if (${LLVM_PACKAGE_VERSION} VERSION_LESS "3.6")
   set(jit_lib jit)
@@ -96,7 +101,7 @@ include(FindPythonInterp)
 set_property(TARGET hobbes-test PROPERTY COMPILE_FLAGS "-DPYTHON_EXECUTABLE=\"${PYTHON_EXECUTABLE}\" -DSCRIPT_DIR=\"${CMAKE_SOURCE_DIR}/scripts/\"")
 
 install(TARGETS hobbes hobbes-pic DESTINATION "lib")
-install(TARGETS hi hog DESTINATION "bin")
+install(TARGETS hi hog hobbes-test DESTINATION "bin")
 install(DIRECTORY "include/hobbes" DESTINATION "include")
 install(DIRECTORY "scripts" DESTINATION "scripts")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ include(FindPythonInterp)
 set_property(TARGET hobbes-test PROPERTY COMPILE_FLAGS "-DPYTHON_EXECUTABLE=\"${PYTHON_EXECUTABLE}\" -DSCRIPT_DIR=\"${CMAKE_SOURCE_DIR}/scripts/\"")
 
 install(TARGETS hobbes hobbes-pic DESTINATION "lib")
-install(TARGETS hi hog hobbes-test DESTINATION "bin")
+install(TARGETS hi hog DESTINATION "bin")
 install(DIRECTORY "include/hobbes" DESTINATION "include")
 install(DIRECTORY "scripts" DESTINATION "scripts")
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1609935452,
+        "narHash": "sha256-McwA/tAnnS8LaAdEoONBsdKFHuOpHMxKqpMCU1wL7H4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "8088c6dbe86a7e6e6396c83e43020e8a1edb08d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1609899452,
@@ -16,6 +31,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1609899452,
+        "narHash": "sha256-JXi5v4lygRyZjv238bKoPFrQiTAurwcL3XqOo2ZCOLg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a3ab47ec9067b5f9fccda506fc8641484c3d8e73",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
             let
               src = self;
               nativeBuildInputs = [ cmake ninja ];
-              buildInputs = [ llvm_6 ncurses readline zlib ];
+              buildInputs = [ ncurses readline zlib ];
               doCheck = true;
               doTarget = "test";
               meta = with stdenv.lib; {
@@ -26,13 +26,20 @@
                 maintainers = with maintainers; [ kthielen thmzlt smunix ];
               };
             in {
+              hobbes-llvm-x = stdenv.mkDerivation {
+                name = "hobbes-llvm-x-${version}";
+                inherit src nativeBuildInputs doCheck doTarget;
+                buildInputs = buildInputs;
+              };
               hobbes-llvm-6 = stdenv.mkDerivation {
                 name = "hobbes-llvm-6-${version}";
-                inherit src nativeBuildInputs buildInputs doCheck doTarget;
+                inherit src nativeBuildInputs doCheck doTarget;
+                buildInputs = buildInputs ++ [ llvm_6 ];
               };
               hobbes-llvm-8 = stdenv.mkDerivation {
                 name = "hobbes-llvm-8-${version}";
-                inherit src nativeBuildInputs buildInputs doCheck doTarget;
+                inherit src nativeBuildInputs doCheck doTarget;
+                buildInputs = buildInputs ++ [ llvm_8 ];
               };
             })
         ];
@@ -42,6 +49,7 @@
       in
         rec {
           packages = flake-utils.lib.flattenTree {
+            inherit (pkgs) hobbes-llvm-x;
             inherit (pkgs) hobbes-llvm-6;
             inherit (pkgs) hobbes-llvm-8;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Hobbes Compiler";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
+      overlays = [
+        (final: prev: {
+          hobbes-master =
+            with final;
+            stdenv.mkDerivation {
+              name = "hobbes-master-${version}";
+              src = ./.;
+              nativeBuildInputs = [ cmake ninja ];
+              buildInputs = [ llvm_6 ncurses readline zlib ];
+              doCheck = false;
+              doTarget = "test";
+            };
+          hobbes-compat =
+            with final;
+            stdenv.mkDerivation {
+              name = "hobbes-compat-${version}";
+              src = fetchFromGitHub { owner="smunix";
+                                      repo="hobbes";
+                                      rev="046ad1f631c90b8d70b3f14675dbe702f6343434";
+                                      sha256="0zhd0v2gjj67r69qwvn6fbjhmnbnaikshdvq53q9vqvfipi42lqz";
+                                    };
+              nativeBuildInputs = [ cmake ninja ];
+              buildInputs = [ llvm_6 ncurses readline zlib ];
+              doCheck = false;
+              doTarget = "test";
+            };
+        })
+      ];
+    in
+      {
+        packages.x86_64-linux = import nixpkgs {
+          inherit system overlays;
+        };
+        defaultPackage.x86_64-linux = (import nixpkgs {
+          inherit system overlays;
+        }).hobbes-master;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
               src = self;
               nativeBuildInputs = [ cmake ninja ];
               buildInputs = [ llvm_6 ncurses readline zlib ];
-              doCheck = false;
+              doCheck = true;
               doTarget = "test";
               meta = with stdenv.lib; {
                 description = "A language and an embedded JIT compiler";

--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -126,7 +126,7 @@ private:
   typedef std::vector<llvm::Module*> Modules;
   Modules modules;
 
-#if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR <= 11
   llvm::legacy::PassManager* mpm;
 
   // the set of allocated execution engines (each will own a finalized module from the set of modules)

--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -126,7 +126,7 @@ private:
   typedef std::vector<llvm::Module*> Modules;
   Modules modules;
 
-#if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
+#if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
   llvm::legacy::PassManager* mpm;
 
   // the set of allocated execution engines (each will own a finalized module from the set of modules)

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -29,12 +29,13 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/Signals.h>
-#if LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
+#if LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
 #include <llvm/Bitcode/BitstreamReader.h>
 #include <llvm/Bitcode/BitstreamWriter.h>
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
+
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
@@ -43,7 +44,7 @@
 #if LLVM_VERSION_MINOR == 3
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/PassManager.h>
-#elif LLVM_VERSION_MINOR >= 5 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
+#elif LLVM_VERSION_MINOR >= 5 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
 #include <llvm/IR/Verifier.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/LegacyPassManager.h>
@@ -358,6 +359,19 @@ inline llvm::Constant* padding(size_t len) {
   return llvm::ConstantArray::get(arrayType(byteType(), len), pad);
 }
 
+inline llvm::Value* memCopy(llvm::IRBuilder<>* b, llvm::Value* dst, uint32_t dstAlign, llvm::Value* src, uint32_t srcAlign, llvm::Value* sz) {
+#if LLVM_VERSION_MAJOR == 3 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 5 || LLVM_VERSION_MAJOR == 6
+  (void)dstAlign;
+  return b->CreateMemCpy(dst, src, sz, srcAlign);
+#elif LLVM_VERSION_MAJOR == 8
+  return b->CreateMemCpy(dst, dstAlign, src, srcAlign, sz);
+#endif
+}
+
+inline llvm::Value* memCopy(llvm::IRBuilder<>* b, llvm::Value* dst, uint32_t dstAlign, llvm::Value* src, uint32_t srcAlign, unsigned int sz) {
+  return memCopy(b, dst, dstAlign, src, srcAlign, civalue(sz));
+}
+
 inline Constants mergePadding(const Constants& cs, const Record::Members& ms) {
   Constants r;
   size_t i = 0;
@@ -478,7 +492,7 @@ inline llvm::Value* structOffset(llvm::IRBuilder<>* b, llvm::Value* p, unsigned 
 #endif
 }
 
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
 inline llvm::ExecutionEngine* makeExecutionEngine(llvm::Module* m, llvm::SectionMemoryManager* smm) {
   std::string err;
   llvm::ExecutionEngine* ee =

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -11,7 +11,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if LLVM_VERSION_MAJOR != 3 && LLVM_VERSION_MAJOR != 4 && LLVM_VERSION_MAJOR != 6 && LLVM_VERSION_MAJOR != 8
+#if LLVM_VERSION_MAJOR != 3 && LLVM_VERSION_MAJOR != 4 && LLVM_VERSION_MAJOR != 6 && LLVM_VERSION_MAJOR != 8 && LLVM_VERSION_MAJOR != 9 && LLVM_VERSION_MAJOR != 10 && LLVM_VERSION_MAJOR != 11
 #error "I don't know how to use this version of LLVM"
 #endif
 
@@ -29,11 +29,14 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/Signals.h>
-#if LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
-#include <llvm/Bitcode/BitstreamReader.h>
-#include <llvm/Bitcode/BitstreamWriter.h>
+#if LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR <= 8 
+#  include <llvm/Bitcode/BitstreamReader.h>
+#  include <llvm/Bitcode/BitstreamWriter.h>
+#elif  LLVM_VERSION_MAJOR <= 11
+#  include <llvm/Bitstream/BitstreamReader.h>
+#  include <llvm/Bitstream/BitstreamWriter.h>
 #else
-#include <llvm/Bitcode/ReaderWriter.h>
+#  include <llvm/Bitcode/ReaderWriter.h>
 #endif
 
 #include <llvm/Support/raw_os_ostream.h>
@@ -42,13 +45,13 @@
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 
 #if LLVM_VERSION_MINOR == 3
-#include <llvm/Analysis/Verifier.h>
-#include <llvm/PassManager.h>
-#elif LLVM_VERSION_MINOR >= 5 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
-#include <llvm/IR/Verifier.h>
-#include <llvm/ExecutionEngine/SectionMemoryManager.h>
-#include <llvm/IR/LegacyPassManager.h>
-#include <llvm/Object/ELFObjectFile.h>
+#  include <llvm/Analysis/Verifier.h>
+#  include <llvm/PassManager.h>
+#elif LLVM_VERSION_MINOR >= 5 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
+#  include <llvm/IR/Verifier.h>
+#  include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#  include <llvm/IR/LegacyPassManager.h>
+#  include <llvm/Object/ELFObjectFile.h>
 #endif
 
 #pragma GCC diagnostic pop
@@ -257,7 +260,11 @@ typedef std::vector<ConstFieldValue>            ConstRecordValue;
 
 // add any standard settings to global variables that we need
 inline llvm::GlobalVariable* prepgv(llvm::GlobalVariable* gv, unsigned int align = sizeof(void*)) {
+#if LLVM_VERSION_MAJOR >= 10
+  gv->setAlignment(llvm::MaybeAlign(align));
+#else  
   gv->setAlignment(align);
+#endif
   return gv;
 }
 
@@ -360,11 +367,13 @@ inline llvm::Constant* padding(size_t len) {
 }
 
 inline llvm::Value* memCopy(llvm::IRBuilder<>* b, llvm::Value* dst, uint32_t dstAlign, llvm::Value* src, uint32_t srcAlign, llvm::Value* sz) {
-#if LLVM_VERSION_MAJOR == 3 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 5 || LLVM_VERSION_MAJOR == 6
+#if LLVM_VERSION_MAJOR == 3 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 5 || LLVM_VERSION_MAJOR <= 6
   (void)dstAlign;
   return b->CreateMemCpy(dst, src, sz, srcAlign);
-#elif LLVM_VERSION_MAJOR == 8
+#elif LLVM_VERSION_MAJOR <= 9
   return b->CreateMemCpy(dst, dstAlign, src, srcAlign, sz);
+#elif LLVM_VERSION_MAJOR <= 11
+  return b->CreateMemCpy(dst, llvm::MaybeAlign(dstAlign), src, llvm::MaybeAlign(srcAlign), sz);
 #endif
 }
 
@@ -492,7 +501,7 @@ inline llvm::Value* structOffset(llvm::IRBuilder<>* b, llvm::Value* p, unsigned 
 #endif
 }
 
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
 inline llvm::ExecutionEngine* makeExecutionEngine(llvm::Module* m, llvm::SectionMemoryManager* smm) {
   std::string err;
   llvm::ExecutionEngine* ee =
@@ -561,7 +570,7 @@ inline llvm::Function* cloneFunction(llvm::Function *f, llvm::Module *targetMod)
 }
 
 inline llvm::Value* fncall(llvm::IRBuilder<>* b, llvm::Value* vfn, const Values& args) {
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR <= 6
   llvm::Module* thisMod = b->GetInsertBlock()->getParent()->getParent();
 
   llvm::Function* fn = llvm::dyn_cast<llvm::Function>(vfn);
@@ -574,8 +583,15 @@ inline llvm::Value* fncall(llvm::IRBuilder<>* b, llvm::Value* vfn, const Values&
       return b->CreateCall(newF, args);
     return b->CreateCall(externDecl(fn, thisMod), args);
   }
-#else
+#elif LLVM_VERSION_MAJOR <= 10
   return b->CreateCall(vfn, args);
+#elif LLVM_VERSION_MAJOR <= 11
+  if (auto *fn = llvm::dyn_cast<llvm::Function>(vfn)) {
+      return b->CreateCall(fn->getFunctionType(), fn, args);
+  } else {
+    throw std::runtime_error("fncall(...) invoked on non-function type (internal error)");
+  }
+  return nullptr;
 #endif
 }
 

--- a/lib/hobbes/db/bindings.C
+++ b/lib/hobbes/db/bindings.C
@@ -232,7 +232,7 @@ class dbstoreVF : public op {
     }
 
     if (isLargeType(sty)) {
-      return c->builder()->CreateMemCpy(allocv, outv, sizeOf(sty), 8);
+      return memCopy(c->builder(), allocv, 8, outv, 8, sizeOf(sty));
     } else {
       return c->builder()->CreateStore(outv, allocv);
     }
@@ -458,7 +458,7 @@ struct dbstoreF : public op {
 
       if (!isUnit(tys[0])) {
         llvm::Value* p = fncall(c->builder(), dblf, list<llvm::Value*>(db, id, cvalue(static_cast<long>(sz))));
-        c->builder()->CreateMemCpy(p, c->builder()->CreateBitCast(v, ptrType(charType())), sz, 8);
+        memCopy(c->builder(), p, 8, c->builder()->CreateBitCast(v, ptrType(charType())), 8, sz);
       }
 
       return id;
@@ -492,7 +492,7 @@ struct dbstorePF : public op {
 
       if (!isUnit(tys[1])) {
         llvm::Value* p = fncall(c->builder(), dblf, list<llvm::Value*>(db, id, cvalue(static_cast<long>(sz))));
-        c->builder()->CreateMemCpy(p, c->builder()->CreateBitCast(v, ptrType(charType())), sz, 8);
+        memCopy(c->builder(), p, 8, c->builder()->CreateBitCast(v, ptrType(charType())), 8, sz);
       }
 
       return id;

--- a/lib/hobbes/eval/cexpr.C
+++ b/lib/hobbes/eval/cexpr.C
@@ -156,7 +156,7 @@ public:
       llvm::Value* rhs = compile(v->right());
 
       if (isLargeType(rty)) {
-        builder()->CreateMemCpy(lhs, rhs, sizeOf(rty), 8);
+        memCopy(builder(), lhs, 8, rhs, 8, sizeOf(rty));
       } else {
         builder()->CreateStore(rhs, lhs);
       }
@@ -197,7 +197,7 @@ public:
 
           // we only memcopy into an array if the data is large and isn't an opaque pointer (always write opaque pointers as pointers)
           if (!isStoredPtr && isLargeType(aty->type())) {
-            builder()->CreateMemCpy(ap, ev, sizeOf(aty->type()), 8);
+            memCopy(builder(), ap, 8, ev, 8, sizeOf(aty->type()));
           } else {
             builder()->CreateStore(ev, ap);
           }
@@ -225,7 +225,7 @@ public:
     llvm::Value* pp    = offset(builder(), p, vty->payloadOffset());
 
     if (isLargeType(valty)) {
-      builder()->CreateMemCpy(pp, tv, sizeOf(valty), 8);
+      memCopy(builder(), pp, 8, tv, 8, sizeOf(valty));
     } else if (isUnit(valty)) {
       // don't store unit values
     } else {
@@ -260,7 +260,7 @@ public:
         MonoTypePtr  fty = rty->member(rv->first);
 
         if (isLargeType(fty)) {
-          builder()->CreateMemCpy(fp, fv, sizeOf(fty), 8);
+          memCopy(builder(), fp, 8, fv, 8, sizeOf(fty));
         } else {
           builder()->CreateStore(fv, fp);
         }

--- a/lib/hobbes/eval/cmodule.C
+++ b/lib/hobbes/eval/cmodule.C
@@ -8,6 +8,7 @@
 #include <hobbes/util/str.H>
 #include <hobbes/util/array.H>
 #include <stdexcept>
+#include <deque>
 #include <dlfcn.h>
 #include <glob.h>
 

--- a/lib/hobbes/eval/func.C
+++ b/lib/hobbes/eval/func.C
@@ -315,8 +315,8 @@ public:
       long elemSize = is<OpaquePtr>(aty->type()) ? sizeof(void*) : static_cast<long>(sizeOf(aty->type()));
 
       llvm::Value* od = structOffset(c->builder(), cmdata, 1);
-      c->builder()->CreateMemCpy(offset(c->builder(), od, 0),  d0, c->builder()->CreateMul(c0, cvalue(elemSize)), 8);
-      c->builder()->CreateMemCpy(offset(c->builder(), od, c0), d1, c->builder()->CreateMul(c1, cvalue(elemSize)), 8);
+      memCopy(c->builder(), offset(c->builder(), od, 0), 8, d0, 8, c->builder()->CreateMul(c0, cvalue(elemSize)));
+      memCopy(c->builder(), offset(c->builder(), od, c0), 8, d1, 8, c->builder()->CreateMul(c1, cvalue(elemSize)));
     }
     return cmdata;
   }
@@ -412,7 +412,7 @@ class saacopy : public op {
     llvm::Value* len  = c->compile(es[2]);
     llvm::Value* lenb = c->builder()->CreateMul(len, cvalue(static_cast<long>(sizeOf(aty->type()))));
 
-    c->builder()->CreateMemCpy(farr, vard, lenb, 8);
+    memCopy(c->builder(), farr, 8, vard, 8, lenb);
     return cvalue(true);
   }
 

--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -32,7 +32,7 @@ namespace hobbes {
 // this should be moved out of here eventually
 bool isFileType(const MonoTypePtr&);
 
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
 class jitmm : public llvm::SectionMemoryManager {
 public:
   jitmm(jitcc* jit) : jit(jit) { }
@@ -99,7 +99,7 @@ jitcc::jitcc(const TEnvPtr& tenv) :
   this->fpm->doInitialization();
 #endif
 
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
   this->mpm = new llvm::legacy::PassManager();
   this->mpm->add(llvm::createFunctionInliningPass());
 #endif
@@ -112,7 +112,7 @@ jitcc::~jitcc() {
   }
 
   // release LLVM resources
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
   for (auto ee : this->eengines) {
     delete ee;
   }
@@ -148,7 +148,7 @@ void* jitcc::getSymbolAddress(const std::string& vn) {
   }
 
   // do we have a compiled function with this name?
-#if LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
   for (auto ee : this->eengines) {
     if (ee->FindFunctionNamed(vn) || ee->FindGlobalVariableNamed(vn)) {
       if (uint64_t faddr = ee->getFunctionAddress(vn)) {
@@ -170,7 +170,7 @@ void* jitcc::getSymbolAddress(const std::string& vn) {
 
 void jitcc::dump() const {
   for (auto m : this->modules) {
-#if LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
     m->print(llvm::dbgs(), nullptr, /*ShouldPreserveUseListOrder=*/false, /*IsForDebug=*/true);
 #else
     m->dump();
@@ -179,7 +179,7 @@ void jitcc::dump() const {
 }
 
 void* jitcc::getMachineCode(llvm::Function* f, llvm::JITEventListener* listener) {
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
   // try to get the machine code for this function out of an existing compiled module
   for (auto ee : this->eengines) {
     if (void* pf = ee->getPointerToFunction(f)) {
@@ -212,13 +212,13 @@ void* jitcc::getMachineCode(llvm::Function* f, llvm::JITEventListener* listener)
 #else // LLVM_VERSION_MINOR >= 8
   this->currentModule->setDataLayout(ee->getDataLayout());
 #endif
-#if LLVM_VERSION_MAJOR == 8
+#if LLVM_VERSION_MAJOR >= 8
   // todo: smunix: what do we substitute this with?
 #else
   fpm.add(llvm::createInstructionCombiningPass());
 #endif
   fpm.add(llvm::createReassociatePass());
-#if LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR == 8  
+#if LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
   fpm.add(llvm::createNewGVNPass());
 #else
   fpm.add(llvm::createGVNPass());
@@ -276,7 +276,7 @@ void* jitcc::getMachineCode(llvm::Function* f, llvm::JITEventListener* listener)
 #endif
 }
 
-#if LLVM_VERSION_MINOR >= 7 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6
+#if LLVM_VERSION_MINOR >= 7 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
 // get the machine code produced for a given expression
 // (there must be a simpler way)
 class LenWatch : public llvm::JITEventListener {
@@ -410,17 +410,16 @@ void jitcc::bindGlobal(const std::string& vn, const MonoTypePtr& ty, void* x) {
       g.value = p;
     }
 
-    g.ref.var =
-      new llvm::GlobalVariable(
-        *module(),
-        toLLVM(ty, true),
-        false,
-        llvm::GlobalValue::ExternalLinkage,
-        0,
-        vn
-      );
-    g.ref.var->setAlignment(sizeof(void*));
-
+    g.ref.var = prepgv(new llvm::GlobalVariable(
+                         *module(),
+                         toLLVM(ty, true),
+                         false,
+                         llvm::GlobalValue::ExternalLinkage,
+                         0,
+                         vn
+                       ),
+                       sizeof(void*));
+    
 #if LLVM_VERSION_MINOR == 3 or LLVM_VERSION_MINOR == 5
   this->eengine->addGlobalMapping(g.ref.var, g.value);
 #endif
@@ -468,9 +467,14 @@ llvm::GlobalVariable* jitcc::refGlobal(const std::string& vn, llvm::GlobalVariab
   } else if (llvm::GlobalVariable* rgv = mod->getGlobalVariable(vn)) {
     return rgv;
   } else {
-    auto ret = new llvm::GlobalVariable(*mod, gv->getType()->getElementType(), gv->isConstant(), llvm::GlobalVariable::ExternalLinkage, 0, vn);
-    ret->setAlignment(sizeof(void*));
-    return ret;
+    return prepgv(new llvm::GlobalVariable(
+                    *mod,
+                    gv->getType()->getElementType(),
+                    gv->isConstant(),
+                    llvm::GlobalVariable::ExternalLinkage,
+                    0,
+                    vn),
+                  sizeof(void*));
   }
 }
 

--- a/test/Hog.C
+++ b/test/Hog.C
@@ -737,6 +737,7 @@ DEFINE_STORAGE_GROUP(
 );
 
 /// The same test sequence as above except for running hog as batchsend/batchrecv modes
+#if 1 // issues -> https://git.io/JLpCq
 TEST(Hog, OrderedSender) {
   HogApp batchrecv(RunMode(availablePort(10000, 10100), /* consolidate */ true));
   HogApp batchsend(RunMode{{"TestOrderedSend"}, {batchrecv.localport()}, 1024, 1000000});
@@ -782,6 +783,7 @@ TEST(Hog, OrderedSender) {
   EXPECT_TRUE(cc.compileFn<bool()>("[x.0|x<-f.seq, x.0 in [1,3]][:0] == concat([repeat(x, 1024L)|x<-[1,3]])")());
   EXPECT_TRUE(cc.compileFn<bool()>("[x.0|x<-f.seq, x.0 in [2,3]][:0] == concat([repeat(x, 1024L)|x<-[2,3]])")());
 }
+#endif // https://git.io/JLpCq
 
 DEFINE_STORAGE_GROUP(
   TestBatchSendRestart,


### PR DESCRIPTION
Supported versions are:

```sh
└───packages
    ├───x86_64-darwin
    │   ├───hobbes-llvm-10: package 'hobbes-llvm-10-20210109.02dc46f'
    │   ├───hobbes-llvm-6: package 'hobbes-llvm-6-20210109.02dc46f'
    │   ├───hobbes-llvm-8: package 'hobbes-llvm-8-20210109.02dc46f'
    │   └───hobbes-llvm-9: package 'hobbes-llvm-9-20210109.02dc46f'
    └───x86_64-linux
        ├───hobbes-llvm-10: package 'hobbes-llvm-10-20210109.02dc46f'
        ├───hobbes-llvm-6: package 'hobbes-llvm-6-20210109.02dc46f'
        ├───hobbes-llvm-8: package 'hobbes-llvm-8-20210109.02dc46f'
        └───hobbes-llvm-9: package 'hobbes-llvm-9-20210109.02dc46f'

```