### PR TITLE
Add LLVM 20 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        clang: [16, 18]
+        clang: [16, 18, 20]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        clang: [16, 18]
+        clang: [16, 18, 20]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,7 +72,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         gcc: [13, 14]
-        llvm: [16, 18]
+        llvm: [16, 18, 20]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,10 @@
             inherit system;
             version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
             src = self;
-            llvmVersions = [ 16 18 ];
+            llvmVersions = [ 16 18 20 ];
             gccConstraints = [
-              { gccVersion = 13; llvmVersions = [ 16 18 ]; }
-              { gccVersion = 14; llvmVersions = [ 16 18 ]; }
+              { gccVersion = 13; llvmVersions = [ 16 18 20 ]; }
+              { gccVersion = 14; llvmVersions = [ 16 18 20 ]; }
             ];
           })
         ];


### PR DESCRIPTION
## Summary
- Add LLVM 20 to the Nix flake build matrix (clang and GCC+LLVM combinations)
- Add LLVM 20 to all GitHub Actions CI jobs (clang, clang+ASan/UBSan, GCC+LLVM)
- LLVM 20 was already in the supported version allowlist in `include/hobbes/util/llvm.H`
- The existing `>= 18` code paths are API-compatible with LLVM 20

## Test plan
- [ ] Verify CI passes for clang-20 build
- [ ] Verify CI passes for clang-20 ASan/UBSan build
- [ ] Verify CI passes for GCC 13/14 + LLVM 20 builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)