### PR TITLE
Revert "move llvm include to end of search path to prevent cxxabi.h c…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,7 @@ find_package(Curses REQUIRED)
 include_directories(${CURSES_INCLUDE_DIRS})
 
 find_package(LLVM REQUIRED CONFIG)
-if (CMAKE_COMPILER_IS_GNUCXX)
-  # if libc++abi is installed, cxxabi.h in llvm path will be used
-  # have to lower llvm include path search order
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -idirafter ${LLVM_INCLUDE_DIRS}")
-else()
-  include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-endif()
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
…onflicts (#425)"

PR #425 adds llvm headers by `-idirafter` to make them lowest priority in path search, however this introduces a new problem

- ubuntu 20.04
- llvm-dev installed by apt, this is llvm version 10, headers are on `/usr/include`, the default header location
- using `LLVM_DIR` to build hobbes with different llvm version, like `LLVM_DIR=/home/ubuntu/llvm-12.0.1/install/lib/cmake/llvm cmake -Bbuild -S. ....`

in this case, the search order is

```
#include <...> search starts here:
 /usr/lib/gcc/x86_64-linux-gnu/9/include
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include                             <<-- llvm-dev version 10, wrong headers
 /home/ubuntu/llvm-12.0.1/install/include <<-- here is the correct path
End of search list.
```

compiler will use llvm10's header file, and link against llvm12's lib, which causes _undefined reference_ linking error

It occurs to me that with multiple (versions?) of toolchains mixed together, there is no (easy?) way to cover all permutations

I'm thinking of making `CMakeLists.txt` as simple as possible, and just covers most common cases might not be the worst idea