### PR TITLE
Fix sanitizer option name to match its condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${cxx_flags}")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
-option(USE_ASAN_UBSAN "Use address,undefined sanitizers" OFF)
+option(USE_ASAN_AND_UBSAN "Use address,undefined sanitizers" OFF)
 if(USE_ASAN_AND_UBSAN)
   # _FORTIFY_SOURCE doesn't play well with asan
   # https://github.com/google/sanitizers/issues/247

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,10 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
 option(USE_ASAN_AND_UBSAN "Use address,undefined sanitizers" OFF)
+if(USE_ASAN_UBSAN)
+  message(DEPRECATION "USE_ASAN_UBSAN is deprecated (it previously had no effect); use USE_ASAN_AND_UBSAN")
+  set(USE_ASAN_AND_UBSAN ON)
+endif()
 if(USE_ASAN_AND_UBSAN)
   # _FORTIFY_SOURCE doesn't play well with asan
   # https://github.com/google/sanitizers/issues/247


### PR DESCRIPTION
## Summary

`CMakeLists.txt` declares `option(USE_ASAN_UBSAN ...)` but the condition that enables the sanitizer flags checks `if(USE_ASAN_AND_UBSAN)` — so the declared option is a no-op, and `-DUSE_ASAN_UBSAN=ON` silently does nothing. Everything that actually enables sanitizers (`nix/overlays.nix`, and through it the CI ASanAndUBSan builds) passes `-DUSE_ASAN_AND_UBSAN=ON`, which only works because CMake lets an undeclared cache variable satisfy `if()`.

This renames the declared option to `USE_ASAN_AND_UBSAN` so the declaration matches the condition and all existing usage keeps working unchanged. One-line change.

## Testing

- Verified `nix/overlays.nix` is the only place that passes the variable, and it already uses the `USE_ASAN_AND_UBSAN` spelling; no other references exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)