### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+# OpenSSF Scorecard supply-chain security analysis.
+# https://github.com/ossf/scorecard-action
+name: Scorecard supply-chain security
+on:
+  # Re-run when branch protection settings change (Scorecard measures them)
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'
+  push:
+    branches: [main]
+
+# Default to no permissions; the analysis job requests what it needs
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the SARIF results to the code-scanning dashboard
+      security-events: write
+      # Needed to publish results to the OpenSSF REST API (for the badge)
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,14 +9,18 @@ on:
   push:
     branches: [main]
 
-# Default to no permissions; the analysis job requests what it needs
+# Read-only by default; the analysis job adds the write scopes it needs
 permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # Job-level permissions replace the workflow-level ones entirely, so
+    # grant the checkout read scope here alongside the write scopes
     permissions:
+      # Needed by actions/checkout to clone the repository
+      contents: read
       # Needed to upload the SARIF results to the code-scanning dashboard
       security-events: write
       # Needed to publish results to the OpenSSF REST API (for the badge)


### PR DESCRIPTION
## Summary

Adds an OpenSSF Scorecard workflow that runs the supply-chain security analysis weekly, on pushes to `main`, and whenever branch protection settings change (Scorecard measures those). Results go two places:

- **Published to the OpenSSF REST API** (`publish_results: true`), which enables the public score and README badge: `https://api.scorecard.dev/projects/github.com/morganstanley/hobbes/badge`. I've left the badge out of the README until a first successful publish confirms the score renders; happy to add it here or in a follow-up.
- **Uploaded as SARIF to the code-scanning dashboard**, so individual check findings show up under Security → Code scanning.

Details:

- Actions are pinned by commit SHA with version comments, per Scorecard's own Pinned-Dependencies guidance; the existing Dependabot `github-actions` config keeps the pins updated.
- Top-level `permissions: read-all`; the analysis job requests only `security-events: write` (SARIF upload) and `id-token: write` (OIDC for publishing).

Several checks should score well immediately from existing practice (Dependency-Update-Tool via Dependabot + Renovate, CI-Tests, Security-Policy once #514 lands, Fuzzing once #515 lands and OSS-Fuzz onboarding follows). Others surface repo settings only maintainers can adjust (branch protection, default token permissions) — the weekly run gives a concrete, quantified list.

## Testing

- YAML validated locally. The analysis itself only runs meaningfully once merged to `main` (Scorecard evaluates the default branch); `publish_results` requires the workflow to run from the default branch of the upstream repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)