### PR TITLE
Fix unused-variable error building with LLVM < 16 (Covered by dco/Brian_Egge.md)

### DIFF
--- a/lib/hobbes/eval/func.C
+++ b/lib/hobbes/eval/func.C
@@ -460,7 +460,9 @@ class saelem : public op {
       llvm::Type* elemLLTy = toLLVM(rty, isElemPtr);
       llvm::Value* p = offset(c->builder(), elemLLTy, c->compile(es[0]), c->compile(es[1]));
 #else
+#if LLVM_VERSION_MAJOR >= 16
       llvm::Type* elemLLTy = toLLVM(rty, true);
+#endif
       llvm::Value* p = offset(c->builder(), c->compile(es[0]), 0, c->compile(es[1]));
 #endif
 


### PR DESCRIPTION
In the pre-LLVM-18 branch of `saelem::apply` (lib/hobbes/eval/func.C), `elemLLTy` is only consumed by the `CreateLoad` call when `LLVM_VERSION_MAJOR >= 16`, so building against LLVM 8–15 with gcc and `-Werror` fails:

```
/src/lib/hobbes/eval/func.C:463:19: error: unused variable 'elemLLTy' [-Werror=unused-variable]
```

This guards the declaration with the same condition as its use. Found while reproducing #501, which needed an LLVM 8 build for comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)