### PR TITLE
Add Ubuntu 26.04 CI job and GCC 15 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        clang: [16, 18, 20]
+        clang: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        clang: [16, 18, 20]
+        clang: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,7 +72,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         gcc: [13, 14]
-        llvm: [16, 18, 20]
+        llvm: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        gcc: [13, 14]
+        gcc: [13, 14, 15]
         llvm: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v6
@@ -128,6 +128,38 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: rhel9-build-logs
+          path: build/
+  ubuntu2604-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: ubuntu:26.04
+    steps:
+      - name: Install dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential cmake make git ca-certificates \
+            libncurses-dev zlib1g-dev libreadline-dev libzstd-dev \
+            python3 \
+            llvm-dev clang libclang-dev
+      - uses: actions/checkout@v6
+      - name: Build hobbes
+        run: |
+          mkdir -p build && cd build
+          CC=clang CXX=clang++ cmake ..
+          VERBOSE=1 make -j2
+      - name: Test hobbes
+        run: |
+          cd build
+          make test
+      - name: Upload build logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ubuntu2604-build-logs
           path: build/
   macos-build:
     runs-on: macos-latest

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
             gccConstraints = [
               { gccVersion = 13; llvmVersions = [ 16 18 20 21 ]; }
               { gccVersion = 14; llvmVersions = [ 16 18 20 21 ]; }
+              { gccVersion = 15; llvmVersions = [ 16 18 20 21 ]; }
             ];
           })
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,10 @@
             inherit system;
             version = "${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
             src = self;
-            llvmVersions = [ 16 18 20 ];
+            llvmVersions = [ 16 18 20 21 ];
             gccConstraints = [
-              { gccVersion = 13; llvmVersions = [ 16 18 20 ]; }
-              { gccVersion = 14; llvmVersions = [ 16 18 20 ]; }
+              { gccVersion = 13; llvmVersions = [ 16 18 20 21 ]; }
+              { gccVersion = 14; llvmVersions = [ 16 18 20 21 ]; }
             ];
           })
         ];

--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -386,7 +386,7 @@ public:
 #define LIFTCTY(cc, e) (cc).liftMonoType<decltype(e)>()
 
 template <typename T> struct rccF {
-  static T compile(cc *, const str::seq &, const std::string &) {
+  [[noreturn]] static T compile(cc *, const str::seq &, const std::string &) {
     throw std::runtime_error(
         "Internal error, unsupported compilation target type");
   }

--- a/include/hobbes/eval/cmodule.H
+++ b/include/hobbes/eval/cmodule.H
@@ -28,7 +28,10 @@ using OptDescs = std::map<std::string, std::string>;
 OptDescs getAllOptions();
 
 ExprPtr translateExprWithOpts(const ModulePtr&, const ExprPtr&);
-ExprPtr translateExprWithOpts(const std::vector<std::string>&, const ExprPtr&, std::function<void(std::string const&)> const& = [](std::string const& err) -> void { throw std::runtime_error(err); });
+[[noreturn]] inline void translateExprWithOptsThrow(std::string const& err) {
+  throw std::runtime_error(err);
+}
+ExprPtr translateExprWithOpts(const std::vector<std::string>&, const ExprPtr&, std::function<void(std::string const&)> const& = &translateExprWithOptsThrow);
 
 // change set of safe/unsafe expressions allowed in Safe mode
 class SafeSet {

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -20,7 +20,8 @@
     LLVM_VERSION_MAJOR != 12 && \
     LLVM_VERSION_MAJOR != 16 && \
     LLVM_VERSION_MAJOR != 18 && \
-    LLVM_VERSION_MAJOR != 20
+    LLVM_VERSION_MAJOR != 20 && \
+    LLVM_VERSION_MAJOR != 21
 #error "I don't know how to use this version of LLVM"
 #endif
 
@@ -105,11 +106,17 @@ inline llvm::orc::ThreadSafeContext& threadSafeContext() {
 }
 
 template <typename Fn> auto withContext(Fn fn) -> decltype(auto) {
+#if LLVM_VERSION_MAJOR >= 21
+  return threadSafeContext().withContextDo([&](llvm::LLVMContext *ctx) {
+    return fn(*ctx);
+  });
+#else
   auto lk = threadSafeContext().getLock();
 #if LLVM_VERSION_MAJOR == 16
   threadSafeContext().getContext()->setOpaquePointers(false);
 #endif
   return fn(*threadSafeContext().getContext());
+#endif
 }
 
 using Types = std::vector<llvm::Type *>;

--- a/lib/hobbes/eval/cexpr.C
+++ b/lib/hobbes/eval/cexpr.C
@@ -60,7 +60,7 @@ public:
   llvm::ConstantInt* with(const Float*  v) const override { return fail(*v); }
   llvm::ConstantInt* with(const Double* v) const override { return fail(*v); }
 private:
-  llvm::ConstantInt* fail(const LexicallyAnnotated& la) const {
+  [[noreturn]] llvm::ConstantInt* fail(const LexicallyAnnotated& la) const {
     throw annotated_error(la, "Internal error, can't switch on non-integral type");
   }
 };

--- a/lib/hobbes/eval/ctype.C
+++ b/lib/hobbes/eval/ctype.C
@@ -60,15 +60,15 @@ public:
     }
   }
 
-  llvm::Type* with(const TVar* v) const override {
+  [[noreturn]] llvm::Type* with(const TVar* v) const override {
     throw std::runtime_error("Internal compiler error: Cannot translate type variable '" + v->name() + "' to LLVM type");
   }
 
-  llvm::Type* with(const TGen*) const override {
+  [[noreturn]] llvm::Type* with(const TGen*) const override {
     throw std::runtime_error("Internal compiler error: Cannot translate polytype instantiation point to LLVM type.");
   }
 
-  llvm::Type* with(const TAbs* v) const override {
+  [[noreturn]] llvm::Type* with(const TAbs* v) const override {
     throw std::runtime_error("Can't translate to LLVM monotype: " + show(v));
   }
 
@@ -144,15 +144,15 @@ public:
     return ptrType(byteType());
   }
 
-  llvm::Type* with(const TString* v) const override {
+  [[noreturn]] llvm::Type* with(const TString* v) const override {
     throw std::runtime_error("Internal compiler error: Cannot translate value to LLVM type: '" + v->value() + "'");
   }
 
-  llvm::Type* with(const TLong* v) const override {
+  [[noreturn]] llvm::Type* with(const TLong* v) const override {
     throw std::runtime_error("Internal compiler error: Cannot translate value to LLVM type: " + str::from(v->value()));
   }
 
-  llvm::Type* with(const TExpr* v) const override {
+  [[noreturn]] llvm::Type* with(const TExpr* v) const override {
     throw std::runtime_error("Internal compiler error: Cannot translate expression to LLVM type: " + show(v->expr()));
   }
 private:

--- a/lib/hobbes/lang/pat/dfa.C
+++ b/lib/hobbes/lang/pat/dfa.C
@@ -795,7 +795,7 @@ struct makeSuccStateF : public switchPattern<MStatePtr> {
   size_t c;
   makeSuccStateF(MDFA* dfa, const PatternRows& ps, size_t c) : dfa(dfa), ps(ps), c(c) { }
 
-  MStatePtr with(const MatchAny* ma) const override {
+  [[noreturn]] MStatePtr with(const MatchAny* ma) const override {
     throw annotated_error(*ma, "Internal error, can't deconstruct wildcard columns in match expression");
   }
 
@@ -1470,11 +1470,11 @@ struct makePrimDFASF : public switchMState<UnitV> {
     return unitv;
   }
 
-  UnitV with(const LoadVars*) const override {
+  [[noreturn]] UnitV with(const LoadVars*) const override {
     throw std::runtime_error("Internal error, not a primitive match table (load vars)");
   }
 
-  UnitV with(const SwitchVariant*) const override {
+  [[noreturn]] UnitV with(const SwitchVariant*) const override {
     throw std::runtime_error("Internal error, not a primitive match table (switch variant)");
   }
 

--- a/lib/hobbes/lang/preds/cpptdesc.C
+++ b/lib/hobbes/lang/preds/cpptdesc.C
@@ -69,19 +69,19 @@ struct defineCPPTy : public switchType<UnitV> {
     return unitv;
   }
 
-  UnitV with(const TVar*) const override {
+  [[noreturn]] UnitV with(const TVar*) const override {
     throw annotated_error(this->la, "Can't translate type with variables to C++ type.");
   }
 
-  UnitV with(const TGen*) const override {
+  [[noreturn]] UnitV with(const TGen*) const override {
     throw annotated_error(this->la, "Can't translate polymorphic type to C++ type.");
   }
 
-  UnitV with(const TAbs*) const override {
+  [[noreturn]] UnitV with(const TAbs*) const override {
     throw annotated_error(this->la, "Can't translate type abstraction to C++ type.");
   }
 
-  UnitV with(const TApp*) const override {
+  [[noreturn]] UnitV with(const TApp*) const override {
     throw annotated_error(this->la, "Can't translate type application to C++ type.");
   }
 
@@ -158,23 +158,23 @@ struct defineCPPTy : public switchType<UnitV> {
     return unitv;
   }
 
-  UnitV with(const Exists*) const override {
+  [[noreturn]] UnitV with(const Exists*) const override {
     throw annotated_error(this->la, "Can't translate existential type to C++ type.");
   }
 
-  UnitV with(const Recursive*) const override {
+  [[noreturn]] UnitV with(const Recursive*) const override {
     throw annotated_error(this->la, "Can't translate recursive type to C++ type.");
   }
 
-  UnitV with(const TString*) const override {
+  [[noreturn]] UnitV with(const TString*) const override {
     throw annotated_error(this->la, "Can't translate type string to C++ type.");
   }
 
-  UnitV with(const TLong*) const override {
+  [[noreturn]] UnitV with(const TLong*) const override {
     throw annotated_error(this->la, "Can't translate type number to C++ type.");
   }
 
-  UnitV with(const TExpr*) const override {
+  [[noreturn]] UnitV with(const TExpr*) const override {
     throw annotated_error(this->la, "Can't translate type expression to C++ type.");
   }
 };

--- a/lib/hobbes/lang/preds/subtype/obj.C
+++ b/lib/hobbes/lang/preds/subtype/obj.C
@@ -21,9 +21,12 @@ bool Objs::pathExists(const std::string&, const std::string&) const {
   return false;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-noreturn"
 PtrAdjustmentPath Objs::adjustment(const std::string& derived, const std::string& base) const {
   throw std::runtime_error("No path exists from the class '" + derived + "' to '" + base + "'.");
 }
+#pragma clang diagnostic pop
 #else
 // object relationship recording and resolution
 void Objs::add(const class_type* ct) {

--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -2124,8 +2124,8 @@ public:
   }
 
   nat with(const OpaquePtr*  v) const override { return v->storedContiguously() ? v->size() : sizeof(void*); }
-  nat with(const TVar*       v) const override { throw std::runtime_error("Can't determine size of type variable '" + v->name() + "'"); }
-  nat with(const TGen*       v) const override { throw std::runtime_error("Can't determine size of polytype argument #" + str::from(v->id())); }
+  [[noreturn]] nat with(const TVar*       v) const override { throw std::runtime_error("Can't determine size of type variable '" + v->name() + "'"); }
+  [[noreturn]] nat with(const TGen*       v) const override { throw std::runtime_error("Can't determine size of polytype argument #" + str::from(v->id())); }
   nat with(const FixedArray* v) const override { return r(v->type()) * v->requireLength(); }
   nat with(const Array*       ) const override { return sizeof(void*); }
   nat with(const Variant*    v) const override { return rv(v); }
@@ -2134,7 +2134,7 @@ public:
   nat with(const Exists*      ) const override { return sizeof(void*); }
   nat with(const Recursive*   ) const override { return sizeof(void*); }
 
-  nat with(const TAbs* v) const override {
+  [[noreturn]] nat with(const TAbs* v) const override {
     throw std::runtime_error("Can't determine size of type abstraction: " + show(v));
   }
 


### PR DESCRIPTION
## Summary
- Adds a container-based `ubuntu2604-build` CI job (`ubuntu:26.04` image with clang 21 + llvm-dev 21 + gcc 15.2 + cmake 4.2). GitHub does not yet ship an `ubuntu-26.04` hosted runner, so the job runs in a container on `ubuntu-latest` mirroring the existing `rhel9-build` pattern.
- Extends the nix gcc/llvm matrix with `gcc 15` (paired against llvm 16/18/20/21).
- Annotates unconditionally-throwing helpers with `[[noreturn]]` so the project's `-Werror -Wmissing-noreturn` policy (CMakeLists.txt:99) keeps compiling under clang 21's stricter analysis. Sites: `rccF<T>::compile`, `cexpr.C::fail`, throwing `with(...)` overrides in `ctype.C` / `dfa.C` / `cpptdesc.C` / `type.C`, and a named replacement for the lambda default argument of `translateExprWithOpts` (clang 21 rejects `[[noreturn]]` on the lambda position).
- For `Objs::adjustment`, only the `__clang__` stub branch always throws — the non-clang branch returns normally — so a localized clang diagnostic pragma is used instead of changing the header signature.

The branch builds on top of #484 ("Add LLVM 21 support"); since that PR is still in draft, the LLVM 21 commit is included here so CI is exercised end-to-end on both clang-21 and gcc-15. If #484 lands first, that commit can drop out via rebase.

## Test plan
- [x] Smoke-tested locally in a podman `ubuntu:26.04` container: `apt` deps install, cmake configures, `make -j` builds clean, `./hobbes-test` exits 0 with all visible test groups SUCCESS.
- [x] CI matrix passes (existing nix `linux-clang-*`/`linux-gcc-build`, `rhel9-build`, `macos-build`, plus the new `ubuntu2604-build`).
- [x] Confirm the `linux-gcc-build` `gcc=15` cells succeed against all four LLVM versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)