### PR TITLE
Bounds-check the binary MonoType decoder

### DIFF
--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -2353,9 +2353,23 @@ template <typename T>
     }
   }
 
+// the type decoders below consume a byte buffer that may be malformed or
+// truncated (it can originate from a file or an untrusted network peer), so
+// every read must confirm the requested span is present before touching it --
+// checked overflow-safely, since 'in.size() - *n' underflows once the cursor
+// has been advanced past the end.
+static void ensureAvail(const bytes& in, unsigned int n, size_t sz) {
+  if (n > in.size() || (in.size() - n) < sz) {
+    throw std::runtime_error(
+      "Encoded type information is truncated (need " + str::from(sz) +
+      " bytes at offset " + str::from(n) + " but only " + str::from(in.size()) + " available)");
+  }
+}
+
 template <typename T>
   struct readF {
     static T read(const bytes& in, unsigned int* n) {
+      ensureAvail(in, *n, sizeof(T));
       T r;
       std::memcpy(&r, &in[*n], sizeof(T));
       *n += sizeof(T);
@@ -2374,9 +2388,7 @@ template <>
   struct readF<std::string> {
     static std::string read(const bytes& in, unsigned int* n) {
       size_t sz = readF<size_t>::read(in, n);
-      if (sz > (in.size()-*n)) {
-        throw std::runtime_error("Encoded type information is invalid (recorded string with size=" + str::from(sz) + " but only " + str::from(in.size()-*n) + " bytes are available to read)");
-      }
+      ensureAvail(in, *n, sz);
       std::string r(reinterpret_cast<const char*>(&(in[*n])), sz);
       *n += sz;
       return r;

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -1,6 +1,7 @@
 
 #include "test.H"
 #include <hobbes/hobbes.H>
+#include <cstring>
 #include <memory>
 
 using namespace hobbes;
@@ -24,3 +25,39 @@ TEST(TypeInf, Unification) {
   EXPECT_TRUE(*substitute(&u, t0) == *t5);
 }
 
+
+TEST(TypeInf, DecodeRejectsTruncatedInput) {
+  // the binary type decoder consumes buffers that can be malformed or truncated
+  // (they may arrive from a file or an untrusted network peer), so a short or
+  // hostile buffer must throw rather than read out of bounds
+  MonoTypePtr ty = tuplety(list(primty("int"), arrayty(primty("char")), tvar("elephant")));
+
+  std::vector<unsigned char> enc;
+  encode(ty, &enc);
+  EXPECT_TRUE(enc.size() > 0);
+
+  // the full buffer round-trips
+  EXPECT_TRUE(show(decode(enc)) == show(ty));
+
+  // every proper-prefix truncation is rejected with an exception, not an
+  // out-of-bounds read
+  for (size_t k = 0; k < enc.size(); ++k) {
+    std::vector<unsigned char> trunc(enc.begin(), enc.begin() + static_cast<long>(k));
+    bool threw = false;
+    try { decode(trunc); } catch (const std::exception&) { threw = true; }
+    EXPECT_TRUE(threw);
+  }
+
+  // a length field that overruns the buffer must be rejected rather than trusted:
+  // encode a bare type variable ([int tag][size_t namelen][name...]) and rewrite
+  // the name length to SIZE_MAX -- the pre-fix code trusted this via a subtraction
+  // that underflows once the cursor passes the end of the buffer
+  std::vector<unsigned char> craft;
+  encode(tvar("x"), &craft);
+  EXPECT_TRUE(craft.size() >= sizeof(int) + sizeof(size_t));
+  size_t huge = ~static_cast<size_t>(0);
+  memcpy(&craft[sizeof(int)], &huge, sizeof(huge));
+  bool threw = false;
+  try { decode(craft); } catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+}


### PR DESCRIPTION
## Summary

The type-description decoder (`decodeFrom` and friends in `lib/hobbes/lang/type.C`) reads a byte buffer that can be malformed, truncated, or attacker-supplied. It backs `ty::decode`, which the net RPC layer (`lib/hobbes/ipc/net.C`) runs on type blobs from an **unauthenticated** peer (server side) and on blobs returned by a remote server (client side).

- The generic `readF<T>::read` did an unchecked `memcpy(&r, &in[*n], sizeof(T))`, so a short buffer read past the end. The discriminant tag, element counts, and offsets all funnel through it.
- The one existing guard, in `readF<std::string>`, was **bypassable**: `in.size() - *n` underflows (both unsigned) once an earlier unchecked read has advanced `*n` past `in.size()`, so the size check passed and the string read went out of bounds anyway.

## Fix

Add `ensureAvail(in, *n, sz)` — an overflow-safe check (`n > in.size() || in.size() - n < sz`) — and call it in the primitive reader before every `memcpy` and in the string reader before copying. Every read funnels through these two, so a truncated or hostile buffer now throws a `std::runtime_error` instead of reading out of bounds.

## Testing

New `TypeInf/DecodeRejectsTruncatedInput`:
- round-trips a composite type through `encode`/`decode`;
- asserts **every** proper-prefix truncation throws rather than crashing;
- asserts a type-variable buffer whose name-length field is rewritten to `SIZE_MAX` is rejected (the old underflow path).

Passes, and no regressions across `Storage`, `Structs`, `Definitions`, `Arrays`, `Compiler` (all of which round-trip types through the decoder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)