### PR TITLE
darwin: remove gcc packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ include(FindPythonInterp)
 set_property(TARGET hobbes-test PROPERTY COMPILE_FLAGS "-DPYTHON_EXECUTABLE=\"${PYTHON_EXECUTABLE}\" -DSCRIPT_DIR=\"${CMAKE_SOURCE_DIR}/scripts/\"")
 
 install(TARGETS hobbes hobbes-pic DESTINATION "lib")
-install(TARGETS hi hog DESTINATION "bin")
+install(TARGETS hi hog hobbes-test DESTINATION "bin")
 install(DIRECTORY "include/hobbes" DESTINATION "include")
 install(DIRECTORY "scripts" DESTINATION "scripts")
 

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ let
   overlays = [
     (import ./nix/overlays.nix {
       version = "unstable";
+      system = builtins.currentSystem;
       src = ./.;
       llvmVersions = [ 6 8 9 10 11 ];
       gccConstraints = [

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
       let
         overlays = [
           (import ./nix/overlays.nix {
+            inherit system;
             version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
             src = self;
             llvmVersions = [ 6 8 9 10 11 ];

--- a/test/test.H
+++ b/test/test.H
@@ -18,7 +18,6 @@
 #include <libgen.h>
 
 #if defined(__APPLE__) && defined(__MACH__)
-#  include <libproc.h>
 #  include <mach-o/dyld.h>
 #elif __linux__
 #  include <linux/limits.h>
@@ -28,9 +27,15 @@
 
 template<class Fn>
 auto execPath(Fn && fn) -> void {
+
 #if defined(__APPLE__) && defined(__MACH__)
-  std::string r(PROC_PIDPATHINFO_MAXSIZE, 0);
-  uint32_t count = PROC_PIDPATHINFO_MAXSIZE;
+#  if !defined(PROC_PIDPATHINFO_MAXSIZE) && !defined(PROC_PIDPATHINFO_MAXSIZE_HOBBES_FEATURED)
+#    define PROC_PIDPATHINFO_MAXSIZE_HOBBES_FEATURED 2048
+#  elif defined(PROC_PIDPATHINFO_MAXSIZE)
+#    define PROC_PIDPATHINFO_MAXSIZE_HOBBES_FEATURED = PROC_PIDPATHINFO_MAXSIZE
+#  endif
+  std::string r(PROC_PIDPATHINFO_MAXSIZE_HOBBES_FEATURED, 0);
+  uint32_t count = PROC_PIDPATHINFO_MAXSIZE_HOBBES_FEATURED;
   if (-1 != _NSGetExecutablePath(const_cast<char*>(r.data()), &count)) {
 #elif __linux__  
   std::string r(PATH_MAX, 0);


### PR DESCRIPTION
remove gcc builds from darwin as ld isn't passing the right triple target for LLVM