### PR TITLE
fix a race condition in StringMap[] for new element

### DIFF
--- a/include/hobbes/hobbes.H
+++ b/include/hobbes/hobbes.H
@@ -14,14 +14,8 @@
 
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringMap.h>
-#include <llvm/Support/FormatVariadic.h>
 
 namespace hobbes {
-
-LLVM_NODISCARD inline std::string createUniqueName(llvm::StringRef prefix) {
-  static llvm::StringMap<std::atomic_int> m;
-  return llvm::formatv("{0}{1}", prefix, llvm::to_string(m[prefix]++));
-}
 
 // type aliases for common types
 DEFINE_TYPE_ALIAS_AS(timespanT, timespan, int64_t);

--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -654,10 +654,11 @@ llvm::IRBuilder<>* jitcc::builder() const {
 }
 
 #if LLVM_VERSION_MAJOR >= 11
-llvm::Module* jitcc::module() {
+llvm::Module *jitcc::module() {
   if (this->currentModule == nullptr) {
-    this->currentModule = withContext([](llvm::LLVMContext& c) {
-      return std::make_unique<llvm::Module>(createUniqueName("jitModule"), c);
+    this->currentModule = withContext([](llvm::LLVMContext &c) {
+      static std::atomic_int mc{};
+      return std::make_unique<llvm::Module>("jitModule" + std::to_string(mc++), c);
     });
   }
   return this->currentModule.get();


### PR DESCRIPTION
In `createUniqueName`, `llvm::StringMap m` is not thread safe if it gets written at the same time.

Since this function is only used in `jitcc::module`, then there is no reason to put it in `hobbes.H`