### PR TITLE
Add SECURITY.md and threat model documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you believe you have found a security issue or vulnerability in Hobbes, we
 encourage you to let us know right away. Please report it through Morgan
-Stanley's coordinated vulnerability disclosure process:
+Stanley's responsible disclosure program:
 
 https://www.morganstanley.com/vulnerability-disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,9 @@ design choices here. The full threat model is documented in
 
 * Memory unsafety (out-of-bounds read/write, use-after-free, unchecked
   allocation sizes) reachable from *malformed data*: structured data files
-  read by `fregion.H` / `hi` / `hog`, binary type descriptions decoded by
-  `ty::decode`, or network payloads processed before a peer would be trusted.
+  read by `hobbes::fregion::reader` / `hi` / `hog`, binary type descriptions
+  decoded by `hobbes::decode` (`hobbes/lang/type.H`), or network payloads
+  processed before a peer would be trusted.
 * Crashes or memory corruption in the lexer/parser triggered by malformed
   *source text*, as distinct from the behavior of successfully compiled code.
 * Vulnerabilities in the build, release, or CI pipeline of this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security issue or vulnerability in Hobbes, we
+encourage you to let us know right away. Please report it through Morgan
+Stanley's coordinated vulnerability disclosure process:
+
+https://www.morganstanley.com/vulnerability-disclosure
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+## Scope: what is (and is not) a vulnerability in Hobbes
+
+Hobbes is an embedded compiler and JIT. It runs inside a host process, with
+that process's privileges, and by design it is **not a sandbox**. Some
+behaviors that would be vulnerabilities in other software are intentional
+design choices here. The full threat model is documented in
+[doc/en/security.rst](doc/en/security.rst); in brief:
+
+**In scope** (please report):
+
+* Memory unsafety (out-of-bounds read/write, use-after-free, unchecked
+  allocation sizes) reachable from *malformed data*: structured data files
+  read by `fregion.H` / `hi` / `hog`, binary type descriptions decoded by
+  `ty::decode`, or network payloads processed before a peer would be trusted.
+* Crashes or memory corruption in the lexer/parser triggered by malformed
+  *source text*, as distinct from the behavior of successfully compiled code.
+* Vulnerabilities in the build, release, or CI pipeline of this repository.
+
+**Out of scope** (by design, not vulnerabilities):
+
+* Hobbes code having full access to the host process. Hobbes source code is
+  trusted code, equivalent to C++ compiled into the process. There is no
+  sandboxed runtime, no array bounds checking in generated code, and direct
+  memory access is a feature.
+* Remote code execution over the RPC/networking layer by a connected peer.
+  Hobbes RPC exists to let peers define and invoke native code remotely; it
+  must only be exposed on trusted internal networks (see the threat model).
+* Denial of service through legitimately compiled Hobbes code (e.g. a
+  nonterminating expression).
+
+## Supported Versions
+
+Security fixes are applied to the `main` branch. There are currently no
+maintained release branches; consumers are expected to track `main`.

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -31,7 +31,7 @@ Read on to discover more about the Hobbes language - its design and purpose, and
 
    **Hobbes Usage**
 
-   Hobbes is built for high performance integration with C/C++ applications. While Hobbes is a strongly typed language that offers compile-time checks, it doesn't have a sandboxed runtime environment or runtime safety features. By design, Hobbes gives direct access to memory and does not have array bounds checks. Additionally, Hobbes supports compilation and execution of native code remotely over a network (RPC). This feature is meant for use within your trusted internal network only. If you choose to utilize such functionality, you need to be aware of these design choices and understand the security implications.
+   Hobbes is built for high performance integration with C/C++ applications. While Hobbes is a strongly typed language that offers compile-time checks, it doesn't have a sandboxed runtime environment or runtime safety features. By design, Hobbes gives direct access to memory and does not have array bounds checks. Additionally, Hobbes supports compilation and execution of native code remotely over a network (RPC). This feature is meant for use within your trusted internal network only. If you choose to utilize such functionality, you need to be aware of these design choices and understand the security implications. See :doc:`security` for the full threat model.
 
 Contribution
 ============
@@ -97,6 +97,12 @@ License information `here <https://github.com/Morgan-Stanley/hobbes/blob/master/
 
   examples/simplerepl
   examples/raindrop_logger
+
+.. toctree::
+  :hidden:
+  :caption: Security
+
+  security
 
 .. toctree::
   :hidden:

--- a/doc/en/security.rst
+++ b/doc/en/security.rst
@@ -1,0 +1,98 @@
+Security Model
+**************
+
+This page describes the trust boundaries Hobbes assumes, what that means for
+applications embedding it, and which classes of behavior are considered
+security defects (please report those — see ``SECURITY.md`` in the repository
+root) versus intentional design.
+
+Hobbes is an embedded compiler and JIT for high-performance integration with
+C/C++ applications. It runs *inside* a host process, with the privileges of
+that process. It is not a sandbox, and the security boundary is always owned
+by the embedding application.
+
+Trust boundaries
+================
+
+Hobbes source code is trusted code
+----------------------------------
+
+Hobbes scripts and expressions are equivalent to C++ compiled into your
+process. Generated code has direct access to memory, arrays are not
+bounds-checked at runtime, and there are no runtime safety features or
+resource limits. Evaluating an expression means running native code with the
+full privileges of the host process.
+
+**Implication:** never compile and evaluate Hobbes source text from an
+untrusted party. Treat Hobbes source the way you treat C++ source: something
+you review and deploy, not something you accept as input.
+
+The parser, however, sits on the near side of this boundary: *reading* source
+text (lexing and parsing, before anything is compiled or evaluated) must be
+safe on arbitrary bytes. A crash or memory error in the lexer/parser on
+malformed input is a defect.
+
+Networking and RPC assume a trusted network
+-------------------------------------------
+
+The networking layer (``hobbes/ipc``, ``hobbes::net``, and ``hi -p``) lets a
+connected peer define and invoke expressions remotely — that is its purpose.
+A peer that can connect can execute native code in the server process.
+
+There is no built-in authentication, authorization, or transport encryption.
+
+**Implication:** only expose Hobbes RPC endpoints on trusted internal
+networks. If the transport crosses anything less trusted, the embedding
+application must provide the controls (network segmentation, firewalls,
+authenticated tunnels such as TLS or SSH).
+
+Protocol handling on the near side of the boundary must still be robust:
+malformed bytes on the wire — in particular the binary type descriptions
+decoded by ``ty::decode`` before any expression is accepted — must be
+rejected cleanly, never cause memory unsafety. Defects here are in scope for
+security reports.
+
+Structured data files assume a trusted writer
+---------------------------------------------
+
+Structured data (fregion) files — as produced by ``hog`` and read by ``hi``
+and the ``fregion.H`` reader — are memory-mapped into the reading process.
+The reader validates file structure (malformed images are rejected with an
+error rather than trusted), but these files are designed as a
+high-performance shared medium between cooperating processes, not as an
+interchange format for data from arbitrary sources.
+
+**Implications:**
+
+* Prefer reading structured data files written by processes you trust, and
+  use filesystem permissions to control who can write them: a writer shares a
+  memory mapping with every reader.
+* Even so, the reader's structural validation (file headers, page metadata,
+  environment records, stored lengths and offsets) must be safe on arbitrary
+  bytes. An out-of-bounds read or write triggered by a corrupt or crafted
+  file is a defect — report it.
+
+Summary table
+=============
+
+===============================================  ==========================================
+Input                                            Trust assumption
+===============================================  ==========================================
+Hobbes source (compiled and evaluated)           Trusted — equivalent to native code
+Hobbes source (lexed/parsed only)                Untrusted — parser must be safe
+RPC peers (post-handshake semantics)             Trusted — peers execute code by design
+RPC wire bytes (framing, type descriptions)      Untrusted — decoder must be safe
+Structured data files (fregion / hog logs)       Trusted writers — reader must still
+                                                 reject malformed images safely
+===============================================  ==========================================
+
+Guidance for embedding applications
+===================================
+
+* Run processes embedding Hobbes with the least privilege they need; assume
+  any Hobbes code they evaluate can do anything the process can do.
+* Keep RPC endpoints on trusted network segments; wrap them in authenticated,
+  encrypted transports if they must cross anything else.
+* Restrict write access to structured data files to the processes that are
+  supposed to produce them.
+* Keep up with ``main``: security fixes land there (see ``SECURITY.md``).

--- a/doc/en/security.rst
+++ b/doc/en/security.rst
@@ -48,7 +48,8 @@ authenticated tunnels such as TLS or SSH).
 
 Protocol handling on the near side of the boundary must still be robust:
 malformed bytes on the wire — in particular the binary type descriptions
-decoded by ``ty::decode`` before any expression is accepted — must be
+decoded by ``hobbes::decode`` (``hobbes/lang/type.H``) before any expression
+is accepted — must be
 rejected cleanly, never cause memory unsafety. Defects here are in scope for
 security reports.
 
@@ -56,7 +57,8 @@ Structured data files assume a trusted writer
 ---------------------------------------------
 
 Structured data (fregion) files — as produced by ``hog`` and read by ``hi``
-and the ``fregion.H`` reader — are memory-mapped into the reading process.
+and the ``hobbes::fregion::reader`` API (declared in ``hobbes/fregion.H``) —
+are memory-mapped into the reading process.
 The reader validates file structure (malformed images are rejected with an
 error rather than trusted), but these files are designed as a
 high-performance shared medium between cooperating processes, not as an


### PR DESCRIPTION
## Summary

Adds a repository-level security policy and a documented threat model, so that (a) researchers who find issues have a clear reporting channel and scope statement, and (b) embedding applications deploy Hobbes with correct assumptions about its trust boundaries.

- **SECURITY.md**: points at Morgan Stanley's coordinated vulnerability disclosure process (same channel as the org-level policy), and spells out what is in scope for security reports (memory unsafety reachable from malformed data — fregion files, `ty::decode` wire bytes, parser input) versus intentional design (Hobbes code has full host-process access; RPC peers execute code by design on trusted networks).
- **doc/en/security.rst**: a Security Model page for the Sphinx docs covering each trust boundary — source text (trusted when evaluated, parser must be safe on arbitrary bytes), networking/RPC (trusted network assumption, no built-in authn/encryption), and structured data files (trusted writers, reader must still reject malformed images safely) — plus embedding guidance. Wired into the docs toctree; the existing security note in the index now links to it.

No code changes.

## Testing

- Verified the rst simple-table column alignment mechanically; sphinx not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)