### PR TITLE
clang: build on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,111 +5,159 @@ env:
 matrix:
   include:
     - os: linux
-      compiler: g++
+      compiler: clang
       language: nix
-      nix: 2.3.6
-      group: deprecated-2017Q4
-      name: hobbesPackages.llvm-6.hobbes
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.clang-6.hobbes
       env:
-        - HOBBES_DRV=hobbesPackages.llvm-6.hobbes
-      script: nix-build -A $HOBBES_DRV
+        - HOBBES_DRV=hobbesPackages.clang-6.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
 
-    - os: linux
-      compiler: g++
-      language: nix
-      nix: 2.3.6
-      group: deprecated-2017Q4
-      name: hobbesPackages.llvm-8.hobbes
-      env:
-        - HOBBES_DRV=hobbesPackages.llvm-8.hobbes
-      script: nix-build -A $HOBBES_DRV
-
-    - os: linux
-      compiler: g++
-      language: nix
-      nix: 2.3.6
-      group: deprecated-2017Q4
-      name: hobbesPackages.llvm-9.hobbes
-      env:
-        - HOBBES_DRV=hobbesPackages.llvm-9.hobbes
-      script: nix-build -A $HOBBES_DRV
-
-    - os: linux
-      compiler: g++
-      language: nix
-      nix: 2.3.6
-      group: deprecated-2017Q4
-      name: hobbesPackages.llvm-10.hobbes
-      env:
-        - HOBBES_DRV=hobbesPackages.llvm-10.hobbes
-      script: nix-build -A $HOBBES_DRV
-
-    - os: linux
-      compiler: g++
-      language: nix
-      nix: 2.3.6
-      group: deprecated-2017Q4
-      name: hobbesPackages.llvm-11.hobbes
-      env:
-        - HOBBES_DRV=hobbesPackages.llvm-11.hobbes
-      script: nix-build -A $HOBBES_DRV
-
-    # Temporarilly disable osx => https://git.io/JLp7U
     # - os: osx
+    #   osx_image: xcode10.12 # 12.12
     #   compiler: clang
-    #   osx_image: xcode9.4
+    #   language: nix
+    #   nix: 2.3.10
+    #   group: edge
+    #   name: hobbesPackages.clang-6.hobbes
     #   env:
-    #     - DEPS="${DEPS} readline llvm@6"
-    #     - LLVM_DIR=/usr/local/opt/llvm@6/lib/cmake/llvm/
-    #     - ARGS=-V
-        
-    - os: linux
-      compiler: g++
-      root: required
-      dist: trusty
-      group: deprecated-2017Q4
-      services:
-        - docker
-      name: hobbes-llvm-6.0-dev
-      env:
-        - DIST=xenial
-        - DEPS="llvm-6.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
-        - ARGS=-V
-        
-    - os: linux
-      compiler: g++
-      root: required
-      dist: trusty
-      group: deprecated-2017Q4
-      services:
-        - docker
-      name: hobbes-llvm-4.0-dev
-      env:
-        - DIST=xenial
-        - DEPS="llvm-4.0-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
-        - ARGS=-V
-    
-    - os: linux
-      compiler: g++
-      root: required
-      dist: trusty
-      group: deprecated-2017Q4
-      services:
-        - docker
-      name: hobbes-llvm-3.7-dev
-      env:
-        - DIST=xenial
-        - DEPS="llvm-3.7-dev cmake libedit-dev g++ libncurses5-dev zlib1g-dev libreadline-dev python2.7"
-        - ARGS=-V
-        
-install:
-  - if [ $TRAVIS_OS_NAME = osx   ]; then brew update && brew install -v ${DEPS} && find /usr/local/opt/llvm@6/ | grep cmake; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then cd docker/build && docker build . -f ./${DIST}.Dockerfile -t hobbes:build --build-arg DEPS; cd -; fi
+    #     - HOBBES_DRV=hobbesPackages.clang-6.hobbes
+    #   script: travis_wait 40 nix-build -A $HOBBES_DRV
 
-script:
-  - if [ $TRAVIS_OS_NAME = osx   ]; then mkdir build && cd build/ && cmake .. && make && make test; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then docker run -it -v ${PWD}:/src hobbes:build; fi
+    - os: linux
+      compiler: clang
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.clang-8.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.clang-8.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
 
+    - os: linux
+      compiler: g++
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.gcc-8.llvm-8.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.gcc-8.llvm-8.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    # - os: osx
+    #   osx_image: xcode12.2 # 12.12
+    #   compiler: clang
+    #   language: nix
+    #   nix: 2.3.10
+    #   group: edge
+    #   name: hobbesPackages.clang-8.hobbes
+    #   env:
+    #     - HOBBES_DRV=hobbesPackages.clang-8.hobbes
+    #   script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    - os: linux
+      compiler: clang
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.clang-9.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.clang-9.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    - os: linux
+      compiler: g++
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.gcc-9.llvm-9.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.gcc-9.llvm-9.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    # - os: osx
+    #   osx_image: xcode12.2 # 12.12
+    #   compiler: clang
+    #   language: nix
+    #   nix: 2.3.10
+    #   group: edge
+    #   name: hobbesPackages.clang-9.hobbes
+    #   env:
+    #     - HOBBES_DRV=hobbesPackages.clang-9.hobbes
+    #   script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    - os: linux
+      compiler: clang
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.clang-10.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.clang-10.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    - os: linux
+      compiler: g++
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.gcc-10.llvm-10.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.gcc-10.llvm-10.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    # - os: osx
+    #   osx_image: xcode12.2 # 12.12
+    #   compiler: clang
+    #   language: nix
+    #   nix: 2.3.10
+    #   group: edge
+    #   name: hobbesPackages.clang-10.hobbes
+    #   env:
+    #     - HOBBES_DRV=hobbesPackages.clang-10.hobbes
+    #   script: travis_wait 40 nix-build -A $HOBBES_DRV
+      
+    - os: linux
+      compiler: clang
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.clang-11.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.clang-11.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    - os: linux
+      compiler: g++
+      language: nix
+      nix: 2.3.10
+      group: edge
+      dist: focal
+      name: hobbesPackages.gcc-10.llvm-11.hobbes
+      env:
+        - HOBBES_DRV=hobbesPackages.gcc-10.llvm-11.hobbes
+      script: travis_wait 40 nix-build -A $HOBBES_DRV
+
+    # - os: osx
+    #   osx_image: xcode12.2 # 12.12
+    #   compiler: clang
+    #   language: nix
+    #   nix: 2.3.10
+    #   group: edge
+    #   name: hobbesPackages.clang-11.hobbes
+    #   env:
+    #     - HOBBES_DRV=hobbesPackages.clang-11.hobbes
+    #   script: travis_wait 40 nix-build -A $HOBBES_DRV
+        
 branches:
   only:
     - master

--- a/bin/hi/evaluator.C
+++ b/bin/hi/evaluator.C
@@ -183,7 +183,7 @@ void evaluator::printTypeOf(const std::string& expr, bool showHiddenTCs) {
 void evaluator::printTypeEnv() {
   std::cout << setfgc(colors.typefg);
   if (std::find(opts.begin(), opts.end(), "Safe") != std::end(opts)) {
-    this->ctx.dumpTypeEnv([this](std::string const& binding) -> std::string const& {
+    this->ctx.dumpTypeEnv([](std::string const& binding) -> std::string const& {
       return hobbes::SafeSet::get(binding);
     });
     return; 

--- a/bin/hi/www.C
+++ b/bin/hi/www.C
@@ -263,7 +263,7 @@ const cstr* jsEscape(const cstr* x) {
 }
 
 // the basic hi web server
-WWWServer::WWWServer(int port, hobbes::cc* c) : port(port), c(c) {
+WWWServer::WWWServer(int port, hobbes::cc* c) : c(c) {
   // add a few bindings that are convenient for web servers
   c->bind("linkTarget",   &linkTarget);
   c->bind("csplit",       &csplit);

--- a/bin/hi/www.H
+++ b/bin/hi/www.H
@@ -13,7 +13,6 @@ public:
   WWWServer(int port, hobbes::cc*);
   ~WWWServer();
 private:
-  int         port;
   hobbes::cc* c;
 
   void printDefaultPage(int);

--- a/bin/hog/batchsend.C
+++ b/bin/hog/batchsend.C
@@ -335,7 +335,7 @@ struct BatchSendSession {
   }
 
   bool completed() const {
-    return std::all_of(destinations.begin(), destinations.end(), [this](const Destination& d) {
+    return std::all_of(destinations.begin(), destinations.end(), [](const Destination& d) {
       glob_t g;
       auto ret = glob((d.localdir + "/segment-*.gz").c_str(), GLOB_NOSORT, 0, &g);
       if (ret == 0) {

--- a/default.nix
+++ b/default.nix
@@ -1,53 +1,26 @@
-{ pkgs ? import (fetchTarball { url="https://github.com/NixOs/nixpkgs/archive/a3ab47ec9067b5f9fccda506fc8641484c3d8e73.tar.gz";
-                                sha256="1f1q89ka73ksvl5hgbrf624x0niwm2rg3dzxiscir0bji6zvjy15";
-                              }) {},
+{ nixpkgs ? import (fetchTarball { url="https://github.com/NixOs/nixpkgs/archive/a3ab47ec9067b5f9fccda506fc8641484c3d8e73.tar.gz";
+                                   sha256="1f1q89ka73ksvl5hgbrf624x0niwm2rg3dzxiscir0bji6zvjy15";
+                                 }),
 }:
 let
-  commonBuildInputs = with pkgs; [
-    ncurses
-    python27
-    readline
-    zlib
+  overlays = [
+    (import ./nix/overlays.nix {
+      version = "unstable";
+      src = ./.;
+      llvmVersions = [ 6 8 9 10 11 ];
+      gccConstraints = [
+        { gccVersion = 6; llvmVersions = [ 6 8 9 ]; }
+        { gccVersion = 8; llvmVersions = [ 6 8 9 10 11 ]; }
+        { gccVersion = 9; llvmVersions = [ 6 8 9 10 11 ]; }
+        { gccVersion = 10; llvmVersions = [ 6 8 9 10 11 ]; }
+      ];
+    })
   ];
-  commonNativeInputs = with pkgs; [
-    ccls
-    cmake
-    ninja
-    meson
-    python27
-  ];
-  src = ./.;
-  doCheck = true;
-  checkTarget = "test";
-  llvmSupportVersions = [ 6 8 9 10 11 ];
-  hobbesDrv = with pkgs;
-    makeOverridable ({ version,
-                       pks ? pkgs,
-                       stdenv ? pks.stdenv,
-                       gcc ? pks.gcc10
-                     }: stdenv.mkDerivation {
-                       pname = "hobbes-llvm-" + (builtins.toString version);
-                       version = "unstable";
-                       inherit
-                         src
-                         doCheck
-                         checkTarget;
-                       nativeBuildInputs = commonNativeInputs ++ [ gcc ];
-                       buildInputs = commonBuildInputs ++ [ (builtins.getAttr ("llvm_" + (builtins.toString version)) pkgs) ];
-                       postPatch = ''
-                         substituteInPlace CMakeLists.txt \
-                         --replace "\''${CMAKE_SOURCE_DIR}" "${src}"
-                       '';
-                     });
-in with pkgs; recurseIntoAttrs (rec {
-  hobbesPackages = recurseIntoAttrs (builtins.listToAttrs (builtins.map (version: {
-    name = "llvm-" + (toString version);
-    value = recurseIntoAttrs {
-      hobbes = callPackage hobbesDrv {
-        inherit
-          version;
-      };
-    };
-  }) llvmSupportVersions));
-  hobbes = callPackage hobbesPackages.llvm-6.hobbes.override { gcc = gcc8; };
-})
+  
+  pkgs = nixpkgs {
+    inherit overlays;
+  };
+in with pkgs; recurseIntoAttrs {
+  inherit hobbesPackages;
+  inherit (hobbesPackages.gcc-8.llvm-6) hobbes;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,63 +6,20 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
       let
-        # LLVM supported versions
-        llvmSupportedVersions = [ 6 8 9 10 11 ];
-        
-        debug = false;
-        
-        version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
-        
         overlays = [
-          (final: prev:
-            with final;
-            let
-              dbg = if debug == true
-                    then enableDebugging
-                    else (x: x);
-              
-              src = self;
-              
-              nativeBuildInputs = [ cmake ninja python27 ];
-              
-              buildInputs = [ ncurses readline zlib python27 ];
-              
-              doCheck = true;
-              
-              doTarget = "test";
-              
-              dontStrip = debug;
-              
-              separateDebugInfo = debug;
-              
-              meta = with stdenv.lib; {
-                description = "A language and an embedded JIT compiler";
-                longDescription = ''
-                  Hobbes is a language, embedded compiler, and runtime for efficient
-                  dynamic expression evalution, data storage and analysis.
-                '';
-                license = licenses.asl20;
-                maintainers = with maintainers; [ kthielen thmzlt smunix ];
-              };
-              
-              withLLVM = makeOverridable ({ v, stdenv ? final.stdenv, gcc ? final.gcc } : stdenv.mkDerivation {
-                pname = "hobbes-llvm-" + (toString v);
-                inherit version src meta doCheck doTarget dontStrip;
-                nativeBuildInputs = nativeBuildInputs ++ [ gcc ];
-                buildInputs = buildInputs ++ [ (builtins.getAttr ("llvm_" + (toString v)) final) ];
-                postPatch = ''
-                  substituteInPlace CMakeLists.txt \
-                     --replace "\''${CMAKE_SOURCE_DIR}" "${src}"
-                '';
-              });
-            in { hobbesPackages = recurseIntoAttrs (builtins.listToAttrs (
-                   builtins.map
-                     (v: { name="llvm-" + toString v;
-                           value = recurseIntoAttrs ({ hobbes = dbg (callPackage withLLVM { inherit v; gcc = gcc10; }); });
-                         })
-                     llvmSupportedVersions));
-               })
+          (import ./nix/overlays.nix {
+            version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
+            src = self;
+            llvmVersions = [ 6 8 9 10 11 ];
+            gccConstraints = [
+              { gccVersion = 6; llvmVersions = [ 6 8 9 ]; }
+              { gccVersion = 8; llvmVersions = [ 6 8 9 10 11 ]; }
+              { gccVersion = 9; llvmVersions = [ 6 8 9 10 11 ]; }
+              { gccVersion = 10; llvmVersions = [ 6 8 9 10 11 ]; }
+            ];
+          })
         ];
+        
         pkgs = import nixpkgs {
           inherit system overlays;
         };
@@ -71,6 +28,6 @@
           packages = flake-utils.lib.flattenTree (pkgs.recurseIntoAttrs {
             inherit (pkgs) hobbesPackages;
           });
-          defaultPackage = packages."hobbesPackages/llvm-6/hobbes";
+          defaultPackage = packages."hobbesPackages/clang-8/hobbes";
         });
 }

--- a/include/hobbes/db/cbindings.H
+++ b/include/hobbes/db/cbindings.H
@@ -11,7 +11,7 @@
 
 namespace hobbes {
 
-class DynDModel0;
+struct DynDModel0;
 
 class UCWriter {
 public:

--- a/include/hobbes/db/series.H
+++ b/include/hobbes/db/series.H
@@ -112,7 +112,6 @@ private:
   UCWriter    w;
   uint8_t*    dynModel;
   region      dynModelMem;
-  size_t      regionID;
 
   CWriteFn    writeFn;
   CAllocM     allocMFn;

--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -326,7 +326,7 @@ private:
 
 template <typename T>
   struct rccF {
-    static T compile(cc* c, const str::seq& vns, const std::string& expr) {
+    static T compile(cc*, const str::seq&, const std::string&) {
       throw std::runtime_error("Internal error, unsupported compilation target type");
     }
   };

--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -112,7 +112,7 @@ typedef std::vector<pagedata> pagetable;
 typedef uint64_t file_pageindex_t;
 
 // convenience for raising errors out of errno
-inline void raiseSysError(const std::string& msg, const std::string& fname) {
+inline void raiseSysError [[noreturn]] (const std::string& msg, const std::string& fname) {
   std::ostringstream ss;
   ss << fname << ": " << msg << " (" << strerror(errno) << ")" << std::flush;
   throw std::runtime_error(ss.str());
@@ -1011,7 +1011,7 @@ template <typename T>
     uint64_t index;
     bool operator==(const fileref<T>& rhs) const { return this->index == rhs.index; }
 
-    fileref<T>& operator=(const fileref<T>& x) { this->index = x.index; return *this; }
+    fileref<T>& operator=(const fileref<T>&) = default;
 
     T* load(imagefile* f) const {
       return reinterpret_cast<T*>(mapFileData(f, this->index, sizeof(T)));
@@ -1652,9 +1652,9 @@ struct printVF {
   std::ostringstream* ss;
   printVF(std::ostringstream* ss) : ss(ss) { }
   template <typename T>
-    void visit(const char* n, int, const T& x) {
-      *this->ss << n << "=" << x;
-    }
+  void visit(const char* n, int, const T& x) {
+    *this->ss << n << "=" << x;
+  }
 };
 template <typename T>
   inline std::string showV(const T& x) {
@@ -1671,9 +1671,9 @@ struct descVariantF {
   descVariantF(ty::Variant::Ctors* ctors) : ctors(ctors) { }
 
   template <typename T>
-    void ctor(const char* n, int id) {
-      this->ctors->push_back(ty::Variant::Ctor(n, id, store<T>::storeType()));
-    }
+  void ctor(const char* n, int id) {
+    this->ctors->push_back(ty::Variant::Ctor(n, id, store<T>::storeType()));
+  }
 };
 
 struct calcVSizeF {
@@ -1682,10 +1682,10 @@ struct calcVSizeF {
   calcVSizeF(size_t* maxSize, size_t* maxAlign) : maxSize(maxSize), maxAlign(maxAlign) { *this->maxSize = 0; *this->maxAlign = sizeof(uint32_t); }
 
   template <typename T>
-    void ctor(const char* n, int id) {
-      *this->maxSize  = std::max<size_t>(*this->maxSize,  store<T>::size());
-      *this->maxAlign = std::max<size_t>(*this->maxAlign, store<T>::alignment());
-    }
+  void ctor(const char*, int) {
+    *this->maxSize  = std::max<size_t>(*this->maxSize,  store<T>::size());
+    *this->maxAlign = std::max<size_t>(*this->maxAlign, store<T>::alignment());
+  }
 };
 
 template <typename T>
@@ -1901,7 +1901,7 @@ template <typename ... Wss>
   struct seqVar {
     static void stepEnc(ty::Variant::Ctors*, size_t*, const Wss& ...) { }
     static ty::desc storeType(imagefile*, const Wss& ...) { return ty::prim("unit"); }
-    static void setWriteCBs(uint32_t, const std::function<void(uint32_t,uint64_t)>&, Wss& ... wss) { }
+    static void setWriteCBs(uint32_t, const std::function<void(uint32_t,uint64_t)>&, Wss& ...) { }
   };
 template <typename Ws, typename ... Wss>
   struct seqVar<Ws, Wss...> {

--- a/include/hobbes/ipc/procman.H
+++ b/include/hobbes/ipc/procman.H
@@ -19,7 +19,7 @@ public:
   ExprPtr unqualify(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*) const;
   std::string name() const;
 private:
-  friend class ProcManUnqualify;
+  friend struct ProcManUnqualify;
 
   typedef std::map<std::string, proc> SpawnedProcs;
   SpawnedProcs procs;

--- a/include/hobbes/lang/pat/dfa.H
+++ b/include/hobbes/lang/pat/dfa.H
@@ -22,6 +22,7 @@ typedef std::vector<PrimFArg> PrimFArgs;
 // the various states of pattern matching
 class MState {
 public:
+  virtual ~MState(void) = default;  
   virtual std::string stamp() = 0;
 
   // how many times is this state referenced?
@@ -127,7 +128,8 @@ typedef std::vector<MStatePtr>  MStates;
 
 // destruction-side for high-level pattern representations
 template <typename T>
-  struct switchMState {
+struct switchMState {
+    virtual ~switchMState(void) = default;
     virtual T with(const LoadVars*)      const = 0;
     virtual T with(const SwitchVal*)     const = 0;
     virtual T with(const SwitchVariant*) const = 0;

--- a/include/hobbes/lang/pat/regex.H
+++ b/include/hobbes/lang/pat/regex.H
@@ -35,6 +35,7 @@ class cc;
  *     rstates : a mapping of F return codes to input regex indexes
  */
 struct Regex {
+  virtual ~Regex(void) = default;
   virtual void show(std::ostream&) const = 0;
 };
 typedef std::shared_ptr<Regex> RegexPtr;

--- a/include/hobbes/lang/preds/subtype.H
+++ b/include/hobbes/lang/preds/subtype.H
@@ -15,6 +15,7 @@ bool dec(const ConstraintPtr&, Subtype*);
 
 // a "subtype eliminator" knows how to resolve a "Subtype" constraint at a particular (category of) type
 struct SubtypeEliminator {
+   virtual ~SubtypeEliminator(void) = default;
   // is this instance eliminable?
   virtual bool satisfied(const TEnvPtr& tenv, const MonoTypePtr& lhs, const MonoTypePtr& rhs) const = 0;
 

--- a/include/hobbes/lang/preds/subtype/obj.H
+++ b/include/hobbes/lang/preds/subtype/obj.H
@@ -46,6 +46,7 @@ std::string show(const PtrAdjustmentPath& p);
 //  (this implementation only works with GCC)
 class Objs : public SubtypeEliminator {
 public:
+  virtual ~Objs(void) = default;
 #ifndef __clang__
   typedef __cxxabiv1::__class_type_info     class_type;
   typedef __cxxabiv1::__si_class_type_info  si_class_type;

--- a/include/hobbes/lang/tylift.H
+++ b/include/hobbes/lang/tylift.H
@@ -426,7 +426,7 @@ template <typename T>
 template <typename ... Fields>
   struct liftTuple {
     static void addFields(size_t, Record::Members*, typedb&) { }
-    static MonoTypePtr type(typedb& tenv) { return Prim::make("unit"); }
+    static MonoTypePtr type(typedb&) { return Prim::make("unit"); }
   };
 template <typename Field, typename ... Fields>
   struct liftTuple<Field, Fields...> {

--- a/include/hobbes/lang/tyunqualify.H
+++ b/include/hobbes/lang/tyunqualify.H
@@ -18,52 +18,53 @@ typedef std::vector<FunDep>    FunDeps;
 
 // if E :: T and R.satisfied(T), then R.unqualify(E)
 class Unqualifier {
-public:
-  // bind any implied type variables in a constraint
-  virtual bool refine(const TEnvPtr& tenv, const ConstraintPtr& cst, MonoTypeUnifier* u, Definitions* ds) = 0;
+  public:
+    virtual ~Unqualifier(void) {};
+    // bind any implied type variables in a constraint
+    virtual bool refine(const TEnvPtr& tenv, const ConstraintPtr& cst, MonoTypeUnifier* u, Definitions* ds) = 0;
 
-  // determine whether or not this constraint is satisfied
-  virtual bool satisfied(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const = 0;
+    // determine whether or not this constraint is satisfied
+    virtual bool satisfied(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const = 0;
 
-  // determine whether or not it's possible to satisfy this constraint
-  virtual bool satisfiable(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const = 0;
+    // determine whether or not it's possible to satisfy this constraint
+    virtual bool satisfiable(const TEnvPtr& tenv, const ConstraintPtr& cst, Definitions* ds) const = 0;
 
-  // why couldn't this constraint be eliminated?
-  virtual void explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*) = 0;
+    // why couldn't this constraint be eliminated?
+    virtual void explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*) = 0;
 
-  // resolve a qualified expression
-  virtual ExprPtr unqualify(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds) const = 0;
+    // resolve a qualified expression
+    virtual ExprPtr unqualify(const TEnvPtr& tenv, const ConstraintPtr& cst, const ExprPtr& e, Definitions* ds) const = 0;
 
-  // allow overloaded symbols (as in type classes)
-  virtual PolyTypePtr lookup(const std::string& vn) const = 0;
+    // allow overloaded symbols (as in type classes)
+    virtual PolyTypePtr lookup(const std::string& vn) const = 0;
 
-  // list overloaded symbols (if any)
-  virtual SymSet bindings() const = 0;
+    // list overloaded symbols (if any)
+    virtual SymSet bindings() const = 0;
 
-  // list functional dependencies between constraint parameters (if any)
-  virtual FunDeps dependencies(const ConstraintPtr&) const = 0;
+    // list functional dependencies between constraint parameters (if any)
+    virtual FunDeps dependencies(const ConstraintPtr&) const = 0;
 };
 typedef std::shared_ptr<Unqualifier> UnqualifierPtr;
 
 // type predicates are resolved by an assumed disjoint set of unqualifiers
 class UnqualifierSet : public Unqualifier {
-public:
-  typedef std::map<std::string, UnqualifierPtr> Unqualifiers;
+  public:
+    typedef std::map<std::string, UnqualifierPtr> Unqualifiers;
 
-  void                add(const std::string& name, const UnqualifierPtr& uq);
-  UnqualifierPtr      findUnqualifier(const std::string& name);
-  const Unqualifiers& unqualifiers() const;
+    void                add(const std::string& name, const UnqualifierPtr& uq);
+    UnqualifierPtr      findUnqualifier(const std::string& name);
+    const Unqualifiers& unqualifiers() const;
 
-  bool        refine(const TEnvPtr&,const ConstraintPtr&,MonoTypeUnifier*,Definitions*);
-  bool        satisfied(const TEnvPtr&,const ConstraintPtr&,Definitions*)                  const;
-  bool        satisfiable(const TEnvPtr&,const ConstraintPtr&,Definitions*)                const;
-  void        explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*);
-  ExprPtr     unqualify(const TEnvPtr&,const ConstraintPtr&, const ExprPtr&, Definitions*) const;
-  PolyTypePtr lookup(const std::string& vn)                                                const;
-  SymSet      bindings()                                                                   const;
-  FunDeps     dependencies(const ConstraintPtr&)                                           const;
-private:
-  Unqualifiers uqs;
+    bool        refine(const TEnvPtr&,const ConstraintPtr&,MonoTypeUnifier*,Definitions*);
+    bool        satisfied(const TEnvPtr&,const ConstraintPtr&,Definitions*)                  const;
+    bool        satisfiable(const TEnvPtr&,const ConstraintPtr&,Definitions*)                const;
+    void        explain(const TEnvPtr&, const ConstraintPtr&, const ExprPtr&, Definitions*, annmsgs*);
+    ExprPtr     unqualify(const TEnvPtr&,const ConstraintPtr&, const ExprPtr&, Definitions*) const;
+    PolyTypePtr lookup(const std::string& vn)                                                const;
+    SymSet      bindings()                                                                   const;
+    FunDeps     dependencies(const ConstraintPtr&)                                           const;
+  private:
+    Unqualifiers uqs;
 };
 typedef std::shared_ptr<UnqualifierSet> UnqualifierSetPtr;
 

--- a/include/hobbes/read/pgen/hexpr.parse.H
+++ b/include/hobbes/read/pgen/hexpr.parse.H
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.1.  */
+/* A Bison parser, made by GNU Bison 3.7.4.  */
 
 /* Bison interface for Yacc-like parsers in C
 

--- a/include/hobbes/storage.H
+++ b/include/hobbes/storage.H
@@ -1064,7 +1064,7 @@ template <typename T, size_t N>
 template <typename T, size_t N>
   struct store<T[N], typename tbool<store<T>::can_memcpy>::type> : public fixedArrTyDesc<T,N> {
     static const bool can_memcpy = true;
-    static size_t size (const T (&v)[N])           { return sizeof(T)*N; }
+    static size_t size (const T (&)[N])           { return sizeof(T)*N; }
     static bool   write(wpipe& p, const T (&v)[N]) { return p.write(reinterpret_cast<const uint8_t*>(v), sizeof(T)*N); }
   };
 template <typename T, size_t N>
@@ -1520,7 +1520,7 @@ template <>
 
 template <typename T>
   struct store<recursive<T>> {
-    static void encode(bytes* out) {
+    static void encode(bytes*) {
       return ty::recursive("x", store<T>::type());
     }
     static size_t recSize(const recursion& x) {

--- a/lib/hobbes/db/cbindings.C
+++ b/lib/hobbes/db/cbindings.C
@@ -204,7 +204,9 @@ static void destroyDynDModel0(DynDModel0* m) {
 // read a compressed series of values
 class UCReader {
 public:
-  UCReader(size_t fileRefVal, size_t node, size_t batchSize) : fileRefVal(fileRefVal), batchSize(batchSize), readState(reinterpret_cast<reader*>(fileRefVal)->fileData()) {
+  UCReader(size_t fileRefVal, size_t node, size_t /*batchSize: unused*/) :
+    fileRefVal(fileRefVal),
+    readState(reinterpret_cast<reader*>(fileRefVal)->fileData()) {
     loadReadState(node);
   }
 
@@ -264,7 +266,6 @@ public:
   }
 private:
   size_t     fileRefVal;
-  size_t     batchSize;
 
   std::queue<uint64_t> batches;
   crbitstream readState;

--- a/lib/hobbes/ipc/prepl.C
+++ b/lib/hobbes/ipc/prepl.C
@@ -441,7 +441,7 @@ void runMachineREPLStep(cc* c) {
 
 typedef std::map<int,const char*> Signames;
 static Signames rsignames;
-static void deadlySignal(int sig, siginfo_t*, void*) {
+static void deadlySignal [[noreturn]] (int sig, siginfo_t*, void*) {
   if (machineREPLLogFD > 0) {
     static const char* msg = "RECEIVED DEADLY SIGNAL: ";
     auto rc = write(machineREPLLogFD, msg, strlen(msg));

--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -379,7 +379,6 @@ str::seq bindingNames(const RegexPtr& rgx) {
  ******************************/
 typedef uint32_t state;
 typedef std::set<state> stateset;
-static const state nullState = static_cast<state>(-1);
 
 typedef uint32_t result;
 static const result nullResult = static_cast<result>(-1);

--- a/lib/hobbes/lang/preds/subtype/obj.C
+++ b/lib/hobbes/lang/preds/subtype/obj.C
@@ -12,7 +12,7 @@ void appendPath(PtrAdjustmentPath* p, const PtrAdjustmentPath& sfx);
 
 #ifdef __clang__
 // TODO -- figure out how to get class type info from clang
-bool Objs::add(const std::type_info* ti) {
+bool Objs::add(const std::type_info*) {
   return false;
 }
 

--- a/lib/hobbes/parse/data.C
+++ b/lib/hobbes/parse/data.C
@@ -5,8 +5,6 @@
 
 namespace hobbes {
 
-const bool unit = true;
-
 // map char sequence positions to line numbers
 linedb::linedb(nat stype, const std::string& sdesc) : stype(stype), sdesc(sdesc), c(0) {
 }

--- a/lib/hobbes/read/pgen/hexpr.l
+++ b/lib/hobbes/read/pgen/hexpr.l
@@ -4,6 +4,7 @@
 
 int yycolumn = 1;
 
+#define YY_NO_INPUT
 #define YY_USER_ACTION \
   yylloc.first_line = yylloc.last_line = yylineno; \
   yylloc.first_column = yycolumn; yylloc.last_column = yycolumn+yyleng-1; \

--- a/lib/hobbes/read/pgen/hexpr.lex.C
+++ b/lib/hobbes/read/pgen/hexpr.lex.C
@@ -731,6 +731,7 @@ char *yytext;
 
 int yycolumn = 1;
 
+#define YY_NO_INPUT
 #define YY_USER_ACTION \
   yylloc.first_line = yylloc.last_line = yylineno; \
   yylloc.first_column = yycolumn; yylloc.last_column = yycolumn+yyleng-1; \
@@ -788,9 +789,9 @@ std::string* identifier(const char* b, const char* e) {
     return hobbes::autorelease(new std::string(b, e));
   }
 }
-#line 791 "hexpr.lex.C"
+#line 792 "hexpr.lex.C"
 
-#line 793 "hexpr.lex.C"
+#line 794 "hexpr.lex.C"
 
 #define INITIAL 0
 #define BLOCK_COMMENT 1
@@ -977,48 +978,48 @@ extern int yylex (void);
  */
 YY_DECL
 {
-	yy_state_type yy_current_state;
-	char *yy_cp, *yy_bp;
-	int yy_act;
+    yy_state_type yy_current_state;
+    char *yy_cp, *yy_bp;
+    int yy_act;
     
-	if ( !(yy_init) )
-		{
-		(yy_init) = 1;
+    if ( !(yy_init) )
+    {
+        (yy_init) = 1;
 
 #ifdef YY_USER_INIT
-		YY_USER_INIT;
+        YY_USER_INIT;
 #endif
 
         /* Create the reject buffer large enough to save one state per allowed character. */
         if ( ! (yy_state_buf) )
             (yy_state_buf) = (yy_state_type *)yyalloc(YY_STATE_BUF_SIZE  );
-            if ( ! (yy_state_buf) )
-                YY_FATAL_ERROR( "out of dynamic memory in yylex()" );
+        if ( ! (yy_state_buf) )
+            YY_FATAL_ERROR( "out of dynamic memory in yylex()" );
 
-		if ( ! (yy_start) )
-			(yy_start) = 1;	/* first start state */
+        if ( ! (yy_start) )
+            (yy_start) = 1;     /* first start state */
 
-		if ( ! yyin )
-			yyin = stdin;
+        if ( ! yyin )
+            yyin = stdin;
 
-		if ( ! yyout )
-			yyout = stdout;
+        if ( ! yyout )
+            yyout = stdout;
 
-		if ( ! YY_CURRENT_BUFFER ) {
-			yyensure_buffer_stack ();
-			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer( yyin, YY_BUF_SIZE );
-		}
+        if ( ! YY_CURRENT_BUFFER ) {
+            yyensure_buffer_stack ();
+            YY_CURRENT_BUFFER_LVALUE =
+                yy_create_buffer( yyin, YY_BUF_SIZE );
+        }
 
-		yy_load_buffer_state(  );
-		}
+        yy_load_buffer_state(  );
+    }
 
-	{
-#line 70 "hexpr.l"
+    {
+#line 71 "hexpr.l"
 
 
 
-#line 74 "hexpr.l"
+#line 75 "hexpr.l"
   /* simulate multiple start symbols in our grammar by supporting a distinguished prefix token to switch on pseudo-start symbol productions */
   if (yyInitToken) {
     int r = yyInitToken;
@@ -1027,7 +1028,7 @@ YY_DECL
   }
 
 
-#line 1030 "hexpr.lex.C"
+#line 1031 "hexpr.lex.C"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1120,616 +1121,616 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 82 "hexpr.l"
+#line 83 "hexpr.l"
 { yycolumn = 1; }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 83 "hexpr.l"
+#line 84 "hexpr.l"
 { }
 	YY_BREAK
 case 3:
 /* rule 3 can match eol */
 YY_RULE_SETUP
-#line 84 "hexpr.l"
+#line 85 "hexpr.l"
 { yycolumn = 2; if (wantIndent()) { return TINDENT; } }
 	YY_BREAK
 case 4:
 /* rule 4 can match eol */
 YY_RULE_SETUP
-#line 85 "hexpr.l"
+#line 86 "hexpr.l"
 { yycolumn = 2; if (wantIndent()) { return TINDENT; } }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 86 "hexpr.l"
+#line 87 "hexpr.l"
 {               if (wantIndent()) { return TINDENT; } }
 	YY_BREAK
 case 6:
 /* rule 6 can match eol */
 YY_RULE_SETUP
-#line 87 "hexpr.l"
+#line 88 "hexpr.l"
 { yycolumn = 2; if (wantIndent()) { return TINDENT; } }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 88 "hexpr.l"
+#line 89 "hexpr.l"
 {               if (wantIndent()) { return TINDENT; } }
 	YY_BREAK
 case 8:
 /* rule 8 can match eol */
 YY_RULE_SETUP
-#line 89 "hexpr.l"
+#line 90 "hexpr.l"
 { yycolumn = 1; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 91 "hexpr.l"
+#line 92 "hexpr.l"
 { BEGIN(BLOCK_COMMENT); }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 92 "hexpr.l"
+#line 93 "hexpr.l"
 { BEGIN(INITIAL); }
 	YY_BREAK
 case 11:
 /* rule 11 can match eol */
 YY_RULE_SETUP
-#line 93 "hexpr.l"
+#line 94 "hexpr.l"
 { yycolumn = 1; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 94 "hexpr.l"
+#line 95 "hexpr.l"
 { }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 96 "hexpr.l"
+#line 97 "hexpr.l"
 { return TOPTION; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 97 "hexpr.l"
+#line 98 "hexpr.l"
 { return TMODULE; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 98 "hexpr.l"
+#line 99 "hexpr.l"
 { return TWHERE; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 99 "hexpr.l"
+#line 100 "hexpr.l"
 { return TIMPORT; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 100 "hexpr.l"
+#line 101 "hexpr.l"
 { return TTYPE; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 101 "hexpr.l"
+#line 102 "hexpr.l"
 { return TDATA; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 102 "hexpr.l"
+#line 103 "hexpr.l"
 { wantIndent(true); return TCLASS; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 103 "hexpr.l"
+#line 104 "hexpr.l"
 { wantIndent(true); return TINST; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 104 "hexpr.l"
+#line 105 "hexpr.l"
 { return TEXISTS; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 105 "hexpr.l"
+#line 106 "hexpr.l"
 { return TUNSAFE; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 106 "hexpr.l"
+#line 107 "hexpr.l"
 { return TSAFE; } 
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 108 "hexpr.l"
+#line 109 "hexpr.l"
 { return TASSIGN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 109 "hexpr.l"
+#line 110 "hexpr.l"
 { return TEQUALS; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 110 "hexpr.l"
+#line 111 "hexpr.l"
 { return TASSUMP; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 111 "hexpr.l"
+#line 112 "hexpr.l"
 { return TCSTARROW; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 112 "hexpr.l"
+#line 113 "hexpr.l"
 { return TPARROW; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 113 "hexpr.l"
+#line 114 "hexpr.l"
 { return TCOLON; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 114 "hexpr.l"
+#line 115 "hexpr.l"
 { return TARROW; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 115 "hexpr.l"
+#line 116 "hexpr.l"
 { return TEQUIV; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 116 "hexpr.l"
+#line 117 "hexpr.l"
 { return TEQ; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 117 "hexpr.l"
+#line 118 "hexpr.l"
 { return TCIEQ; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 118 "hexpr.l"
+#line 119 "hexpr.l"
 { return TNEQ; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 119 "hexpr.l"
+#line 120 "hexpr.l"
 { return TLT; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 120 "hexpr.l"
+#line 121 "hexpr.l"
 { return TLTE; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 121 "hexpr.l"
+#line 122 "hexpr.l"
 { return TGT; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 122 "hexpr.l"
+#line 123 "hexpr.l"
 { return TGTE; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 123 "hexpr.l"
+#line 124 "hexpr.l"
 { return TNOT; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 124 "hexpr.l"
+#line 125 "hexpr.l"
 { return TNOT; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 125 "hexpr.l"
+#line 126 "hexpr.l"
 { return TLET; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 126 "hexpr.l"
+#line 127 "hexpr.l"
 { return TCASE; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 127 "hexpr.l"
+#line 128 "hexpr.l"
 { return TDEFAULT; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 128 "hexpr.l"
+#line 129 "hexpr.l"
 { return TMATCH; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 129 "hexpr.l"
+#line 130 "hexpr.l"
 { return TMATCHES; }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 130 "hexpr.l"
+#line 131 "hexpr.l"
 { return TPARSE; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 131 "hexpr.l"
+#line 132 "hexpr.l"
 { return TWITH; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 132 "hexpr.l"
+#line 133 "hexpr.l"
 { return TOF; }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 133 "hexpr.l"
+#line 134 "hexpr.l"
 { return TAND; }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 134 "hexpr.l"
+#line 135 "hexpr.l"
 { return TOR; }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 135 "hexpr.l"
+#line 136 "hexpr.l"
 { return TIF; }
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 136 "hexpr.l"
+#line 137 "hexpr.l"
 { return TTHEN; }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 137 "hexpr.l"
+#line 138 "hexpr.l"
 { return TELSE; }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 138 "hexpr.l"
+#line 139 "hexpr.l"
 { SAVE_BOOL; return TBOOL; }
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 139 "hexpr.l"
+#line 140 "hexpr.l"
 { SAVE_BOOL; return TBOOL; }
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 140 "hexpr.l"
+#line 141 "hexpr.l"
 { return TIN; }
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 141 "hexpr.l"
+#line 142 "hexpr.l"
 { return TPACK; }
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 142 "hexpr.l"
+#line 143 "hexpr.l"
 { return TUNPACK; }
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 143 "hexpr.l"
+#line 144 "hexpr.l"
 { return TDO; }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 144 "hexpr.l"
+#line 145 "hexpr.l"
 { return TRETURN; }
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 146 "hexpr.l"
+#line 147 "hexpr.l"
 { return TLPRAGMA; }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 147 "hexpr.l"
+#line 148 "hexpr.l"
 { return TRPRAGMA; }   
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 149 "hexpr.l"
+#line 150 "hexpr.l"
 { pushIndent(); return TLPAREN; }
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 150 "hexpr.l"
+#line 151 "hexpr.l"
 { popIndent();  return TRPAREN; }
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 151 "hexpr.l"
+#line 152 "hexpr.l"
 { pushIndent(); return TLBRACKET; }
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 152 "hexpr.l"
+#line 153 "hexpr.l"
 { popIndent();  return TRBRACKET; }
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 153 "hexpr.l"
+#line 154 "hexpr.l"
 { pushIndent(); return TLBRACE; }
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 154 "hexpr.l"
+#line 155 "hexpr.l"
 { popIndent();  return TRBRACE; }
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 156 "hexpr.l"
+#line 157 "hexpr.l"
 { return TBAR; }
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 157 "hexpr.l"
+#line 158 "hexpr.l"
 { return TCOMMA; }
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 158 "hexpr.l"
+#line 159 "hexpr.l"
 { return TSEMICOLON; }
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 159 "hexpr.l"
+#line 160 "hexpr.l"
 { return TAPPEND; }
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 160 "hexpr.l"
+#line 161 "hexpr.l"
 { return TPLUS; }
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 161 "hexpr.l"
+#line 162 "hexpr.l"
 { return TMINUS; }
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 162 "hexpr.l"
+#line 163 "hexpr.l"
 { return TTIMES; }
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 163 "hexpr.l"
+#line 164 "hexpr.l"
 { return TDIVIDE; }
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 164 "hexpr.l"
+#line 165 "hexpr.l"
 { return TREM; }
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 165 "hexpr.l"
+#line 166 "hexpr.l"
 { return TFN; }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 166 "hexpr.l"
+#line 167 "hexpr.l"
 { return TFNL; }
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 167 "hexpr.l"
+#line 168 "hexpr.l"
 { return TCOMPOSE; }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 168 "hexpr.l"
+#line 169 "hexpr.l"
 { return TDOT; }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 169 "hexpr.l"
+#line 170 "hexpr.l"
 { return TUPTO; }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 170 "hexpr.l"
+#line 171 "hexpr.l"
 { return TCARET; }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 171 "hexpr.l"
+#line 172 "hexpr.l"
 { return TAT; }
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 172 "hexpr.l"
+#line 173 "hexpr.l"
 { return TDOLLAR; }
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 173 "hexpr.l"
+#line 174 "hexpr.l"
 { return TQUESTION; }
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 174 "hexpr.l"
+#line 175 "hexpr.l"
 { SAVE_STR;    return (hobbes::str::unescape(hobbes::str::trimq(*yylval.string, '\'')).size() <= 1) ? TCHAR : TREGEX; }
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 175 "hexpr.l"
+#line 176 "hexpr.l"
 { return TSQUOTE; }
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 176 "hexpr.l"
+#line 177 "hexpr.l"
 { return TEQUOTE; }
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 177 "hexpr.l"
+#line 178 "hexpr.l"
 { SAVE_STR;    return TBYTE; }
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 178 "hexpr.l"
+#line 179 "hexpr.l"
 { SAVE_STR;    return TBYTES; }
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 179 "hexpr.l"
+#line 180 "hexpr.l"
 { SAVE_IDENT;  return TIDENT; }
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 180 "hexpr.l"
+#line 181 "hexpr.l"
 { SAVE_STR;    return TTUPSECTION; }
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 181 "hexpr.l"
+#line 182 "hexpr.l"
 { SAVE_FLOAT;  return TFLOAT; }
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 182 "hexpr.l"
+#line 183 "hexpr.l"
 { SAVE_DOUBLE; return TDOUBLE; }
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 183 "hexpr.l"
+#line 184 "hexpr.l"
 { SAVE_DOUBLE; yylval.doublev *= 0.01; return TDOUBLE; }
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 184 "hexpr.l"
+#line 185 "hexpr.l"
 { SAVE_INT128; return TINT128; }
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 185 "hexpr.l"
+#line 186 "hexpr.l"
 { SAVE_LONG;   return TLONG; }
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 186 "hexpr.l"
+#line 187 "hexpr.l"
 { SAVE_SHORT;  return TSHORT; }
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 187 "hexpr.l"
+#line 188 "hexpr.l"
 { SAVE_INT;    return TINT; }
 	YY_BREAK
 case 101:
 /* rule 101 can match eol */
 YY_RULE_SETUP
-#line 188 "hexpr.l"
+#line 189 "hexpr.l"
 { SAVE_STR;    return TSTRING; }
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 190 "hexpr.l"
+#line 191 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 191 "hexpr.l"
+#line 192 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 192 "hexpr.l"
+#line 193 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 193 "hexpr.l"
+#line 194 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 194 "hexpr.l"
+#line 195 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 195 "hexpr.l"
+#line 196 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 196 "hexpr.l"
+#line 197 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 197 "hexpr.l"
+#line 198 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 198 "hexpr.l"
+#line 199 "hexpr.l"
 { SAVE_STR;    return TTIMEINTERVAL; }
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 200 "hexpr.l"
+#line 201 "hexpr.l"
 { SAVE_STR; return TTIME; }
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 201 "hexpr.l"
+#line 202 "hexpr.l"
 { SAVE_STR; return TTIME; }
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 202 "hexpr.l"
+#line 203 "hexpr.l"
 { SAVE_STR; return TTIME; }
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 203 "hexpr.l"
+#line 204 "hexpr.l"
 { SAVE_STR; return TTIME; }
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 205 "hexpr.l"
+#line 206 "hexpr.l"
 { SAVE_STR; return TDATETIME; }
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 206 "hexpr.l"
+#line 207 "hexpr.l"
 { SAVE_STR; return TDATETIME; }
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 207 "hexpr.l"
+#line 208 "hexpr.l"
 { SAVE_STR; return TDATETIME; }
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 208 "hexpr.l"
+#line 209 "hexpr.l"
 { SAVE_STR; return TDATETIME; }
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 209 "hexpr.l"
+#line 210 "hexpr.l"
 { SAVE_STR; return TDATETIME; }
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 211 "hexpr.l"
+#line 212 "hexpr.l"
 { yyVexpLexError = "Unknown character: " + std::string(yytext); yyterminate(); if (false) { yyrealloc(0, 0); yyunput(0, 0); } }
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 213 "hexpr.l"
+#line 214 "hexpr.l"
 ECHO;
 	YY_BREAK
-#line 1732 "hexpr.lex.C"
+#line 1733 "hexpr.lex.C"
 			case YY_STATE_EOF(INITIAL):
 			case YY_STATE_EOF(BLOCK_COMMENT):
 				yyterminate();
@@ -2012,21 +2013,21 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	int yy_is_jam;
+    int yy_is_jam;
     
-	YY_CHAR yy_c = 1;
-	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
-		{
-		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 281 )
-			yy_c = yy_meta[yy_c];
-		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 280);
-	if ( ! yy_is_jam )
-		*(yy_state_ptr)++ = yy_current_state;
+    YY_CHAR yy_c = 1;
+    while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
+    {
+        yy_current_state = (int) yy_def[yy_current_state];
+        if ( yy_current_state >= 281 )
+            yy_c = yy_meta[yy_c];
+    }
+    yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+    yy_is_jam = (yy_current_state == 280);
+    if ( ! yy_is_jam )
+        *(yy_state_ptr)++ = yy_current_state;
 
-		return yy_is_jam ? 0 : yy_current_state;
+    return yy_is_jam ? 0 : yy_current_state;
 }
 
 #ifndef YY_NO_UNPUT
@@ -2720,7 +2721,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 213 "hexpr.l"
+#line 214 "hexpr.l"
 
 #pragma GCC diagnostic pop
 

--- a/lib/hobbes/read/pgen/hexpr.parse.C
+++ b/lib/hobbes/read/pgen/hexpr.parse.C
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.1.  */
+/* A Bison parser, made by GNU Bison 3.7.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -45,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30704
 
-/* Bison version.  */
-#define YYBISON_VERSION "3.7.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.7.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -224,7 +224,7 @@ Expr* makeIrrefutablePatternFn(const Patterns& ps, const ExprPtr& e, const Lexic
 }
 
 Expr* makePatternFn(const Patterns& ps, const ExprPtr& e, const LexicalAnnotation& la) {
-  for (const auto p : ps) {
+  for (const auto& p : ps) {
     if (refutable(p)) {
       return makeRefutablePatternFn(ps, e, la);
     }

--- a/lib/hobbes/read/pgen/hexpr.y
+++ b/lib/hobbes/read/pgen/hexpr.y
@@ -155,7 +155,7 @@ Expr* makeIrrefutablePatternFn(const Patterns& ps, const ExprPtr& e, const Lexic
 }
 
 Expr* makePatternFn(const Patterns& ps, const ExprPtr& e, const LexicalAnnotation& la) {
-  for (const auto p : ps) {
+  for (const auto& p : ps) {
     if (refutable(p)) {
       return makeRefutablePatternFn(ps, e, la);
     }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,74 @@
+{ src,
+  version,
+  llvmVersions,
+  gccConstraints,
+  debug ? false,
+}: final: prev:
+with final;
+let
+  dbg = if debug == true
+        then enableDebugging
+        else (x: x);
+  
+  nativeBuildInputs = [ cmake ninja python27 ];
+  
+  buildInputs = [ ncurses readline zlib python27 ];
+  
+  doCheck = true;
+  
+  doTarget = "test";
+  
+  dontStrip = debug;
+  
+  separateDebugInfo = debug;
+  
+  meta = with stdenv.lib; {
+    description = "A language and an embedded JIT compiler";
+    longDescription = ''
+                  Hobbes is a language, embedded compiler, and runtime for efficient
+                  dynamic expression evalution, data storage and analysis.
+                '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kthielen thmzlt smunix ];
+  };
+  
+  withGCC = { gccVersion ? 10 }:
+    let gccPkgs = { gccVersion }: builtins.getAttr ("gcc" + (toString gccVersion) + "Stdenv") final;
+        llvmPkgs = { llvmVersion }: builtins.getAttr ("llvmPackages_" + (toString llvmVersion)) final;                    
+    in makeOverridable ({ llvmVersion, stdenv ? (gccPkgs { inherit gccVersion; }) } : stdenv.mkDerivation {
+      pname = "hobbes-gcc-" + toString gccVersion + "-llvm-" + toString llvmVersion;
+      inherit version src meta doCheck doTarget dontStrip;
+      nativeBuildInputs = nativeBuildInputs;
+      buildInputs = buildInputs ++ [ (llvmPkgs { inherit llvmVersion; }).llvm ];
+      postPatch = ''
+                  substituteInPlace CMakeLists.txt \
+                     --replace "\''${CMAKE_SOURCE_DIR}" "${src}"
+                '';
+    });
+  
+  withCLANG =
+    let llvmPkgs = { llvmVersion }: builtins.getAttr ("llvmPackages_" + (toString llvmVersion)) final;
+    in makeOverridable ({ llvmVersion, stdenv ? (llvmPkgs { inherit llvmVersion; }).stdenv } : stdenv.mkDerivation {
+      pname = "hobbes-clang-" + (toString llvmVersion);
+      inherit version src meta doCheck doTarget dontStrip;
+      nativeBuildInputs = nativeBuildInputs;
+      buildInputs = buildInputs ++ [ (llvmPkgs { inherit llvmVersion; }).llvm ];
+      postPatch = ''
+                  substituteInPlace CMakeLists.txt \
+                     --replace "\''${CMAKE_SOURCE_DIR}" "${src}"
+                '';
+    });
+in { hobbesPackages = recurseIntoAttrs (builtins.listToAttrs (builtins.map (gccConstraint: {
+       name = "gcc-" + toString gccConstraint.gccVersion;
+       value = recurseIntoAttrs (builtins.listToAttrs (builtins.map (llvmVersion: {
+         name = "llvm-" + toString llvmVersion;
+         value = recurseIntoAttrs ({ hobbes = dbg (callPackage (withGCC { inherit (gccConstraint) gccVersion; }) { inherit llvmVersion; }); });
+       }) gccConstraint.llvmVersions));
+     }) gccConstraints))
+     // recurseIntoAttrs (builtins.listToAttrs (
+       builtins.map
+         (llvmVersion: { name="clang-" + toString llvmVersion;
+                         value = recurseIntoAttrs ({ hobbes = dbg (callPackage withCLANG { inherit llvmVersion; }); });
+                       })
+         llvmVersions));
+   }

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -312,7 +312,7 @@ TEST(Storage, FRegionAlignment) {
     std::array<int, 42> someInts;
     FRALIGN_TEST(someInts);
 
-    int oneInt;
+    int oneInt{};
     FRALIGN_TEST(oneInt);
 
     std::pair<int,double> intAndDouble;
@@ -629,8 +629,6 @@ TEST(Storage, FRegion_FSeq_Write_Resume_After_Restart) {
 TEST(Storage, DArrayMemLayout) {
   EXPECT_TRUE(c().compileFn<bool()>("show([unsafeCast(\"jimmy\")::((darray char)),unsafeCast(\"chicken\")]) == \"[\\\"jimmy\\\", \\\"chicken\\\"]\"")());
 }
-
-static const size_t recordCount = 100;
 
 DEFINE_VARIANT(
   MyVariant,

--- a/test/test.H
+++ b/test/test.H
@@ -14,15 +14,28 @@
 #include <hobbes/util/str.H>
 #include <hobbes/util/stream.H>
 
-#include <unistd.h> // readlink
-#include <libgen.h> // direname, basename
-#include <linux/limits.h> // PATH_MAX
+#include <unistd.h>
+#include <libgen.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#  include <libproc.h>
+#  include <mach-o/dyld.h>
+#elif __linux__
+#  include <linux/limits.h>
+#else
+#  error "platform is not supported"
+#endif
 
 template<class Fn>
 auto execPath(Fn && fn) -> void {
+#if defined(__APPLE__) && defined(__MACH__)
+  std::string r(PROC_PIDPATHINFO_MAXSIZE, 0);
+  uint32_t count = PROC_PIDPATHINFO_MAXSIZE;
+  if (-1 != _NSGetExecutablePath(const_cast<char*>(r.data()), &count)) {
+#elif __linux__  
   std::string r(PATH_MAX, 0);
-  auto count = ::readlink("/proc/self/exe", const_cast<char*>(r.data()), r.size());
-  if (count != -1) {
+  if (-1 != ::readlink("/proc/self/exe", const_cast<char*>(r.data()), r.size())) {
+#endif
     fn(std::string(dirname(const_cast<char*>(r.data()))));
   } else {
     throw std::runtime_error("failed to readlink(\"/proc/self/exe\") ...");


### PR DESCRIPTION
It turns out building with Clang is a lot stricter than gcc with error process in C++.This fixes #384 , while also moving all of our CI builds to use clang by default.