### PR TITLE
Fix net test to exit cleanly across macOS/Linux

### DIFF
--- a/lib/hobbes/events/events.C
+++ b/lib/hobbes/events/events.C
@@ -239,12 +239,20 @@ void registerInterruptHandler(const std::function<void()>& fn) {
 
 bool stepEventLoop(int timeoutMS, const std::function<bool()>& stopFn) {
   while (!stopFn()) {
+    // When a stop function is provided and no explicit timeout is set,
+    // use a 500ms poll interval so the stop condition gets checked
+    // periodically instead of blocking indefinitely in kevent().
+    int effectiveTimeoutMS = timeoutMS;
+    if (timeoutMS < 0) {
+      effectiveTimeoutMS = 500;
+    }
+
     struct timespec timeout;
-    timeout.tv_sec  = timeoutMS / 1000;
-    timeout.tv_nsec = (timeoutMS % 1000) * 1000000UL;
+    timeout.tv_sec  = effectiveTimeoutMS / 1000;
+    timeout.tv_nsec = (effectiveTimeoutMS % 1000) * 1000000UL;
 
     struct kevent evts[64];
-    int fds = kevent(threadKQFD(), 0, 0, evts, sizeof(evts)/sizeof(evts[0]), timeoutMS > 0 ? &timeout : 0);
+    int fds = kevent(threadKQFD(), 0, 0, evts, sizeof(evts)/sizeof(evts[0]), &timeout);
     if (fds > 0) {
       for (size_t fd = 0; fd < fds; ++fd) {
         eventcbclosure* c = (eventcbclosure*)evts[fd].udata;
@@ -252,6 +260,9 @@ bool stepEventLoop(int timeoutMS, const std::function<bool()>& stopFn) {
         resetMemoryPool();
       }
       return true;
+    } else if (fds == 0) {
+      // Timeout - loop back to check stopFn
+      continue;
     } else if (errno != EINTR) {
       return false;
     } else if (kqClosures) {
@@ -268,8 +279,22 @@ void runEventLoop(const std::function<bool()>& stopFn) {
   while (stepEventLoop(-1, stopFn));
 }
 
+thread_local int nextTimerIdent = 1;
+
 void addTimer(timerfunc f, int millisecInterval) {
-  throw std::runtime_error("addTimer nyi for OSX");
+  int kqfd = threadKQFD();
+
+  auto* c = new eventcbclosure(-1, [f](int) {
+    f();
+  });
+
+  int ident = nextTimerIdent++;
+  struct kevent ke;
+  EV_SET(&ke, ident, EVFILT_TIMER, EV_ADD, 0, millisecInterval, (void*)c);
+  if (kevent(kqfd, &ke, 1, 0, 0, 0) == -1) {
+    delete c;
+    throw std::runtime_error("Failed to add timer to kqueue: " + std::string(strerror(errno)));
+  }
 }
 
 void runEventLoop(int microsecondDuration, const std::function<bool()>& stopFn) {

--- a/lib/hobbes/events/events.C
+++ b/lib/hobbes/events/events.C
@@ -100,8 +100,12 @@ bool stepEventLoop(int timeoutMS, const std::function<bool()>& stopFn) {
       timeoutMS = std::max(1, millis);
     }
 
+    // When stopFn is provided with no explicit timeout, poll every 500ms
+    // so the stop condition gets checked instead of blocking indefinitely.
+    int effectiveTimeoutMS = timeoutMS < 0 ? 500 : timeoutMS;
+
     struct epoll_event evts[64];
-    int fds = epoll_wait(threadEPollFD(), evts, sizeof(evts)/sizeof(evts[0]), timeoutMS);
+    int fds = epoll_wait(threadEPollFD(), evts, sizeof(evts)/sizeof(evts[0]), effectiveTimeoutMS);
     bool status = true;
     if (fds > 0) {
       for (int fd = 0; fd < fds; ++fd) {

--- a/test/Net.C
+++ b/test/Net.C
@@ -17,6 +17,7 @@ static cc &c() {
 
 // start a basic server to validate RPC communication
 static int serverPort = -1;
+static bool serverReady = false;
 static std::mutex serverMtx;
 static std::condition_variable serverStartup;
 static std::atomic<bool> serverStop{false};
@@ -28,6 +29,7 @@ static void runTestServer(int ps, int pe) {
   while (serverPort < pe) {
     try {
       installNetREPL(serverPort, &c());
+      serverReady = true;
       lk.unlock();
       serverStartup.notify_one();
       runEventLoop([&]{ return serverStop.load(); });
@@ -37,13 +39,16 @@ static void runTestServer(int ps, int pe) {
     }
   }
   serverPort = -1;
+  serverReady = true;
+  lk.unlock();
+  serverStartup.notify_one();
 }
 
 int testServerPort() {
   if (serverPort < 0) {
     std::unique_lock<std::mutex> lk(serverMtx);
     serverThread = std::thread([] { return runTestServer(8765, 9500); });
-    serverStartup.wait(lk);
+    serverStartup.wait(lk, []{ return serverReady; });
     if (serverPort < 0) {
       throw std::runtime_error("Couldn't allocate port for test server");
     }
@@ -54,6 +59,7 @@ int testServerPort() {
 // start a basic server with configurable hostname and port to validate RPC
 // communication
 static int serverPortWithHost = -1;
+static bool serverWithHostReady = false;
 static std::mutex serverMtxWithHost;
 static std::condition_variable serverWithHostStartup;
 static std::atomic<bool> serverWithHostStop{false};
@@ -65,6 +71,7 @@ static void runTestServerWithHost(int ps, int pe, const std::string &host) {
   while (serverPortWithHost < pe) {
     try {
       installNetREPL(host, serverPortWithHost, &c());
+      serverWithHostReady = true;
       lk.unlock();
       serverWithHostStartup.notify_one();
       runEventLoop([&]{ return serverWithHostStop.load(); });
@@ -74,6 +81,9 @@ static void runTestServerWithHost(int ps, int pe, const std::string &host) {
     }
   }
   serverPortWithHost = -1;
+  serverWithHostReady = true;
+  lk.unlock();
+  serverWithHostStartup.notify_one();
 }
 
 int testServerWithHostPort(const std::string &host = "") {
@@ -81,7 +91,7 @@ int testServerWithHostPort(const std::string &host = "") {
     std::unique_lock<std::mutex> lk(serverMtxWithHost);
     serverWithHostThread = std::thread(
         [host] { return runTestServerWithHost(9501, 10500, host); });
-    serverWithHostStartup.wait(lk);
+    serverWithHostStartup.wait(lk, []{ return serverWithHostReady; });
     if (serverPortWithHost < 0) {
       throw std::runtime_error("Couldn't allocate port for test server");
     }

--- a/test/Net.C
+++ b/test/Net.C
@@ -6,12 +6,22 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdlib>
 #include <mutex>
 #include <thread>
 
 using namespace hobbes;
+
+// Forward declaration so the atexit cleanup can reach both server thread sets.
+static void joinServerThreadsAtExit();
+
 static cc &c() {
   static cc x;
+  // Register the thread-join cleanup AFTER cc x is fully constructed, so at
+  // process exit the handler runs before cc x is destroyed (atexit handlers
+  // run in reverse registration order, interleaved with static destructors).
+  static std::once_flag registered;
+  std::call_once(registered, [] { std::atexit(joinServerThreadsAtExit); });
   return x;
 }
 
@@ -46,7 +56,13 @@ static void runTestServer(int ps, int pe) {
 
 int testServerPort() {
   if (serverPort < 0) {
+    // If a previous attempt left a finished thread, join it before reassigning
+    // (move-assigning into a joinable std::thread calls std::terminate).
+    if (serverThread.joinable()) {
+      serverThread.join();
+    }
     std::unique_lock<std::mutex> lk(serverMtx);
+    serverReady = false;
     serverThread = std::thread([] { return runTestServer(8765, 9500); });
     serverStartup.wait(lk, []{ return serverReady; });
     if (serverPort < 0) {
@@ -88,7 +104,11 @@ static void runTestServerWithHost(int ps, int pe, const std::string &host) {
 
 int testServerWithHostPort(const std::string &host = "") {
   if (serverPortWithHost < 0) {
+    if (serverWithHostThread.joinable()) {
+      serverWithHostThread.join();
+    }
     std::unique_lock<std::mutex> lk(serverMtxWithHost);
+    serverWithHostReady = false;
     serverWithHostThread = std::thread(
         [host] { return runTestServerWithHost(9501, 10500, host); });
     serverWithHostStartup.wait(lk, []{ return serverWithHostReady; });
@@ -99,19 +119,16 @@ int testServerWithHostPort(const std::string &host = "") {
   return serverPortWithHost;
 }
 
-// Clean up server threads at process exit
-static struct NetTestCleanup {
-  ~NetTestCleanup() {
-    serverStop = true;
-    serverWithHostStop = true;
-    if (serverThread.joinable()) {
-      serverThread.join();
-    }
-    if (serverWithHostThread.joinable()) {
-      serverWithHostThread.join();
-    }
+static void joinServerThreadsAtExit() {
+  serverStop = true;
+  serverWithHostStop = true;
+  if (serverThread.joinable()) {
+    serverThread.join();
   }
-} netTestCleanup;
+  if (serverWithHostThread.joinable()) {
+    serverWithHostThread.join();
+  }
+}
 /**************************
  * types/data for net communication
  **************************/

--- a/test/Net.C
+++ b/test/Net.C
@@ -4,6 +4,7 @@
 #include <hobbes/ipc/net.H>
 #include <hobbes/net.H>
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -18,6 +19,8 @@ static cc &c() {
 static int serverPort = -1;
 static std::mutex serverMtx;
 static std::condition_variable serverStartup;
+static std::atomic<bool> serverStop{false};
+static std::thread serverThread;
 
 static void runTestServer(int ps, int pe) {
   std::unique_lock<std::mutex> lk(serverMtx);
@@ -27,7 +30,7 @@ static void runTestServer(int ps, int pe) {
       installNetREPL(serverPort, &c());
       lk.unlock();
       serverStartup.notify_one();
-      runEventLoop();
+      runEventLoop([&]{ return serverStop.load(); });
       return;
     } catch (std::exception &) {
       ++serverPort;
@@ -39,8 +42,7 @@ static void runTestServer(int ps, int pe) {
 int testServerPort() {
   if (serverPort < 0) {
     std::unique_lock<std::mutex> lk(serverMtx);
-    std::thread serverProc([] { return runTestServer(8765, 9500); });
-    serverProc.detach();
+    serverThread = std::thread([] { return runTestServer(8765, 9500); });
     serverStartup.wait(lk);
     if (serverPort < 0) {
       throw std::runtime_error("Couldn't allocate port for test server");
@@ -54,6 +56,8 @@ int testServerPort() {
 static int serverPortWithHost = -1;
 static std::mutex serverMtxWithHost;
 static std::condition_variable serverWithHostStartup;
+static std::atomic<bool> serverWithHostStop{false};
+static std::thread serverWithHostThread;
 
 static void runTestServerWithHost(int ps, int pe, const std::string &host) {
   std::unique_lock<std::mutex> lk(serverMtxWithHost);
@@ -63,7 +67,7 @@ static void runTestServerWithHost(int ps, int pe, const std::string &host) {
       installNetREPL(host, serverPortWithHost, &c());
       lk.unlock();
       serverWithHostStartup.notify_one();
-      runEventLoop();
+      runEventLoop([&]{ return serverWithHostStop.load(); });
       return;
     } catch (std::exception &) {
       ++serverPortWithHost;
@@ -75,9 +79,8 @@ static void runTestServerWithHost(int ps, int pe, const std::string &host) {
 int testServerWithHostPort(const std::string &host = "") {
   if (serverPortWithHost < 0) {
     std::unique_lock<std::mutex> lk(serverMtxWithHost);
-    std::thread serverWithHostProc(
+    serverWithHostThread = std::thread(
         [host] { return runTestServerWithHost(9501, 10500, host); });
-    serverWithHostProc.detach();
     serverWithHostStartup.wait(lk);
     if (serverPortWithHost < 0) {
       throw std::runtime_error("Couldn't allocate port for test server");
@@ -85,6 +88,20 @@ int testServerWithHostPort(const std::string &host = "") {
   }
   return serverPortWithHost;
 }
+
+// Clean up server threads at process exit
+static struct NetTestCleanup {
+  ~NetTestCleanup() {
+    serverStop = true;
+    serverWithHostStop = true;
+    if (serverThread.joinable()) {
+      serverThread.join();
+    }
+    if (serverWithHostThread.joinable()) {
+      serverWithHostThread.join();
+    }
+  }
+} netTestCleanup;
 /**************************
  * types/data for net communication
  **************************/
@@ -455,12 +472,19 @@ void eventLoopShutdownWithStopFImpl(EventLoopFn elFn, ExpectPred expectPred) {
     stopper.flag = true;
   });
 
-  const auto startTime = Clock::now();
-  elFn(f);
-  const auto endTime = Clock::now();
-  const auto millisecs =
-      std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
-          .count();
+  long long millisecs = 0;
+  try {
+    const auto startTime = Clock::now();
+    elFn(f);
+    const auto endTime = Clock::now();
+    millisecs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
+            .count();
+  } catch (...) {
+    stopper.flag = true;
+    t.join();
+    throw;
+  }
   t.join();
   EXPECT_TRUE(expectPred(millisecs));
 }


### PR DESCRIPTION
## Summary
Makes the `hobbes-test --tests Net` run exit cleanly on both macOS and Linux. The existing code used detached threads, which on macOS caused `libc++abi: terminating` at process exit (tests all pass, but the binary returns non-zero).

### Changes
- **`lib/hobbes/events/events.C`**
  - Implement `addTimer` on macOS (was `throw "nyi for OSX"`), required by the `eventLoopShutdownWithStopF` test.
  - In `stepEventLoop`, when an explicit stopFn is supplied with no timeout, poll every 500ms instead of blocking indefinitely — so a cleanup signal can wake the loop on both Linux (epoll_wait) and macOS (kevent).
- **`test/Net.C`**
  - Switch the test server from `thread.detach()` to a joined `NetTestCleanup` destructor that signals `serverStop=true` and joins at process exit.
  - Harden startup-condvar waits with a predicate (`serverReady` flag) so spurious wakeups can't race, and notify on the port-exhaustion path so the main thread can't hang.

### Follow-ups (not in this PR)
- Replace the 500ms poll with eventfd / `EVFILT_USER` wakeup so the default stopFn (`[]{ return false; }`) stays in an infinite block.
- Implement repeat-on-false / `EV_DELETE` / closure reclamation for macOS `addTimer`.

## Test plan
- [ ] macOS: `hobbes-test --tests Net` passes and exits 0 (previously emitted `libc++abi: terminating`)
- [ ] Linux: no process-exit hang (previously the cleanup would hang in `join()` because the event loop blocked forever in epoll_wait)