### PR TITLE
Add LLVM 21 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        clang: [16, 18, 20]
+        clang: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        clang: [16, 18, 20]
+        clang: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,7 +72,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         gcc: [13, 14]
-        llvm: [16, 18, 20]
+        llvm: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,10 @@
             inherit system;
             version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
             src = self;
-            llvmVersions = [ 16 18 20 ];
+            llvmVersions = [ 16 18 20 21 ];
             gccConstraints = [
-              { gccVersion = 13; llvmVersions = [ 16 18 20 ]; }
-              { gccVersion = 14; llvmVersions = [ 16 18 20 ]; }
+              { gccVersion = 13; llvmVersions = [ 16 18 20 21 ]; }
+              { gccVersion = 14; llvmVersions = [ 16 18 20 21 ]; }
             ];
           })
         ];

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -20,7 +20,8 @@
     LLVM_VERSION_MAJOR != 12 && \
     LLVM_VERSION_MAJOR != 16 && \
     LLVM_VERSION_MAJOR != 18 && \
-    LLVM_VERSION_MAJOR != 20
+    LLVM_VERSION_MAJOR != 20 && \
+    LLVM_VERSION_MAJOR != 21
 #error "I don't know how to use this version of LLVM"
 #endif
 
@@ -105,11 +106,17 @@ inline llvm::orc::ThreadSafeContext& threadSafeContext() {
 }
 
 template <typename Fn> auto withContext(Fn fn) -> decltype(auto) {
+#if LLVM_VERSION_MAJOR >= 21
+  return threadSafeContext().withContextDo([&](llvm::LLVMContext *ctx) {
+    return fn(*ctx);
+  });
+#else
   auto lk = threadSafeContext().getLock();
 #if LLVM_VERSION_MAJOR == 16
   threadSafeContext().getContext()->setOpaquePointers(false);
 #endif
   return fn(*threadSafeContext().getContext());
+#endif
 }
 
 using Types = std::vector<llvm::Type *>;


### PR DESCRIPTION
## Summary
- Add LLVM 21 to the supported version allowlist in `llvm.H`
- LLVM 21 removed `ThreadSafeContext::getLock()` and `getContext()` in favor of `withContextDo()` — add a new code path for `LLVM_VERSION_MAJOR >= 21`
- Add LLVM 21 to the nix flake and CI build matrix (clang, gcc, and ASan builds)

## Test plan
- [ ] New `clang-21` and `gcc-*-llvm-21` CI jobs pass
- [ ] Existing LLVM 16/18/20 builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)