### PR TITLE
Add Python 3.10–3.14 compatibility CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,14 +172,15 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang llvm-dev libncurses-dev libreadline-dev zlib1g-dev
+          sudo apt-get install -y cmake clang-18 llvm-18-dev libncurses-dev libreadline-dev zlib1g-dev
       - name: Configure
         run: |
-          CC=clang CXX=clang++ cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          export PATH="/usr/lib/llvm-18/bin:$PATH"
+          CC=clang-18 CXX=clang++-18 cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm \
             -DPython_EXECUTABLE="$(which python3)"
       - name: Build
         run: cmake --build build -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,30 @@ jobs:
         with:
           name: ubuntu2604-build-logs
           path: build/
+  python-compat:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang llvm-dev libncurses-dev libreadline-dev zlib1g-dev
+      - name: Configure
+        run: |
+          CC=clang CXX=clang++ cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DPython_EXECUTABLE="$(which python3)"
+      - name: Build
+        run: cmake --build build -j$(nproc)
+      - name: Run Python tests
+        run: ./build/hobbes-test --tests Python
   macos-build:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,14 +203,15 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang llvm-dev libncurses-dev libreadline-dev zlib1g-dev
+          sudo apt-get install -y cmake clang-18 llvm-18-dev libncurses-dev libreadline-dev zlib1g-dev
       - name: Configure
         run: |
-          CC=clang CXX=clang++ cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          export PATH="/usr/lib/llvm-18/bin:$PATH"
+          CC=clang-18 CXX=clang++-18 cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm \
             -DPython_EXECUTABLE="$(which python3)"
       - name: Build
         run: cmake --build build -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,8 +199,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,30 @@ jobs:
         with:
           name: apt-llvm22-build-logs
           path: build/
+  python-compat:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang llvm-dev libncurses-dev libreadline-dev zlib1g-dev
+      - name: Configure
+        run: |
+          CC=clang CXX=clang++ cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DPython_EXECUTABLE="$(which python3)"
+      - name: Build
+        run: cmake --build build -j$(nproc)
+      - name: Run Python tests
+        run: ./build/hobbes-test --tests Python
   macos-build:
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
## Summary
- Adds a `python-compat` matrix job to `.github/workflows/build.yml` exercising the Python test group against Python 3.10, 3.11, 3.12, 3.13, and 3.14.
- Uses a plain apt-based cmake build (not Nix) so this job genuinely tests the host Python version (Nix jobs pin their own python310 from nix/overlays.nix). Kept minimal: just builds `hobbes-test` and runs `--tests Python`, which shells out to `python3 scripts/fregion.py`.

## Test plan
- [ ] All five matrix cells (3.10–3.14) pass the Python test group
- [ ] No regressions on the existing linux/macos/rhel9 jobs