### PR TITLE
Reject path-traversing group names in hog batchrecv

### DIFF
--- a/bin/hog/batchrecv.C
+++ b/bin/hog/batchrecv.C
@@ -152,6 +152,13 @@ void runRecvConnection(SessionGroup* sg, NetConnection* pc, const std::string& d
     // get the log group for incoming data
     const std::string group = receiveString(*connection);
 
+    // the group name is attacker-controlled and is substituted into a filesystem
+    // path; reject anything that is not a single, non-hidden path component so a
+    // client cannot direct storage outside the configured data directory
+    if (!isValidGroupName(group)) {
+      throw std::runtime_error("rejected log session: invalid group name");
+    }
+
     // get the (compressed) init message data
     std::vector<uint8_t> inb = receiveBuffer(*connection);
     gzbuffer zb(inb, &outb);

--- a/bin/hog/path.H
+++ b/bin/hog/path.H
@@ -5,6 +5,25 @@
 
 namespace hog {
 
+// Is 'g' safe to substitute as the $GROUP component of a storage path?
+//
+// A group name arriving from an untrusted source (a batchrecv network client)
+// is substituted verbatim into a filesystem path template, so it must denote a
+// single, non-hidden path component. Reject anything that could escape the
+// intended data directory: empty names, a leading '.' (covers "." and ".." and
+// hidden dirs), and any name containing a path separator or NUL.
+inline bool isValidGroupName(const std::string& g) {
+  if (g.empty() || g[0] == '.') {
+    return false;
+  }
+  for (const char c : g) {
+    if (c == '/' || c == '\0') {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::string instantiateDir(const std::string& groupName, const std::string& dir);
 
 }


### PR DESCRIPTION
## Summary

hog `batchrecv` reads a log-group name from an **unauthenticated** network client (`batchrecv.C`) and substitutes it verbatim as the `$GROUP` component of the storage-path template via `instantiateDir` (`path.C`), which then feeds a recursive `mkdir`. Nothing validated the name, so a client sending a group like `../../../../var/www/html` could create directories — and drop storage files — **outside the configured data directory**.

## Fix

Validate the group name at the untrusted boundary (`runRecvConnection`) before it is used. A valid group must be a single, non-hidden path component: reject empty names, a leading `.` (covers `.`, `..`, and hidden dirs), and any name containing a path separator or NUL. Invalid names throw; the existing per-connection handler logs and tears the session down.

The check is applied **only on the recv path**, which is the security boundary — local/`batchsend` group names come from trusted local registration and are unaffected.

## Testing

- Unit-tested the (header-inline) `isValidGroupName` predicate: accepts ordinary names (`prod`, `md-feed_2024`, `a.b`); rejects `""`, `.`, `..`, `../../../escape/pwn`, `../etc`, `a/b`, `/abs`, `.ssh`, and embedded-NUL names.
- `hog` target builds clean (macOS, LLVM 18).

Note: hog's `bin/` code is not linked into `hobbes-test`, so this is validated by the standalone predicate test above plus the build rather than a `hobbes-test` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)