### PR TITLE
Fix out-of-bounds read on a truncated hex escape in str::unescape

### DIFF
--- a/lib/hobbes/util/str.C
+++ b/lib/hobbes/util/str.C
@@ -1,5 +1,6 @@
 
 #include <hobbes/util/str.H>
+#include <iterator>
 #include <memory>
 #include <wordexp.h>
 #include <glob.h>
@@ -376,9 +377,13 @@ std::string unescape(const std::string& cs) {
         result.put('\0');
         break;
       case 'x': {
+          // only step onto a digit that exists: incrementing an iterator that
+          // is already at the end is undefined, and leaves the following
+          // 'c != cs.end()' guard passing on a past-the-end iterator, so a
+          // string ending in "\x" read one byte beyond the buffer
           char b1 = 0; char b2 = 0;
-          ++c; if (c != cs.end()) b1 = *c;
-          ++c; if (c != cs.end()) b2 = *c;
+          if (std::next(c) != cs.end()) { ++c; b1 = *c; }
+          if (std::next(c) != cs.end()) { ++c; b2 = *c; }
           result.put((denyb(b1) << 4) + denyb(b2));
           break;
         }

--- a/test/Str.C
+++ b/test/Str.C
@@ -1,0 +1,31 @@
+#include "test.H"
+#include <hobbes/util/str.H>
+#include <string>
+
+using namespace hobbes;
+
+TEST(Str, UnescapeTruncatedHexEscape) {
+  // unescape runs on string and char literals taken from source text, which
+  // the parser reads before anything is compiled, so it has to be safe on
+  // arbitrary input. A truncated "\x" escape used to step its iterator past
+  // the end of the string and read the byte beyond it.
+  EXPECT_TRUE(str::unescape("\\x").empty() || str::unescape("\\x").size() == 1);
+
+  // a hex escape with only one digit, at the very end
+  std::string one = str::unescape("\\xA");
+  EXPECT_TRUE(one.size() == 1);
+
+  // the same cases with leading text, so the escape is not also the first char
+  EXPECT_TRUE(str::unescape("ab\\x").size() >= 2);
+  EXPECT_TRUE(str::unescape("ab\\xA").size() == 3);
+
+  // well-formed escapes are unaffected
+  EXPECT_TRUE(str::unescape("\\x41") == "A");
+  EXPECT_TRUE(str::unescape("a\\x41b") == "aAb");
+  EXPECT_TRUE(str::unescape("\\n").size() == 1 && str::unescape("\\n")[0] == '\n');
+  EXPECT_TRUE(str::unescape("\\t").size() == 1 && str::unescape("\\t")[0] == '\t');
+  EXPECT_TRUE(str::unescape("plain") == "plain");
+
+  // a trailing lone backslash must also be handled without overrunning
+  EXPECT_TRUE(str::unescape("abc\\").size() >= 3);
+}

--- a/test/Str.C
+++ b/test/Str.C
@@ -9,15 +9,25 @@ TEST(Str, UnescapeTruncatedHexEscape) {
   // the parser reads before anything is compiled, so it has to be safe on
   // arbitrary input. A truncated "\x" escape used to step its iterator past
   // the end of the string and read the byte beyond it.
-  EXPECT_TRUE(str::unescape("\\x").empty() || str::unescape("\\x").size() == 1);
+  // missing digits are treated as zero, so "\x" yields exactly one NUL byte
+  std::string none = str::unescape("\\x");
+  EXPECT_EQ(none.size(), size_t(1));
+  EXPECT_EQ(int(static_cast<unsigned char>(none[0])), 0);
 
-  // a hex escape with only one digit, at the very end
+  // a hex escape with only one digit, at the very end: the present digit is
+  // the high nibble and the missing one is zero
   std::string one = str::unescape("\\xA");
-  EXPECT_TRUE(one.size() == 1);
+  EXPECT_EQ(one.size(), size_t(1));
+  EXPECT_EQ(int(static_cast<unsigned char>(one[0])), 0xA0);
 
   // the same cases with leading text, so the escape is not also the first char
-  EXPECT_TRUE(str::unescape("ab\\x").size() >= 2);
-  EXPECT_TRUE(str::unescape("ab\\xA").size() == 3);
+  std::string pre = str::unescape("ab\\x");
+  EXPECT_EQ(pre.size(), size_t(3));
+  EXPECT_EQ(int(static_cast<unsigned char>(pre[2])), 0);
+
+  std::string preOne = str::unescape("ab\\xA");
+  EXPECT_EQ(preOne.size(), size_t(3));
+  EXPECT_EQ(int(static_cast<unsigned char>(preOne[2])), 0xA0);
 
   // well-formed escapes are unaffected
   EXPECT_TRUE(str::unescape("\\x41") == "A");
@@ -26,6 +36,7 @@ TEST(Str, UnescapeTruncatedHexEscape) {
   EXPECT_TRUE(str::unescape("\\t").size() == 1 && str::unescape("\\t")[0] == '\t');
   EXPECT_TRUE(str::unescape("plain") == "plain");
 
-  // a trailing lone backslash must also be handled without overrunning
-  EXPECT_TRUE(str::unescape("abc\\").size() >= 3);
+  // a trailing lone backslash must also be handled without overrunning: it
+  // opens an escape that never completes, so it contributes nothing
+  EXPECT_TRUE(str::unescape("abc\\") == "abc");
 }


### PR DESCRIPTION
Found by an overnight fuzzing campaign against the harnesses from #515, reported as a heap-buffer-overflow reached through `cc::readExpr`.

## The problem

The `\\x` branch of `str::unescape` stepped its iterator twice with the end check placed *after* each increment:

```cpp
++c; if (c != cs.end()) b1 = *c;
++c; if (c != cs.end()) b2 = *c;
```

Incrementing an iterator that already equals `end()` is undefined, and it leaves the following guard passing on a past-the-end iterator — so `*c` reads the byte after the buffer. A string ending in `\\x` takes that path directly, and one ending in `\\xA` hits the same problem via the loop's own increment.

## The fix

Only step onto a digit that exists (`std::next(c) != cs.end()`), which leaves missing digits as zero exactly as the guarded case already intended. No change to well-formed escapes.

`unescape` runs on string and character literals taken from source text, which the parser reads *before* anything is compiled or evaluated. Per the threat model in `doc/en/security.rst`, evaluating Hobbes code is running trusted native code, but reading source text sits on the near side of that boundary and must be safe on arbitrary bytes.

## Testing

- New `test/Str.C` with `Str/UnescapeTruncatedHexEscape`, covering truncated escapes both at and after the start of a string, a single-digit escape at the end, a trailing lone backslash, and well-formed escapes (`\\x41`, `\\n`, `\\t`) that must be unchanged.
- `Str`, `Structs`, `TypeInf`, `Compiler`, `Arrays`, `Definitions`, `Matching`, `Objects`, `Storage` and `Variants` all pass (macOS arm64, clang 18 Debug).

Third of three fixes from the campaign, alongside #521 (stream codec) and #522 (fregion reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)