### PR TITLE
Fix sign extension of sub-32-bit return types on ARM64

### DIFF
--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -1534,14 +1534,21 @@ llvm::Function* jitcc::allocFunction(const std::string& fname, const MonoTypes& 
         fname.find(".patfs.") == 0 ? llvm::Function::InternalLinkage
                                    : llvm::Function::ExternalLinkage,
         fname, m);
-    // https://bugs.llvm.org/show_bug.cgi?id=51163
-    // for a llvm version >=9, zeroext has to be added to functions return boolean
-    // otherwise, 255 will be returned as true
-    if (retType == boolType()) {
+    // Sub-32-bit return types need sign/zero extension attributes so the
+    // callee extends the value in the return register per the platform ABI.
+    // Without this, the upper bits may contain garbage on ARM64.
+    // See also: https://bugs.llvm.org/show_bug.cgi?id=51163 (bool case)
+    if (retType == boolType() || retType == byteType()) {
 #if LLVM_VERSION_MAJOR < 16
       f->addAttribute(llvm::AttributeList::ReturnIndex, llvm::Attribute::ZExt);
 #else
       f->addRetAttr(llvm::Attribute::ZExt);
+#endif
+    } else if (retType == charType() || retType == shortType()) {
+#if LLVM_VERSION_MAJOR < 16
+      f->addAttribute(llvm::AttributeList::ReturnIndex, llvm::Attribute::SExt);
+#else
+      f->addRetAttr(llvm::Attribute::SExt);
 #endif
     }
     return f;


### PR DESCRIPTION
## Summary
- JIT-compiled functions returning `short` or `char` lacked the `SExt` return attribute, so LLVM did not sign-extend the return value in the register
- On ARM64, the caller expects sub-32-bit values to be properly extended per the ABI, causing `short(-32767)` to be read back as unsigned `32769`
- Add `SExt` for signed sub-32-bit return types (`char`, `short`) and `ZExt` for unsigned (`byte`), matching the existing `bool` fix from https://bugs.llvm.org/show_bug.cgi?id=51163

This fixes the pre-existing `Prelude/Short` test failure on macOS ARM64.

## Test plan
- [x] `Prelude/Short` test passes on macOS ARM64 with LLVM 18
- [x] `Prelude/Short` test passes on macOS ARM64 with LLVM 22
- [x] Full test suite (52 tests) passes on macOS ARM64
- [ ] Verify CI passes on Linux (x86-64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)