### PR TITLE
Reject oversized carray length in fregion reader (OOB write)

### DIFF
--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -1191,7 +1191,15 @@ template <typename T, size_t N>
   struct store<carray<T,N>, typename tbool<store<T>::can_memcpy>::type> : public storeCArrayDef<T,N> {
     static const bool can_memcpy = true;
     static void write(imagefile*, void*       p, const carray<T,N>& x) { memcpy(p, &x, storeCArrayDef<T,N>::alignment()+sizeof(T)*x.size); }
-    static void read(imagefile*,  const void* p, carray<T,N>*       x) { memcpy(reinterpret_cast<void*>(x),  p, storeCArrayDef<T,N>::alignment()+sizeof(T)*(*reinterpret_cast<const size_t*>(p))); }
+    static void read(imagefile*,  const void* p, carray<T,N>*       x) {
+      // the stored length comes from the file image and must not exceed the
+      // fixed capacity N, or the copy overruns x->data[N]
+      const size_t n = *reinterpret_cast<const size_t*>(p);
+      if (n > N) {
+        throw std::runtime_error("Not a valid structured data file: carray length (" + hobbes::string::from(n) + ") exceeds capacity (" + hobbes::string::from(N) + ")");
+      }
+      memcpy(reinterpret_cast<void*>(x), p, storeCArrayDef<T,N>::alignment()+sizeof(T)*n);
+    }
   };
 
 template <typename T, size_t N>
@@ -1206,9 +1214,15 @@ template <typename T, size_t N>
       }
     }
     static void read(imagefile* f, const void* p, carray<T,N>* x) {
-      x->size = *reinterpret_cast<const size_t*>(p);
+      // the stored length comes from the file image and must not exceed the
+      // fixed capacity N, or the loop writes past x->data[N]
+      const size_t n = *reinterpret_cast<const size_t*>(p);
+      if (n > N) {
+        throw std::runtime_error("Not a valid structured data file: carray length (" + hobbes::string::from(n) + ") exceeds capacity (" + hobbes::string::from(N) + ")");
+      }
+      x->size = n;
       p = reinterpret_cast<const uint8_t*>(p) + storeCArrayDef<T,N>::alignment();
-      for (size_t i = 0; i < x->size; ++i) {
+      for (size_t i = 0; i < n; ++i) {
         store<T>::read(f, p, &x->data[i]);
         p = reinterpret_cast<const uint8_t*>(p) + store<T>::size();
       }

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -1074,3 +1074,27 @@ TEST(Storage, AvoidTornRead) {
   }
 }
 
+
+TEST(Storage, FRegionCArrayRejectsOversizedLength) {
+  // the carray reader must reject a stored length larger than the fixed
+  // capacity N instead of copying it into x->data[N] (a file-image-driven
+  // out-of-bounds write)
+  using CA = hobbes::carray<double, 4>;
+  std::vector<uint8_t> buf(hobbes::fregion::storeCArrayDef<double, 4>::size(), 0);
+  CA dst;
+
+  // stored length 100 >> capacity 4 must throw, not overrun
+  *reinterpret_cast<size_t*>(buf.data()) = 100;
+  bool threw = false;
+  try { hobbes::fregion::store<CA>::read(nullptr, buf.data(), &dst); }
+  catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+
+  // a within-capacity length is still accepted
+  *reinterpret_cast<size_t*>(buf.data()) = 3;
+  threw = false;
+  try { hobbes::fregion::store<CA>::read(nullptr, buf.data(), &dst); }
+  catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(!threw);
+  EXPECT_EQ(dst.size, size_t(3));
+}


### PR DESCRIPTION
## Summary

`store<carray<T,N>>::read` (in `include/hobbes/fregion.H`) takes the array's element count straight from the mapped file image (`*(size_t*)p`) and copies that many elements into the fixed-capacity destination `carray<T,N>` — which is `{ size_t size; T data[N]; }`. Nothing checked the stored count against `N`, so a file whose `carray` length field exceeds `N` drives an **out-of-bounds write** past `x->data[N]`:

- the `memcpy` in the `can_memcpy` specialization, and
- the element loop in the general specialization.

This is the one file-image-driven OOB **write** in the fregion reader (most readers over-*read*), so it's the highest-impact of the parsing issues.

## Fix

Validate the stored length against the capacity `N` before copying, in both specializations, throwing the same `"Not a valid structured data file"` error the reader already raises for other corruption (consistent with the rest of `fregion.H`).

## Testing

New `Storage/FRegionCArrayRejectsOversizedLength`: a stored length of 100 into a capacity-4 `carray` now throws, while a within-capacity length still reads back correctly. Full `Storage` group passes (27/27).

## Note

This is part of a broader family of "trust a length/offset stored in the file image" issues in the fregion reader (unchecked `mapFileData` offsets, `count * sizeof(elem)` overflows in the string/vector/db-array loaders). Those are over-*reads* rather than an OOB write and are more entangled with the hot read path; I'm happy to follow up on them separately if you'd like the reader hardened against fully-untrusted file images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)