### PR TITLE
Fix record deconstruction for inline opaque fields in non-final positions

### DIFF
--- a/lib/hobbes/lang/preds/consrecord.C
+++ b/lib/hobbes/lang/preds/consrecord.C
@@ -37,6 +37,48 @@ MonoTypePtr stripHiddenFields(const MonoTypePtr& ty) {
   }
 }
 
+static bool isVisibleField(const std::string& f) {
+  return f.size() < 2 || (f[0] != '.' || f[1] != 'p');
+}
+
+static bool hasVisibleField(const Record* rty) {
+  for (const auto& m : rty->members()) {
+    if (isVisibleField(m.field)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// do two types describe records with the same visible fields (by name and type)?
+// (compared member-wise so that neither hidden padding fields nor member offsets --
+// which legitimately differ between a standalone record and the tail of a larger
+// one -- affect the answer)
+static bool equalVisibleFields(const MonoTypePtr& aty, const MonoTypePtr& bty) {
+  if (*aty == *bty) {
+    return true;
+  }
+  const Record* a = is<Record>(aty);
+  const Record* b = is<Record>(bty);
+  if ((a == nullptr) || (b == nullptr)) {
+    return false;
+  }
+  const auto& ams = a->members();
+  const auto& bms = b->members();
+  size_t i = 0, j = 0;
+  while (true) {
+    while (i < ams.size() && !isVisibleField(ams[i].field)) ++i;
+    while (j < bms.size() && !isVisibleField(bms[j].field)) ++j;
+    if (i == ams.size() || j == bms.size()) {
+      return i == ams.size() && j == bms.size();
+    }
+    if (ams[i].field != bms[j].field || !(*ams[i].type == *bms[j].type)) {
+      return false;
+    }
+    ++i; ++j;
+  }
+}
+
 struct ConsRecord {
   bool        forward;
   bool        asTuple;
@@ -137,15 +179,27 @@ bool RecordDeconstructor::satisfied(const TEnvPtr&, const ConstraintPtr& cst, De
     return false;
   }
 
+  if (!hasVisibleField(rty)) {
+    return false;
+  }
+
+  // compare the head and tail of the record independently (as 'refine' unifies them)
+  // rather than reconstructing a record out of the constraint's head and tail types --
+  // 'headMember' normalizes opaque types stored inline to their by-reference form, so a
+  // reconstructed record can never match a record whose head field is an inline opaque
+  // type (eg: a lifted struct with a std::string field followed by any other field)
   if (cr.asTuple) {
     if (tty != nullptr) {
-      return *stripHiddenFields(rty) == *stripHiddenFields(Record::make(cr.headType, tty->members()));
+      return *rty->headMember().type == *cr.headType &&
+             equalVisibleFields(rty->tailType(), cr.tailType);
     } else {
       return *rty->headMember().type == *cr.headType;
     }
   } else {
     if (tty != nullptr) {
-      return *stripHiddenFields(rty) == *stripHiddenFields(Record::make(fname->value(), cr.headType, tty->members()));
+      return rty->headMember().field == fname->value() &&
+             *rty->headMember().type == *cr.headType &&
+             equalVisibleFields(rty->tailType(), cr.tailType);
     } else {
       return rty->headMember().field == fname->value() && *rty->headMember().type == *cr.headType;
     }

--- a/lib/hobbes/lang/preds/consrecord.C
+++ b/lib/hobbes/lang/preds/consrecord.C
@@ -19,10 +19,14 @@ namespace hobbes {
 #define REF_REC_TAIL  "recordTail"
 #define REF_TUP_TAIL  "tupleTail"
 
+static bool isVisibleField(const std::string& f) {
+  return f.size() < 2 || (f[0] != '.' || f[1] != 'p');
+}
+
 MonoTypePtr stripHiddenFields(const Record* rty) {
   Record::Members ms;
   for (const auto& m : rty->members()) {
-    if (m.field.size() < 2 || (m.field[0] != '.' || m.field[1] != 'p')) {
+    if (isVisibleField(m.field)) {
       ms.push_back(Record::Member(m.field, m.type));
     }
   }
@@ -35,10 +39,6 @@ MonoTypePtr stripHiddenFields(const MonoTypePtr& ty) {
   } else {
     return ty;
   }
-}
-
-static bool isVisibleField(const std::string& f) {
-  return f.size() < 2 || (f[0] != '.' || f[1] != 'p');
 }
 
 static bool hasVisibleField(const Record* rty) {

--- a/lib/hobbes/lang/preds/consrecord.C
+++ b/lib/hobbes/lang/preds/consrecord.C
@@ -193,7 +193,7 @@ bool RecordDeconstructor::satisfied(const TEnvPtr&, const ConstraintPtr& cst, De
       return *rty->headMember().type == *cr.headType &&
              equalVisibleFields(rty->tailType(), cr.tailType);
     } else {
-      return *rty->headMember().type == *cr.headType;
+      return *rty->headMember().type == *cr.headType && isUnit(rty->tailType());
     }
   } else {
     if (tty != nullptr) {
@@ -201,7 +201,9 @@ bool RecordDeconstructor::satisfied(const TEnvPtr&, const ConstraintPtr& cst, De
              *rty->headMember().type == *cr.headType &&
              equalVisibleFields(rty->tailType(), cr.tailType);
     } else {
-      return rty->headMember().field == fname->value() && *rty->headMember().type == *cr.headType;
+      return rty->headMember().field == fname->value() &&
+             *rty->headMember().type == *cr.headType &&
+             isUnit(rty->tailType());
     }
   }
 }

--- a/test/Structs.C
+++ b/test/Structs.C
@@ -104,6 +104,29 @@ TEST(Structs, Bindings) {
   EXPECT_TRUE(c().compileFn<array<char>*()>("show(genstruct)") != nullptr);
 }
 
+// a record with opaque C++ types (stored inline) in non-final field positions
+// (issue #506: 'Show' could not be derived when an inline opaque field had any
+// fields after it, because record deconstruction failed on such records)
+DEFINE_STRUCT(
+  InteriorOpaque,
+  (std::string, a),
+  (double,      b),
+  (std::string, c),
+  (int,         d)
+);
+
+TEST(Structs, ShowInteriorOpaqueFields) {
+  static InteriorOpaque io;
+  io.a = "x";
+  io.b = 3.25;
+  io.c = "y";
+  io.d = 7;
+  c().bind("interiorOpaque", &io);
+
+  EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("show(interiorOpaque)")()), "{a=\"x\", b=3.25, c=\"y\", d=7}");
+  EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("show(recordTail(interiorOpaque))")()), "{b=3.25, c=\"y\", d=7}");
+}
+
 TEST(Structs, NoDuplicateFieldNames) {
   // reject outright construction of structs with duplicate field names
   bool introExn = false;

--- a/test/Structs.C
+++ b/test/Structs.C
@@ -127,6 +127,43 @@ TEST(Structs, ShowInteriorOpaqueFields) {
   EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("show(recordTail(interiorOpaque))")()), "{b=3.25, c=\"y\", d=7}");
 }
 
+// the same decomposition through the tuple branch: an inline opaque type in
+// non-final tuple position
+TEST(Structs, ShowInteriorOpaqueTuple) {
+  hobbes::tuple<std::string, int, double> p("abc", 42, 1.5);
+  EXPECT_EQ(makeStdString(c().compileFn<const array<char>*(const hobbes::tuple<std::string, int, double>&)>("p", "show(p)")(p)), "(\"abc\", 42, 1.5)");
+  EXPECT_EQ(makeStdString(c().compileFn<const array<char>*(const hobbes::tuple<std::string, int, double>&)>("p", "show(tupleTail(p))")(p)), "(42, 1.5)");
+}
+
+// and one level deeper: a nested struct member (with its own padding and its
+// own interior opaque field) between other fields
+DEFINE_STRUCT(
+  InnerOpaque,
+  (std::string, s),
+  (int,         y),
+  (long,        z)
+);
+
+DEFINE_STRUCT(
+  OuterOpaque,
+  (std::string, a),
+  (InnerOpaque, in),
+  (double,      d)
+);
+
+TEST(Structs, ShowNestedInteriorOpaqueFields) {
+  static OuterOpaque oo;
+  oo.a = "x";
+  oo.in.s = "y";
+  oo.in.y = 2;
+  oo.in.z = 3;
+  oo.d = 1.5;
+  c().bind("outerOpaque", &oo);
+
+  EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("show(outerOpaque)")()), "{a=\"x\", in={s=\"y\", y=2, z=3}, d=1.5}");
+  EXPECT_EQ(makeStdString(c().compileFn<const array<char>*()>("show(recordTail(outerOpaque))")()), "{in={s=\"y\", y=2, z=3}, d=1.5}");
+}
+
 TEST(Structs, NoDuplicateFieldNames) {
   // reject outright construction of structs with duplicate field names
   bool introExn = false;


### PR DESCRIPTION
Fixes #506.

## Problem

`show(r)` (and any other record-generic type class) failed with `Constraint not satisfiable: Show {...}` naming the entire record whenever a lifted struct had an opaque C++ field stored inline (e.g. `std::string` → `<std.string>`) in any position **except the last**:

```cpp
DEFINE_STRUCT(R, (std::string, f1), (double, d));
c.compileFn<const array<char>*(const R*)>("w", "show(w)");
// error: Constraint not satisfiable: Show { f1:<std.string>, d:double }
```

The same record with the opaque field last worked fine, which is why the failure surfaced only on wide reflection-generated structs (issue #506's record has interior `<std.string>` fields between enum/array/scalar fields — the large sum types and fixed arrays turned out to be innocent bystanders).

## Root cause

`RecordDeconstructor::satisfied` verified a `ConsRecord` decomposition by *reconstructing* a record from the constraint's head and tail types and comparing it to the original record type:

```cpp
return *stripHiddenFields(rty) == *stripHiddenFields(Record::make(fname->value(), cr.headType, tty->members()));
```

But `cr.headType` was produced by `refine()` from `Record::headMember()`, which normalizes inline opaque types to their by-reference form (`normIfOpaquePtr`). Since `MonoType::operator==` is interned-pointer identity, the reconstructed record (by-ref opaque head) can never equal the original (inline opaque head), so the constraint was reported unsatisfiable. With the opaque field in last position, the decomposition bottoms out in the unit-tail branch, which compares via `headMember()` on both sides — hence the position dependence.

## Fix

Compare the head field and the tail record independently — mirroring both what `refine()` unifies and how `VariantDeconstructor::satisfied` already does it — instead of reconstructing a record. Tail records are compared member-wise over visible fields so hidden padding fields and member offsets (which legitimately differ between a standalone record and the tail view of a larger one) don't affect the answer, and an all-hidden record is guarded before `headMember()`/`tailType()` (which throw).

## Testing

- New regression test `Structs.ShowInteriorOpaqueFields`: `show` on a lifted struct with two interior `std::string` fields, plus `show(recordTail(...))`, verifying both compile and produce the expected output. Fails on main, passes with this change.
- Reproduced the full record shape from #506 (fixed `char[8]`/`char[4]` arrays, 30-alternative nullary enum, packed `char` enum with non-contiguous values, 20+ `<std.string>` fields): `show` now compiles and prints correctly.
- Full `hobbes-test` suite passes (macOS arm64, LLVM 18, Release): all 18 groups green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFU79KXimuDCgfyTskFPUu