### PR TITLE
Fix LLVM_DIR handling and declare real cmake minimum (Covered by dco/Brian_Egge.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Hobbes is a compiled, strongly-typed language with an embedded JIT compiler and 
 
 ## Build
 
-Requires CMake 3.4+, LLVM 12-16, a C++17 compiler (GCC or Clang), and system libraries (zlib, readline, ncurses, zstd).
+Requires CMake 3.19+, LLVM (see the supported-version list in `include/hobbes/util/llvm.H`), a C++17 compiler (GCC or Clang), and system libraries (zlib, readline, ncurses, zstd).
 
 ```bash
 cmake --build /path/to/build -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
+# 3.19 is needed for COMMAND_ERROR_IS_FATAL in the llvm-config calls below
+cmake_minimum_required(VERSION 3.19)
 project(hobbes)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -13,7 +14,17 @@ set(CURSES_NEED_NCURSES TRUE)
 find_package(Curses REQUIRED)
 include_directories(${CURSES_INCLUDE_DIRS})
 
-find_package(LLVM 12 CONFIG QUIET)
+# Prefer LLVM 12 when several LLVM installs are discoverable. LLVM's package
+# version files only accept an exact major.minor match, so this probe fails on
+# any other version, and a failed find_package caches LLVM_DIR-NOTFOUND --
+# clobbering an explicitly provided -DLLVM_DIR. Only probe when the user
+# hasn't chosen an install, and undo the probe's cache write if it fails.
+if(NOT LLVM_DIR)
+  find_package(LLVM 12 CONFIG QUIET)
+  if(NOT LLVM_FOUND)
+    unset(LLVM_DIR CACHE)
+  endif()
+endif()
 find_package(LLVM REQUIRED CONFIG)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Hobbes is built for high performance integration with C/C++ applications. While 
 
 ## Building <a name="building"></a>
 
-To build hobbes, you will need [LLVM](http://llvm.org/) 3.3 or later, [cmake](http://cmake.org/) 3.4 or later, [GNU gcc](https://gcc.gnu.org/) 4.8 or later, and a version 2.5 or later Linux kernel.
+To build hobbes, you will need [LLVM](http://llvm.org/) 3.3 or later, [cmake](http://cmake.org/) 3.19 or later, [GNU gcc](https://gcc.gnu.org/) 4.8 or later, and a version 2.5 or later Linux kernel.
 
 With LLVM, cmake, and g++ installed, after downloading this code you should be able to build and install hobbes just by running:
 


### PR DESCRIPTION
Two configure-time fixes found while reproducing #501 across LLVM versions:

**`find_package(LLVM 12 CONFIG QUIET)` clobbers an explicit `-DLLVM_DIR`.** LLVM's package version files require an exact major.minor match, so the "prefer LLVM 12" probe can only ever succeed against LLVM 12.x. For every other version it fails and caches `LLVM_DIR:PATH=LLVM_DIR-NOTFOUND`, overwriting the value the user passed on the command line — the subsequent `find_package(LLVM REQUIRED CONFIG)` then can't find keg-only/custom installs the user explicitly pointed at:

```
cmake -S . -B build -DLLVM_DIR=/opt/homebrew/opt/llvm@16/lib/cmake/llvm
...
CMake Error at CMakeLists.txt:17 (find_package):
  Could not find a package configuration file provided by "LLVM" ...
```

The probe is now skipped when the user has already chosen an install, and its cache write is undone when it fails, preserving the LLVM-12 preference for the multi-install default-path case.

**`cmake_minimum_required` claimed 3.5 but the build needs 3.19.** The `llvm-config` calls use `COMMAND_ERROR_IS_FATAL` (cmake ≥ 3.19); on older cmakes (e.g. Ubuntu 18.04's 3.10) configure fails midway with `execute_process given unknown argument "COMMAND_ERROR_IS_FATAL"` instead of a clear version message.

Verified locally: explicit `-DLLVM_DIR` (LLVM 16), `CMAKE_PREFIX_PATH` (LLVM 18), reconfigure of an existing build dir, and the no-hints error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)