### PR TITLE
Fix duplicate artifact name breaking the Build workflow (Covered by dco/Brian_Egge.md)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,6 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: apt-llvm22-build-logs
           name: rhel10-build-logs
           path: build/
   python-compat:


### PR DESCRIPTION
The `rhel10-build` job's upload-artifact step has two `name:` keys — a copy-paste remnant from the apt-llvm22 job:

```yaml
        with:
          name: apt-llvm22-build-logs
          name: rhel10-build-logs
```

GitHub rejects the workflow file at startup (`Invalid workflow file: .github/workflows/build.yml (Line: 218, Col: 11): 'name' is already defined`), so **every Build run since this landed has failed with zero jobs executed** — on pushes to main and on all PRs ([example run](https://github.com/morganstanley/hobbes/actions/runs/30120228134)). Only Code Coverage has actually been gating PRs, which is why #502/#503/#504 show just two checks.

This drops the stray line, keeping the intended `rhel10-build-logs` artifact name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)