### PR TITLE
Add CodeQL analysis and harden existing workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: "Build"
 on: [push, pull_request]
+# Least privilege by default; jobs opt into more where needed
+permissions:
+  contents: read
+
 jobs:
   linux-clang-ASanAndUBSan-build:
     runs-on: ${{matrix.os}}
@@ -8,15 +12,15 @@ jobs:
         os: [ubuntu-24.04]
         clang: [16, 18, 20, 21]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
             # Nix Flakes doesn't work on shallow clones
             fetch-depth: 0
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes ca-references
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.10'
       - name: nix build hobbesPackages/clang-${{ matrix.clang }}-ASanAndUBSan/hobbes
@@ -28,7 +32,7 @@ jobs:
           nix log  .#hobbesPackages/clang-${{ matrix.clang }}-ASanAndUBSan/hobbes &> ${{ matrix.os }}-clang-${{ matrix.clang }}-ASanAndUBSan-hobbes.log
       - name: upload log ${{ matrix.os }}-clang-${{ matrix.clang }}-ASanAndUBSan-hobbes.log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: output-log-file-${{ matrix.os }}-clang-${{ matrix.clang }}-ASanAndUBSan-hobbes
           path: ${{ matrix.os }}-clang-${{ matrix.clang }}-ASanAndUBSan-hobbes.log
@@ -39,15 +43,15 @@ jobs:
         os: [ubuntu-24.04]
         clang: [16, 18, 20, 21]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
             # Nix Flakes doesn't work on shallow clones
             fetch-depth: 0
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes ca-references
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.10'
       - name: nix build hobbesPackages/clang-${{ matrix.clang }}/hobbes
@@ -62,7 +66,7 @@ jobs:
           nix log  .#hobbesPackages/clang-${{ matrix.clang }}/hobbes &> ${{ matrix.os }}-clang-${{ matrix.clang }}-hobbes.log
       - name: upload log ${{ matrix.os }}-clang-${{ matrix.clang }}-hobbes.log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: output-log-file-${{ matrix.os }}-clang-${{ matrix.clang }}
           path: ${{ matrix.os }}-clang-${{ matrix.clang }}-hobbes.log
@@ -74,15 +78,15 @@ jobs:
         gcc: [13, 14, 15]
         llvm: [16, 18, 19, 20, 21]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
             # Nix Flakes doesn't work on shallow clones
             fetch-depth: 0
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes ca-references
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.10'
       - name: nix build hobbesPackages/gcc-${{ matrix.gcc }}/llvm-${{ matrix.llvm }}/hobbes
@@ -94,7 +98,7 @@ jobs:
           nix log  .#hobbesPackages/gcc-${{ matrix.gcc }}/llvm-${{ matrix.llvm }}/hobbes &> ${{ matrix.os }}-gcc-${{ matrix.gcc }}-llvm-${{ matrix.llvm }}-hobbes.log
       - name: upload log ${{ matrix.os }}-gcc-${{ matrix.gcc }}-llvm-${{ matrix.llvm }}-hobbes.log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: output-log-file-${{ matrix.os }}-gcc-${{ matrix.gcc }}-llvm-${{ matrix.llvm }}
           path: ${{ matrix.os }}-gcc-${{ matrix.gcc }}-llvm-${{ matrix.llvm }}-hobbes.log
@@ -105,7 +109,7 @@ jobs:
     container:
       image: rockylinux:9
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           dnf update -y
@@ -125,7 +129,7 @@ jobs:
           make test
       - name: Upload build logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rhel9-build-logs
           path: build/
@@ -145,7 +149,7 @@ jobs:
             libncurses-dev zlib1g-dev libreadline-dev libzstd-dev \
             python3 \
             llvm-dev clang libclang-dev
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Build hobbes
         run: |
           mkdir -p build && cd build
@@ -157,14 +161,14 @@ jobs:
           make test
       - name: Upload build logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ubuntu2604-build-logs
           path: build/
   apt-llvm22-build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install LLVM 22 from apt.llvm.org
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -193,7 +197,7 @@ jobs:
     container:
       image: quay.io/rockylinux/rockylinux:10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           dnf update -y
@@ -212,7 +216,7 @@ jobs:
           make test
       - name: Upload build logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rhel10-build-logs
           path: build/
@@ -223,8 +227,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -247,8 +251,8 @@ jobs:
       matrix:
         llvm: [18]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,63 @@
+# CodeQL static analysis for the C/C++ sources.
+#
+# C/C++ analysis requires CodeQL to observe a real compilation, so this uses
+# build-mode: manual with the same stock-apt LLVM toolchain as the other
+# Ubuntu build jobs. The build is heavy (~15-25 min), so this runs on pushes
+# to main and weekly rather than on every pull request.
+name: "CodeQL"
+on:
+  push:
+    branches: [main]
+  # Also validate the workflow itself when it changes
+  pull_request:
+    paths: ['.github/workflows/codeql.yml']
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+# Least privilege by default; the analysis job opts into more
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze C/C++
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      # Needed by actions/checkout to clone the repository
+      contents: read
+      # Needed to upload the analysis results to the code-scanning dashboard
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake make ca-certificates \
+            libncurses-dev zlib1g-dev libreadline-dev libzstd-dev \
+            python3 \
+            llvm-18-dev clang-18 libclang-18-dev
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      - name: Build hobbes
+        run: |
+          CC=clang-18 CXX=clang++-18 cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm
+          cmake --build build -j"$(nproc)"
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: "/language:c-cpp"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,13 +5,17 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege by default; jobs opt into more where needed
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
       image: rockylinux:9
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           dnf update -y
@@ -63,7 +67,7 @@ jobs:
           cat coverage-summary.txt >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: coverage-html
   deploy:
@@ -79,4 +83,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
## Summary

Addresses the three OpenSSF Scorecard checks that currently score **0** and are fixable in-repo. The published score after the recent merges is **7.5** — these should take it to roughly 9 (the remainder is branch protection, which needs repo-admin settings, and signed releases).

**SAST (0/10)** — adds `.github/workflows/codeql.yml` for the C/C++ sources. C/C++ analysis requires CodeQL to observe a real compilation, so it uses `build-mode: manual` with the same stock-apt LLVM toolchain as the other Ubuntu jobs (`autobuild` won't handle the LLVM dependency). Because the build takes ~15–25 minutes, it runs on pushes to `main`, weekly, and on demand — *not* on every PR — plus on PRs that touch the workflow file itself so it can be validated before merging.

Note this is CodeQL *advanced setup* (a workflow file), which needs no repository admin toggle — the same pattern `morganstanley/testplan` uses. If anyone separately enables CodeQL *default setup* in repo settings, that would duplicate analyses and should be left off.

**Token-Permissions (0/10)** — adds top-level `permissions: contents: read` to `build.yml` and `coverage.yml`, which previously ran with the default over-privileged token. The one job needing more (the Pages deploy) already declares its own scopes.

**Pinned-Dependencies (0/10)** — pins all GitHub Actions by commit SHA with version comments: 23 references in `build.yml`, 3 in `coverage.yml`. The existing Dependabot `github-actions` config keeps them updated, and this matches how `scorecard.yml` was already written.

## Testing

- All four workflow files validated as YAML; confirmed no unpinned `@vN` action references remain.
- The CodeQL job runs on this PR (via the workflow-path trigger), so its build steps are exercised before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)