### PR TITLE
Call variant payload functions through a correctly typed thunk

### DIFF
--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -506,10 +506,17 @@ template <size_t i, typename R, template <size_t,class,class> class F, typename 
 template <size_t i, typename R, template <size_t,class,class> class F, typename U, typename ... Args, typename Ctor, typename ... Ctors>
   struct variantAppInit<i, R, F, U, tuple<Args...>, Ctor, Ctors...> {
     using PF = R (*)(void *, Args...);
+
+    // Reach the constructor-typed function through a thunk that genuinely has
+    // the erased signature. Casting the function pointer itself and calling
+    // through the mismatched type is undefined behavior even where the ABI
+    // agrees, and -fsanitize=function traps on it.
+    static R thunk(void* p, Args... args) {
+      return F<i, Ctor, U>::fn(reinterpret_cast<Ctor*>(p), args...);
+    }
+
     static bool init(PF* pfs) {
-      using TPF = R (*)(Ctor *, Args...);
-      TPF tpf = &F<i, Ctor, U>::fn;
-      pfs[i] = reinterpret_cast<PF>(tpf);
+      pfs[i] = &thunk;
       return variantAppInit<i+1, R, F, U, tuple<Args...>, Ctors...>::init(pfs);
     }
   };

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -511,6 +511,15 @@ template <size_t i, typename R, template <size_t,class,class> class F, typename 
     // the erased signature. Casting the function pointer itself and calling
     // through the mismatched type is undefined behavior even where the ABI
     // agrees, and -fsanitize=function traps on it.
+    //
+    // The thunk calls fn rather than binding its address, which would accept
+    // implicitly convertible arguments and hide a signature mismatch, so
+    // require the exact signature explicitly -- the check the previous
+    // 'TPF tpf = &F<i, Ctor, U>::fn;' assignment performed implicitly.
+    static_assert(
+      std::is_same<decltype(&F<i, Ctor, U>::fn), R (*)(Ctor *, Args...)>::value,
+      "variant payload function must have signature R(Ctor*, Args...)");
+
     static R thunk(void* p, Args... args) {
       return F<i, Ctor, U>::fn(reinterpret_cast<Ctor*>(p), args...);
     }


### PR DESCRIPTION
## Summary

`variantAppInit::init` stored each per-constructor function by `reinterpret_cast`-ing `R(*)(Ctor*, Args...)` to `R(*)(void*, Args...)`, and `variantApp::apply` then **called** it through that mismatched type. Calling a function through an incompatible function pointer type is undefined behavior even where the ABI happens to agree, and `-fsanitize=function` traps on it:

```
include/hobbes/reflect.H:531:7: runtime error: call to function
hobbes::variantPayloadDtor<0ul, hobbes::unit, void>::fn(hobbes::unit*)
through pointer to incorrect function type 'void (*)(void *)'
```

The practical impact: **constructing a `hobbes::cc` aborts immediately under any UBSan build**, before any work is done (it fires during prelude type-lifting via `cc::defineNamedType` → `TClass::insert`). That makes sanitizer-instrumented fuzzing of the parser impossible — it was found while standing up a fuzzing campaign against the harnesses from #515.

The fix stores a thunk that genuinely has the erased signature and casts the payload pointer inside, so no call goes through a mismatched type. One thunk covers both the void and non-void specializations, since returning a void expression from a void function is well-formed.

## Testing

- Reproduced on **macOS arm64 (clang 20)** and **x86_64 Linux (clang 18)** — the abort fires at `cc` construction on any UBSan build, independent of input, so it is not platform-specific.
- With the change, `Variants`, `Structs`, `TypeInf`, `Matching`, `Compiler`, `Arrays`, `Definitions`, `Existentials`, `Recursives` and `Objects` all pass (macOS arm64, clang 18 Debug).

Worth noting the existing `linux-clang-ASanAndUBSan` CI jobs pass today, so `-fsanitize=function` does not appear to be active there — that may be a gap worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)