### PR TITLE
Add Rocky Linux 10 build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: rockylinux:10
+      image: quay.io/rockylinux/rockylinux:10
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,36 @@ jobs:
         with:
           name: ubuntu2604-build-logs
           path: build/
+  rhel10-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: rockylinux:10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: |
+          dnf update -y
+          dnf install -y epel-release
+          dnf config-manager --set-enabled crb
+          dnf install -y gcc gcc-c++ cmake make ncurses-devel zlib-devel python3 readline readline-devel
+          dnf install -y llvm-devel clang clang-devel
+      - name: Build hobbes
+        run: |
+          mkdir -p build && cd build
+          CC=clang CXX=clang++ cmake ..
+          VERBOSE=1 make -j2
+      - name: Test hobbes
+        run: |
+          cd build
+          make test
+      - name: Upload build logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: rhel10-build-logs
+          path: build/
   macos-build:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,11 +186,36 @@ jobs:
         run: cmake --build build -j$(nproc)
       - name: Test
         run: cd build && ctest --output-on-failure
+  rhel10-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: rockylinux:10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: |
+          dnf update -y
+          dnf install -y epel-release
+          dnf config-manager --set-enabled crb
+          dnf install -y gcc gcc-c++ cmake make ncurses-devel zlib-devel python3 readline readline-devel
+          dnf install -y llvm-devel clang clang-devel
+      - name: Build hobbes
+        run: |
+          mkdir -p build && cd build
+          CC=clang CXX=clang++ cmake ..
+          VERBOSE=1 make -j2
+      - name: Test hobbes
+        run: |
+          cd build
+          make test
       - name: Upload build logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: apt-llvm22-build-logs
+          name: rhel10-build-logs
           path: build/
   macos-build:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
     container:
       image: quay.io/rockylinux/rockylinux:10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install dependencies
         run: |
           dnf update -y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: rockylinux:10
+      image: quay.io/rockylinux/rockylinux:10
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Add `rhel10-build` job using the `rockylinux:10` container image
- Rocky 10 ships LLVM 20 and GCC 14, giving us build coverage on the RHEL 10 toolchain
- Mirrors the existing `rhel9-build` job structure

## Test plan
- [ ] rhel10-build job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)