### PR TITLE
Add LLVM 16/18 support to Nix flake and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/devcontainers/base:dev-ubuntu-22.04
+FROM mcr.microsoft.com/devcontainers/base:dev-ubuntu-24.04
 
 # These dependencies are required by Nix.
 RUN apt update -y
-RUN apt -y install --no-install-recommends curl xz-utils cmake libreadline-dev libncurses-dev llvm-12 llvm-12-dev
+RUN apt -y install --no-install-recommends curl xz-utils cmake libreadline-dev libncurses-dev
 RUN [ -e /usr/bin/gmake ] || sudo ln -s /usr/bin/make /usr/bin/gmake
 
 # Install Nix
@@ -18,3 +18,13 @@ COPY .devcontainer/nix.conf /etc/nix/nix.conf
 COPY .devcontainer/profile.sh /etc/profile.d/devcontainer.sh
 
 # COPY /home/vscode/.nix-profile/etc/profile.d/nix.sh /etc/profile.d/devcontainer.sh
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y gh
+
+# Install Node.js and Claude Code CLI
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g @anthropic-ai/claude-code

--- a/.devcontainer/docker/devcontainer.json
+++ b/.devcontainer/docker/devcontainer.json
@@ -25,12 +25,16 @@
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
-	"runArgs": [],
+	"runArgs": ["--memory=8g", "--memory-swap=8g"],
 	"containerUser": "vscode",
 	"updateRemoteUserUID": true,
 	"containerEnv": {
-	  "HOME": "/home/vscode"
+	  "HOME": "/home/vscode",
+	  "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
 	},
+	"mounts": [
+		"type=volume,source=hobbes-claude-config,target=/home/vscode/.claude"
+	],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -25,14 +25,16 @@
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
-	"runArgs": ["--userns=keep-id"],
+	"runArgs": ["--userns=keep-id", "--memory=8g", "--memory-swap=8g"],
 	"containerUser": "vscode",
 	"updateRemoteUserUID": true,
 	"containerEnv": {
-	  "HOME": "/home/vscode"
+	  "HOME": "/home/vscode",
+	  "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
 	},
 	"mounts": [
-		"type=bind,readonly,source=/etc/localtime,target=/etc/localtime"
+		"type=bind,readonly,source=/etc/localtime,target=/etc/localtime",
+		"type=volume,source=hobbes-claude-config,target=/home/vscode/.claude"
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/profile.sh
+++ b/.devcontainer/profile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROJECT_DIR=${PROJECT_DIR:-/workspace}
+PROJECT_DIR=${PROJECT_DIR:-/workspaces/hobbes}
 
 # Make Nix available as it's not installed system-wide.
 if [ -e $HOME/.nix-profile/etc/profile.d/nix.sh ] ; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        clang: [16]
+        os: [ubuntu-24.04]
+        clang: [16, 18]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,8 +36,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        clang: [8, 10, 11, 12, 16]
+        os: [ubuntu-24.04]
+        clang: [16, 18]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,9 +67,9 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        gcc: [10]
-        llvm: [8, 10, 11, 12, 16]
+        os: [ubuntu-24.04]
+        gcc: [13, 14]
+        llvm: [16, 18]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ CMakeFiles/
 /doc/building.txt
 .vscode/
 .gitmessage
+.hproc.*.log
+.devcontainer/.profile
+.devcontainer/.profile-*-link
+CTestTestfile.cmake
+Makefile
+cmake_install.cmake
+hi
+hobbes-test
+hog
+libhobbes-pic.a
+libhobbes.a
+macos_setup.sh
+mock-proc
+test_report.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.5)
 project(hobbes)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701282334,
-        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
+        "lastModified": 1757807378,
+        "narHash": "sha256-/RDi+TZ6j9IdADZ3Tj2Q3dQr+B5W7lLOVQqip//yxdU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+        "rev": "b6a41a6eb4e5520068653ca2b0c522515e944042",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,17 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ] (system:
       let
         overlays = [
           (import ./nix/overlays.nix {
             inherit system;
             version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
             src = self;
-            llvmVersions = [ 8 9 10 11 12 16 ];
+            llvmVersions = [ 16 18 ];
             gccConstraints = [
-              { gccVersion = 8; llvmVersions = [ 8 9 10 11 12 16 ]; }
-              { gccVersion = 9; llvmVersions = [ 8 9 10 11 12 16 ]; }
-              { gccVersion = 10; llvmVersions = [ 8 9 10 11 12 16 ]; }
-              { gccVersion = 12; llvmVersions = [ 8 9 10 11 12 16 ]; }
+              { gccVersion = 13; llvmVersions = [ 16 18 ]; }
+              { gccVersion = 14; llvmVersions = [ 16 18 ]; }
             ];
           })
         ];
@@ -29,6 +27,6 @@
           packages = flake-utils.lib.flattenTree (pkgs.recurseIntoAttrs {
             inherit (pkgs) hobbesPackages;
           });
-          defaultPackage = packages."hobbesPackages/clang-8/hobbes";
+          defaultPackage = packages."hobbesPackages/clang-18/hobbes";
         });
 }

--- a/include/hobbes/eval/orcjitcc.H
+++ b/include/hobbes/eval/orcjitcc.H
@@ -4,7 +4,9 @@
 #include <llvm/Config/llvm-config.h>
 
 #if LLVM_VERSION_MAJOR >= 11
+#if LLVM_VERSION_MAJOR < 18
 #include <llvm/ADT/Optional.h>
+#endif
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
 #if LLVM_VERSION_MAJOR >= 16
@@ -17,7 +19,11 @@
 namespace llvm {
 class Module;
 namespace orc {
+#if LLVM_VERSION_MAJOR >= 18
+class LLJIT;
+#else
 class LLLazyJIT;
+#endif
 class MaterializationResponsibility;
 class MangleAndInterner;
 } // namespace orc
@@ -46,7 +52,11 @@ public:
   llvm::Error addExternalCallableSymbol(llvm::StringRef name, void *ptr);
 
 private:
+#if LLVM_VERSION_MAJOR >= 18
+  std::unique_ptr<llvm::orc::LLJIT> jit;
+#else
   std::unique_ptr<llvm::orc::LLLazyJIT> jit;
+#endif
   std::unique_ptr<llvm::orc::MangleAndInterner> mangle;
 };
 } // namespace hobbes

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -13,6 +13,7 @@
 #define HOBBES_REFLECT_H_INCLUDED
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <cxxabi.h>
 #include <iostream>

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -18,7 +18,8 @@
     LLVM_VERSION_MAJOR != 10 && \
     LLVM_VERSION_MAJOR != 11 && \
     LLVM_VERSION_MAJOR != 12 && \
-    LLVM_VERSION_MAJOR != 16
+    LLVM_VERSION_MAJOR != 16 && \
+    LLVM_VERSION_MAJOR != 18
 #error "I don't know how to use this version of LLVM"
 #endif
 
@@ -43,18 +44,20 @@
 #include <llvm/Support/TargetRegistry.h>
 #endif
 #include <llvm/Support/TargetSelect.h>
+#if LLVM_VERSION_MAJOR < 18
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Scalar.h>
+#endif
 #include <llvm/Transforms/Utils/Cloning.h>
+#if LLVM_VERSION_MAJOR < 18
 #include <llvm/Transforms/Vectorize.h>
+#endif
 #if LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR <= 8
 #  include <llvm/Bitcode/BitstreamReader.h>
 #  include <llvm/Bitcode/BitstreamWriter.h>
-#elif  LLVM_VERSION_MAJOR <= 16
+#else
 #  include <llvm/Bitstream/BitstreamReader.h>
 #  include <llvm/Bitstream/BitstreamWriter.h>
-#else
-#  include <llvm/Bitcode/ReaderWriter.h>
 #endif
 
 #include <llvm/Support/raw_os_ostream.h>
@@ -74,6 +77,11 @@
 
 #if LLVM_VERSION_MAJOR >= 11
 #  include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
+#endif
+
+#if LLVM_VERSION_MAJOR >= 18
+#  include <llvm/Passes/PassBuilder.h>
+#  include <llvm/Transforms/IPO/ModuleInliner.h>
 #endif
 
 #pragma GCC diagnostic pop
@@ -97,7 +105,7 @@ inline llvm::orc::ThreadSafeContext& threadSafeContext() {
 
 template <typename Fn> auto withContext(Fn fn) -> decltype(auto) {
   auto lk = threadSafeContext().getLock();
-#if LLVM_VERSION_MAJOR >= 16
+#if LLVM_VERSION_MAJOR == 16
   threadSafeContext().getContext()->setOpaquePointers(false);
 #endif
   return fn(*threadSafeContext().getContext());
@@ -149,7 +157,11 @@ inline llvm::Type* doubleType() {
 }
 
 inline llvm::PointerType* ptrType(llvm::Type* ty) {
+#if LLVM_VERSION_MAJOR >= 18
+  return llvm::PointerType::get(ty->getContext(), 0);
+#else
   return llvm::PointerType::getUnqual(ty);
+#endif
 }
 
 inline llvm::ArrayType* arrayType(llvm::Type* ty, size_t sz) {
@@ -204,10 +216,20 @@ inline llvm::StructType* varArrayType(llvm::Type* elemty, size_t sz = 1) {
 
 // casting
 inline llvm::Value* cast(llvm::IRBuilder<>* b, llvm::Type* ty, llvm::Value* v) {
+#if LLVM_VERSION_MAJOR >= 18
+  // with opaque pointers, ptr-to-ptr bitcast is identity
+  if (v->getType()->isPointerTy() && ty->isPointerTy())
+    return v;
+#endif
   return b->CreateBitCast(v, ty);
 }
 
 inline llvm::Constant* ccast(llvm::Type* ty, llvm::Constant* v) {
+#if LLVM_VERSION_MAJOR >= 18
+  // with opaque pointers, ptr-to-ptr bitcast is identity
+  if (v->getType()->isPointerTy() && ty->isPointerTy())
+    return v;
+#endif
   return llvm::ConstantExpr::getBitCast(v, ty);
 }
 
@@ -687,7 +709,7 @@ inline Constants liftArraysAsGlobals(llvm::Module* m, const Constants& cs, const
   Constants r;
   for (size_t i = 0; i < std::min<size_t>(cs.size(), tys.size()); ++i) {
     if (is<Array>(tys[i]) != nullptr) {
-      r.push_back(llvm::ConstantExpr::getBitCast(liftAsGlobalRef(m, cs[i]), toLLVM(tys[i], true)));
+      r.push_back(ccast(toLLVM(tys[i], true), liftAsGlobalRef(m, cs[i])));
     } else {
       r.push_back(cs[i]);
     }
@@ -721,6 +743,39 @@ inline llvm::Value* tryMkConstRecord(llvm::IRBuilder<>*, llvm::Module* m, const 
 }
 
 // pointer / GEP utilities
+
+// typed overloads (work for all LLVM versions, required for LLVM >= 18)
+inline llvm::Value* offset(llvm::IRBuilder<>* b, llvm::Type* elemTy, llvm::Value* p, llvm::Value* o0) {
+  return b->CreateGEP(elemTy, p, {o0});
+}
+
+inline llvm::Value* offset(llvm::IRBuilder<>* b, llvm::Type* elemTy, llvm::Value* p, int o0) {
+  return offset(b, elemTy, p, cvalue(o0));
+}
+
+inline llvm::Value* offset(llvm::IRBuilder<>* b, llvm::Type* elemTy, llvm::Value* p, int o0, int o1) {
+  return b->CreateGEP(elemTy, p, {cvalue(o0), cvalue(o1)});
+}
+
+inline llvm::Value* offset(llvm::IRBuilder<>* b, llvm::Type* elemTy, llvm::Value* p, int o0, llvm::Value* o1) {
+  return b->CreateGEP(elemTy, p, {cvalue(o0), o1});
+}
+
+inline llvm::Value* structOffset(llvm::IRBuilder<>* b, llvm::Type* structTy, llvm::Value* p, unsigned int fieldOffset) {
+  return b->CreateStructGEP(structTy, p, fieldOffset);
+}
+
+// helper to load from a GlobalVariable (uses getValueType instead of getPointerElementType)
+inline llvm::Value* loadFromGlobal(llvm::IRBuilder<>* b, llvm::GlobalVariable* gv) {
+#if LLVM_VERSION_MAJOR < 16
+  return b->CreateLoad(gv);
+#else
+  return b->CreateLoad(gv->getValueType(), gv);
+#endif
+}
+
+#if LLVM_VERSION_MAJOR < 18
+// untyped overloads (LLVM < 18 only — element type derived from pointer)
 inline llvm::Value* offset(llvm::IRBuilder<>* b, llvm::Value* p, llvm::Value* o0) {
   std::vector<llvm::Value*> idxs;
   idxs.push_back(o0);
@@ -770,6 +825,7 @@ inline llvm::Value* structOffset(llvm::IRBuilder<>* b, llvm::Value* p, unsigned 
   return b->CreateStructGEP(p->getType()->getPointerElementType(), p, fieldOffset);
 #endif
 }
+#endif // LLVM_VERSION_MAJOR < 18
 
 #if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
 inline llvm::ExecutionEngine* makeExecutionEngine(llvm::Module* m, llvm::SectionMemoryManager* smm) {
@@ -927,9 +983,25 @@ inline void maybeInlineFunctionsIn(llvm::Module& m) {
   };
 
   if (allFunctionsAreSmall(m)) {
+#if LLVM_VERSION_MAJOR >= 18
+    llvm::PassBuilder PB;
+    llvm::LoopAnalysisManager LAM;
+    llvm::FunctionAnalysisManager FAM;
+    llvm::CGSCCAnalysisManager CGAM;
+    llvm::ModuleAnalysisManager MAM;
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+    llvm::ModulePassManager MPM;
+    MPM.addPass(llvm::ModuleInlinerPass());
+    MPM.run(m, MAM);
+#else
     auto mpm = llvm::legacy::PassManager();
     mpm.add(llvm::createFunctionInliningPass());
     mpm.run(m);
+#endif
   }
 }
 }

--- a/lib/hobbes/db/bindings.C
+++ b/lib/hobbes/db/bindings.C
@@ -196,11 +196,13 @@ class dbloadVF : public op {
       if (hasPointerRep(rty)) {
         return c->builder()->CreateBitCast(allocv, toLLVM(rty, true));
       } else {
-#if LLVM_VERSION_MAJOR < 16
-        return c->builder()->CreateLoad(c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true))));
-#else
+#if LLVM_VERSION_MAJOR >= 18
+        return c->builder()->CreateLoad(toLLVM(rty, true), allocv);
+#elif LLVM_VERSION_MAJOR >= 16
         llvm::Value* cast = c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true)));
         return c->builder()->CreateLoad(cast->getType()->getPointerElementType(), cast);
+#else
+        return c->builder()->CreateLoad(c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true))));
 #endif
       }
     });
@@ -291,11 +293,13 @@ struct dbloadF : public op {
         if (hasPointerRep(rty)) {
           return c->builder()->CreateBitCast(allocv, toLLVM(rty, true));
         } else {
-#if LLVM_VERSION_MAJOR < 16
-          return c->builder()->CreateLoad(c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true))));
-#else
+#if LLVM_VERSION_MAJOR >= 18
+          return c->builder()->CreateLoad(toLLVM(rty, true), allocv);
+#elif LLVM_VERSION_MAJOR >= 16
           llvm::Value* cast = c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true)));
           return c->builder()->CreateLoad(cast->getType()->getPointerElementType(), cast);
+#else
+          return c->builder()->CreateLoad(c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true))));
 #endif
         }
       }
@@ -341,11 +345,13 @@ struct dbloadPF : public op {
         if (hasPointerRep(rty)) {
           return c->builder()->CreateBitCast(allocv, toLLVM(rty, true));
         } else {
-#if LLVM_VERSION_MAJOR < 16
-          return c->builder()->CreateLoad(c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true))));
-#else
+#if LLVM_VERSION_MAJOR >= 18
+          return c->builder()->CreateLoad(toLLVM(rty, true), allocv);
+#elif LLVM_VERSION_MAJOR >= 16
           llvm::Value* cast = c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true)));
           return c->builder()->CreateLoad(cast->getType()->getPointerElementType(), cast);
+#else
+          return c->builder()->CreateLoad(c->builder()->CreateBitCast(allocv, ptrType(toLLVM(rty, true))));
 #endif
         }
       }

--- a/lib/hobbes/eval/func.C
+++ b/lib/hobbes/eval/func.C
@@ -327,8 +327,10 @@ public:
     }
 
     return withContext([&](auto&) {
+#if LLVM_VERSION_MAJOR >= 18
       llvm::Type* varrTy = varArrayType(toLLVM(aty->type(), is<OpaquePtr>(aty->type()) || is<Func>(aty->type())));
       llvm::Type* elemArrTy = arrayType(toLLVM(aty->type(), is<OpaquePtr>(aty->type()) || is<Func>(aty->type())), 1);
+#endif
 
       llvm::Value* a0 = c->compile(es[0]);
 #if LLVM_VERSION_MAJOR >= 18

--- a/lib/hobbes/eval/func.C
+++ b/lib/hobbes/eval/func.C
@@ -295,11 +295,15 @@ class alenexp : public op {
 public:
   llvm::Value* apply(jitcc* c, const MonoTypes&, const MonoTypePtr&, const Exprs& es) override {
     return withContext([c, &es](auto&) {
-#if LLVM_VERSION_MAJOR < 16
-      return c->builder()->CreateLoad(structOffset(c->builder(), c->compile(es[0]), 0), false, "at");
+      llvm::Value* arr = c->compile(es[0]);
+#if LLVM_VERSION_MAJOR >= 18
+      llvm::Value* v = structOffset(c->builder(), varArrayType(boolType()), arr, 0);
+      return c->builder()->CreateLoad(longType(), v, false, "at");
+#elif LLVM_VERSION_MAJOR >= 16
+      llvm::Value* v = structOffset(c->builder(), arr, 0);
+      return c->builder()->CreateLoad(longType(), v, false, "at");
 #else
-      llvm::Value* v = structOffset(c->builder(), c->compile(es[0]), 0);
-      return c->builder()->CreateLoad(v->getType()->getPointerElementType(), v, false, "at");
+      return c->builder()->CreateLoad(structOffset(c->builder(), arr, 0), false, "at");
 #endif
     });
   }
@@ -323,36 +327,61 @@ public:
     }
 
     return withContext([&](auto&) {
+      llvm::Type* varrTy = varArrayType(toLLVM(aty->type(), is<OpaquePtr>(aty->type()) || is<Func>(aty->type())));
+      llvm::Type* elemArrTy = arrayType(toLLVM(aty->type(), is<OpaquePtr>(aty->type()) || is<Func>(aty->type())), 1);
+
       llvm::Value* a0 = c->compile(es[0]);
+#if LLVM_VERSION_MAJOR >= 18
+      llvm::Value* a00 = structOffset(c->builder(), varrTy, a0, 0);
+      llvm::Value* c0 = c->builder()->CreateLoad(longType(), a00);
+      llvm::Value* d0 = structOffset(c->builder(), varrTy, a0, 1);
+#elif LLVM_VERSION_MAJOR >= 16
       llvm::Value* a00 = structOffset(c->builder(), a0, 0);
-#if LLVM_VERSION_MAJOR < 16
-      llvm::Value* c0 = c->builder()->CreateLoad(a00);
-#else
-      llvm::Value* c0 = c->builder()->CreateLoad(a00->getType()->getPointerElementType(), a00);
-#endif
+      llvm::Value* c0 = c->builder()->CreateLoad(longType(), a00);
       llvm::Value* d0 = structOffset(c->builder(), a0, 1);
-      llvm::Value* a1 = c->compile(es[1]);
-      llvm::Value* a10 = structOffset(c->builder(), a1, 0);
-#if LLVM_VERSION_MAJOR < 16
-      llvm::Value* c1 = c->builder()->CreateLoad(a10);
 #else
-      llvm::Value* c1 = c->builder()->CreateLoad(a10->getType()->getPointerElementType(), a10);
+      llvm::Value* a00 = structOffset(c->builder(), a0, 0);
+      llvm::Value* c0 = c->builder()->CreateLoad(a00);
+      llvm::Value* d0 = structOffset(c->builder(), a0, 1);
 #endif
+      llvm::Value* a1 = c->compile(es[1]);
+#if LLVM_VERSION_MAJOR >= 18
+      llvm::Value* a10 = structOffset(c->builder(), varrTy, a1, 0);
+      llvm::Value* c1 = c->builder()->CreateLoad(longType(), a10);
+      llvm::Value* d1 = structOffset(c->builder(), varrTy, a1, 1);
+#elif LLVM_VERSION_MAJOR >= 16
+      llvm::Value* a10 = structOffset(c->builder(), a1, 0);
+      llvm::Value* c1 = c->builder()->CreateLoad(longType(), a10);
       llvm::Value* d1 = structOffset(c->builder(), a1, 1);
+#else
+      llvm::Value* a10 = structOffset(c->builder(), a1, 0);
+      llvm::Value* c1 = c->builder()->CreateLoad(a10);
+      llvm::Value* d1 = structOffset(c->builder(), a1, 1);
+#endif
 
       llvm::Value* aclen = c->builder()->CreateAdd(c0, c1);
       llvm::Value* mlen  = c->builder()->CreateAdd(cvalue(static_cast<long>(sizeof(long))), c->builder()->CreateMul(aclen, cvalue(static_cast<long>(sizeOf(aty->type())))));
 
       llvm::Value* cmdata = c->compileAllocStmt(mlen, cvalue(std::max<long>(sizeof(long), alignment(aty->type()))), toLLVM(tys[0]));
+#if LLVM_VERSION_MAJOR >= 18
+      c->builder()->CreateStore(aclen, structOffset(c->builder(), varrTy, cmdata, 0));
+#else
       c->builder()->CreateStore(aclen, structOffset(c->builder(), cmdata, 0));
+#endif
 
       if (!isUnit(aty->type())) {
         // hack to acknowledge the fact that opaque pointers are stored as pointers within arrays
         long elemSize = is<OpaquePtr>(aty->type()) ? sizeof(void*) : static_cast<long>(sizeOf(aty->type()));
 
+#if LLVM_VERSION_MAJOR >= 18
+        llvm::Value* od = structOffset(c->builder(), varrTy, cmdata, 1);
+        memCopy(c->builder(), offset(c->builder(), elemArrTy, od, 0), 8, d0, 8, c->builder()->CreateMul(c0, cvalue(elemSize)));
+        memCopy(c->builder(), offset(c->builder(), elemArrTy, od, c0), 8, d1, 8, c->builder()->CreateMul(c1, cvalue(elemSize)));
+#else
         llvm::Value* od = structOffset(c->builder(), cmdata, 1);
         memCopy(c->builder(), offset(c->builder(), od, 0), 8, d0, 8, c->builder()->CreateMul(c0, cvalue(elemSize)));
         memCopy(c->builder(), offset(c->builder(), od, c0), 8, d1, 8, c->builder()->CreateMul(c1, cvalue(elemSize)));
+#endif
       }
       return cmdata;
     });
@@ -377,7 +406,11 @@ class asetlen : public op {
 
     llvm::Value* av = c->compile(es[0]);
     llvm::Value* nc = c->compile(es[1]);
+#if LLVM_VERSION_MAJOR >= 18
+    withContext([&](auto&) { c->builder()->CreateStore(nc, structOffset(c->builder(), varArrayType(boolType()), av, 0)); });
+#else
     withContext([&](auto&) { c->builder()->CreateStore(nc, structOffset(c->builder(), av, 0)); });
+#endif
     return cvalue(true);
   }
 
@@ -418,7 +451,16 @@ class saelem : public op {
     }
 
     return withContext([&](auto&) -> llvm::Value* {
+#if LLVM_VERSION_MAJOR >= 18
+      // For GEP element type, don't wrap in pointer (which becomes opaque 'ptr' = 8-byte stride).
+      // Only use pointer representation for types actually stored as pointers in arrays.
+      bool isElemPtr = (is<OpaquePtr>(rty) != nullptr) || (is<Func>(rty) != nullptr);
+      llvm::Type* elemLLTy = toLLVM(rty, isElemPtr);
+      llvm::Value* p = offset(c->builder(), elemLLTy, c->compile(es[0]), c->compile(es[1]));
+#else
+      llvm::Type* elemLLTy = toLLVM(rty, true);
       llvm::Value* p = offset(c->builder(), c->compile(es[0]), 0, c->compile(es[1]));
+#endif
 
       if (isLargeType(rty)) {
         return p;
@@ -426,7 +468,7 @@ class saelem : public op {
 #if LLVM_VERSION_MAJOR < 16
         return c->builder()->CreateLoad(p, false);
 #else
-        return c->builder()->CreateLoad(p->getType()->getPointerElementType(), p, false);
+        return c->builder()->CreateLoad(elemLLTy, p, false);
 #endif
       }
     });
@@ -451,7 +493,11 @@ class saacopy : public op {
 
     llvm::Value* varr = c->compile(es[1]);
     withContext([&](auto&) {
+#if LLVM_VERSION_MAJOR >= 18
+      llvm::Value* vard = structOffset(c->builder(), varArrayType(boolType()), varr, 1); // get the var-length array's 'data' pointer
+#else
       llvm::Value* vard = structOffset(c->builder(), varr, 1); // get the var-length array's 'data' pointer
+#endif
 
       llvm::Value* len  = c->compile(es[2]);
       llvm::Value* lenb = c->builder()->CreateMul(len, cvalue(static_cast<long>(sizeOf(aty->type()))));
@@ -561,11 +607,12 @@ public:
       return cvalue(true);
     } else if (!hasPointerRep(rty)) {
       return withContext([&](auto&) {
+        llvm::Type* valTy = toLLVM(rty, true);
 #if LLVM_VERSION_MAJOR < 16
-        return c->builder()->CreateLoad(c->compileAllocStmt(sizeOf(rty), alignment(rty), ptrType(toLLVM(rty, true)), this->zeroMem));
+        return c->builder()->CreateLoad(c->compileAllocStmt(sizeOf(rty), alignment(rty), ptrType(valTy), this->zeroMem));
 #else
-        llvm::Value* tmp = c->compileAllocStmt(sizeOf(rty), alignment(rty), ptrType(toLLVM(rty, true)), this->zeroMem);
-        return c->builder()->CreateLoad(tmp->getType()->getPointerElementType(), tmp);
+        llvm::Value* tmp = c->compileAllocStmt(sizeOf(rty), alignment(rty), ptrType(valTy), this->zeroMem);
+        return c->builder()->CreateLoad(valTy, tmp);
 #endif
       });
     } else {
@@ -595,7 +642,11 @@ public:
       return c->builder()->CreateAdd(cvalue(static_cast<long>(sizeof(long))), c->builder()->CreateMul(aclen, cvalue(static_cast<long>(sizeOf(aty->type())))));
     });
     llvm::Value* cmdata = c->compileAllocStmt(mlen, cvalue(std::max<long>(sizeof(long), alignment(aty->type()))), toLLVM(rty));
+#if LLVM_VERSION_MAJOR >= 18
+    withContext([&](auto&) { c->builder()->CreateStore(aclen, structOffset(c->builder(), varArrayType(boolType()), cmdata, 0)); });
+#else
     withContext([&](auto&) { c->builder()->CreateStore(aclen, structOffset(c->builder(), cmdata, 0)); });
+#endif
 
     return cmdata;
   }
@@ -618,7 +669,7 @@ public:
 #if LLVM_VERSION_MAJOR < 16
       return c->builder()->CreateGEP(p, o);
 #else
-      return c->builder()->CreateGEP(p->getType()->getPointerElementType(), p, o);
+      return c->builder()->CreateGEP(charType(), p, o);
 #endif
     });
   }
@@ -635,11 +686,20 @@ public:
 class adjvtblptr : public op {
 public:
   llvm::Value* apply(jitcc* c, const MonoTypes&, const MonoTypePtr&, const Exprs& es) override {
-    llvm::Type* tppchar = llvm::PointerType::getUnqual(llvm::PointerType::getUnqual(
-        withContext([](llvm::LLVMContext& ctx) { return llvm::Type::getInt8Ty(ctx); })));
-
     llvm::Value* p = c->compile(es[0]);
     llvm::Value* o = c->compile(es[1]);
+
+#if LLVM_VERSION_MAJOR >= 18
+    // With opaque pointers, all pointer types are just 'ptr'
+    llvm::Value* v2 = c->builder()->CreateLoad(ptrType(charType()), p);
+    llvm::Value* v3 = c->builder()->CreateGEP(charType(), v2, o);
+    llvm::Value* v4 = c->builder()->CreateLoad(charType(), v3);
+    return withContext([&](auto&) {
+      return c->builder()->CreateGEP(charType(), p, v4);
+    });
+#else
+    llvm::Type* tppchar = llvm::PointerType::getUnqual(llvm::PointerType::getUnqual(
+        withContext([](llvm::LLVMContext& ctx) { return llvm::Type::getInt8Ty(ctx); })));
 
     llvm::Value* v1 = c->builder()->CreateBitCast(p, tppchar, "c");
     llvm::Value* v2 = c->builder()->CreateLoad(
@@ -659,6 +719,7 @@ public:
         v4
       );
     });
+#endif
   }
 
   PolyTypePtr type(typedb&) const override {
@@ -833,11 +894,13 @@ public:
       } else if (isLargeType(mty)) {
         return c->builder()->CreateBitCast(pval, toLLVM(mty, true));
       } else {
-#if LLVM_VERSION_MAJOR < 16
-        return c->builder()->CreateLoad(c->builder()->CreateBitCast(pval, llvm::PointerType::getUnqual(toLLVM(mty, true))), false);
-#else
+#if LLVM_VERSION_MAJOR >= 18
+        return c->builder()->CreateLoad(toLLVM(mty, true), pval, false);
+#elif LLVM_VERSION_MAJOR >= 16
         llvm::Value* tmp = c->builder()->CreateBitCast(pval, llvm::PointerType::getUnqual(toLLVM(mty, true)));
         return c->builder()->CreateLoad(tmp->getType()->getPointerElementType(), tmp, false);
+#else
+        return c->builder()->CreateLoad(c->builder()->CreateBitCast(pval, llvm::PointerType::getUnqual(toLLVM(mty, true))), false);
 #endif
       }
     });
@@ -866,6 +929,9 @@ public:
       // if the tail is 0, we can only possibly match the head
       if (isVoid(vty->tailType())) {
         // get an offset to the payload data
+#if LLVM_VERSION_MAJOR >= 18
+        llvm::Value* pval = c->builder()->CreateGEP(charType(), var, {cvalue(vty->payloadOffset())});
+#else
         std::vector<llvm::Value*> idxs;
         idxs.push_back(cvalue(0));
         idxs.push_back(cvalue(vty->payloadOffset()));
@@ -874,15 +940,20 @@ public:
 #else
         llvm::Value* pval = c->builder()->CreateGEP(var->getType()->getPointerElementType(), var, idxs);
 #endif
+#endif
         // invoke the head case function with the payload value
         return callWith(c, es[1], vheadm.type, payloadValue(c, vheadm.type, pval));
       } else {
         // pull out the variant tag
+#if LLVM_VERSION_MAJOR >= 18
+        llvm::Value* tag  = c->builder()->CreateLoad(intType(), var, false);
+#else
         llvm::Value* ptag = c->builder()->CreateBitCast(var, ptrType(intType()));
 #if LLVM_VERSION_MAJOR < 16
         llvm::Value* tag  = c->builder()->CreateLoad(ptag, false);
 #else
         llvm::Value* tag  = c->builder()->CreateLoad(ptag->getType()->getPointerElementType(), ptag, false);
+#endif
 #endif
 
         // compare the tag data to the head tag id
@@ -890,6 +961,9 @@ public:
         llvm::Value* ishtag = c->builder()->CreateICmpEQ(tag, htagv);
 
         // get an offset to the payload data
+#if LLVM_VERSION_MAJOR >= 18
+        llvm::Value* pval = c->builder()->CreateGEP(charType(), var, {cvalue(vty->payloadOffset())});
+#else
         std::vector<llvm::Value*> idxs;
         idxs.push_back(cvalue(0));
         idxs.push_back(cvalue(vty->payloadOffset()));
@@ -897,6 +971,7 @@ public:
         llvm::Value* pval = c->builder()->CreateGEP(var, idxs);
 #else
         llvm::Value* pval = c->builder()->CreateGEP(var->getType()->getPointerElementType(), var, idxs);
+#endif
 #endif
 
         // either invoke the head case function, or the tail case function
@@ -1144,12 +1219,15 @@ class packShortF : public op {
 class cptrrefbyF : public op {
   llvm::Value* apply(jitcc* c, const MonoTypes&, const MonoTypePtr&, const Exprs& es) override {
     return withContext([&](auto&) {
-#if LLVM_VERSION_MAJOR < 16
-      return c->builder()->CreateLoad(
-          offset(c->builder(), c->compile(es[0]), c->compile(es[1])), false);
-#else
+#if LLVM_VERSION_MAJOR >= 18
+      llvm::Value* tmp = offset(c->builder(), charType(), c->compile(es[0]), c->compile(es[1]));
+      return c->builder()->CreateLoad(charType(), tmp, false);
+#elif LLVM_VERSION_MAJOR >= 16
       llvm::Value* tmp = offset(c->builder(), c->compile(es[0]), c->compile(es[1]));
       return c->builder()->CreateLoad(tmp->getType()->getPointerElementType(), tmp, false);
+#else
+      return c->builder()->CreateLoad(
+          offset(c->builder(), c->compile(es[0]), c->compile(es[1])), false);
 #endif
     });
   }

--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -355,12 +355,12 @@ llvm::Value *ConstantList::loadConstant(llvm::StringRef name, llvm::Module &m,
 #if LLVM_VERSION_MAJOR < 16
       return builder.CreateLoad(g);
 #else
-      return builder.CreateLoad(g->getType()->getPointerElementType(), g);
+      return builder.CreateLoad(g->getValueType(), g);
 #endif
     case Ty::HasPointerRep:
       return g;
     default:
-      return builder.CreateAlignedLoad(g->getType()->getPointerElementType(), g,
+      return builder.CreateAlignedLoad(g->getValueType(), g,
                                        llvm::MaybeAlign(8));
     }
   });
@@ -1291,7 +1291,7 @@ llvm::Value* jitcc::lookupVar(const std::string& vn, const MonoTypePtr& vty) {
 #if LLVM_VERSION_MAJOR < 16
     return withContext([this, gv](auto&) { return builder()->CreateLoad(gv); });
 #else
-    return withContext([this, gv](auto&) { return builder()->CreateLoad(gv->getType()->getPointerElementType(), gv); });
+    return withContext([this, gv](auto&) { return builder()->CreateLoad(gv->getValueType(), gv); });
 #endif
   }
 


### PR DESCRIPTION
## Summary

- Pin nixpkgs to 2025-09-13 (last revision with `llvmPackages_16`) and add `aarch64-linux` support
- Update flake to build with LLVM 16/18, GCC 13/14 (replacing removed LLVM 8-12 and GCC 8-10)
- Fix devcontainer: correct `PROJECT_DIR`, add 8GB memory limits, install `gh` CLI, remove redundant apt LLVM packages
- Fix build compatibility: bump `cmake_minimum_required` to 3.5 (CMake 4.x), add `#include <cstdint>` (GCC 14+), guard LLVM 18-only variables in `func.C`

## Verified builds (aarch64-linux)

- clang-16, clang-18
- gcc-13/llvm-16, gcc-13/llvm-18
- gcc-14/llvm-16, gcc-14/llvm-18

## Test plan

- [x] CI builds pass for all matrix variants
- [x] `nix flake check` evaluates cleanly
- [x] Devcontainer rebuilds and `nix print-dev-env` works on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)