### PR TITLE
Remove unused enableModuleInlining flag

### DIFF
--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -299,8 +299,6 @@ public:
   void releaseMachineCode(void *);
 
   // compile/optimization options
-  void enableModuleInlining(bool f);
-  bool enableModuleInlining() const;
   void buildInterpretedMatches(bool f);
   bool buildInterpretedMatches() const;
   void requireMatchReachability(bool f);
@@ -346,7 +344,6 @@ private:
   SearchCache searchCache;
 
   // optimization options
-  bool runModInlinePass;
   bool genInterpretedMatch;
   bool checkMatchReachability;
   bool ignoreUnreachablePatternMatchRows = false;

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -46,7 +46,6 @@ cc::cc() :
   readExprF(&defReadExpr),
   drainingDefs(false),
   unreachableMatchRowsPtr(nullptr),
-  runModInlinePass(true),
   genInterpretedMatch(false),
   checkMatchReachability(true),
   lowerPrimMatchTables(false),
@@ -652,8 +651,6 @@ void cc::releaseMachineCode(void* f) {
   this->jit->releaseMachineCode(f);
 }
 
-void cc::enableModuleInlining(bool f) { this->runModInlinePass = f; }
-bool cc::enableModuleInlining() const { return this->runModInlinePass; }
 
 void cc::buildInterpretedMatches(bool f) { this->genInterpretedMatch = f; }
 bool cc::buildInterpretedMatches() const { return this->genInterpretedMatch; }


### PR DESCRIPTION
## Summary

Removes the dead `cc::enableModuleInlining()` API and its backing `runModInlinePass` member.

The flag has been write-only since the original open-source import: the setter/getter store and return `runModInlinePass`, but nothing anywhere in the codebase reads it to gate compilation. The JIT originally ran its `FunctionInliningPass` unconditionally in `jitcc::getMachineCode`, and since 9a4efd0 ("stop hobbes from generating large IR functions") the inlining decision is made automatically by `maybeInlineFunctionsIn` based on per-function instruction counts (tunable via the `HOBBES_FUNCTION_INLINE_THRESHOLD` environment variable), which also does not consult this flag.

Since calling `enableModuleInlining(false)` has never had any effect, removing the API is behavior-neutral.

## Testing

- Full build with LLVM 18 on macOS ARM64
- `hobbes-test --tests Prelude` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)