### PR TITLE
Add a signed source release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,24 @@ jobs:
           ref: ${{ steps.tag.outputs.name }}
           persist-credentials: false
 
+      - name: Resolve the codename
+        id: codename
+        env:
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          major="${version%%.*}"
+          # each major version is named by the matching row in
+          # RELEASE_CODENAMES.tsv; an unnamed major simply has no codename
+          codename="$(awk -F'\t' -v m="$major" '!/^#/ && $1 == m { print $3 }' RELEASE_CODENAMES.tsv)"
+          if [ -n "$codename" ]; then
+            echo "title=${TAG} \"${codename}\"" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "codename=${codename}" >> "$GITHUB_OUTPUT"
+
       - name: Build the source archive
         id: archive
         env:
@@ -90,7 +108,7 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.tag.outputs.name }}
-          name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.codename.outputs.title }}
           generate_release_notes: true
           files: |
             ${{ steps.archive.outputs.name }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,17 +44,35 @@ jobs:
     steps:
       - name: Resolve tag
         id: tag
+        env:
+          # via env rather than inline expansion, so the value cannot be
+          # interpreted as shell
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            tag="$INPUT_TAG"
           else
-            echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            tag="$GITHUB_REF_NAME"
           fi
+
+          # The tag name becomes an archive filename and a tar prefix, and
+          # workflow_dispatch will accept any ref, so require it to look like a
+          # version tag and contain nothing path-like before going further.
+          case "$tag" in
+            v[0-9]*) ;;
+            *) echo "refusing to release from '$tag': expected a v<version> tag" >&2; exit 1 ;;
+          esac
+          case "$tag" in
+            *[!A-Za-z0-9.+_-]*) echo "refusing to release from '$tag': unexpected characters" >&2; exit 1 ;;
+          esac
+
+          echo "name=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Checkout the tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.tag.outputs.name }}
+          ref: refs/tags/${{ steps.tag.outputs.name }}
           persist-credentials: false
 
       - name: Resolve the codename

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+# Publish a signed source release.
+#
+# Hobbes is consumed as source -- downstream applications compile it -- so no
+# build artifacts are published. What is published is the source archive that
+# corresponds to a tag, a checksum file, and a signature over that checksum
+# file, so a consumer can verify that the source they built came from this
+# repository at this tag.
+#
+# Signing is keyless (Sigstore): the signature is bound to this workflow's
+# OIDC identity and recorded in the public Rekor transparency log, so there is
+# no signing key to issue, store or rotate.
+#
+# To cut a release, push a signed tag:
+#
+#   git tag -s v1.0.0 -m "hobbes 1.0.0"
+#   git push origin v1.0.0
+#
+# The tag name is the release name; nothing here invents a version.
+name: "Release"
+on:
+  push:
+    tags: ['v*']
+  # allows re-running against an existing tag without re-pushing it
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish (e.g. v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Publish signed source release
+    runs-on: ubuntu-latest
+    permissions:
+      # create the release and upload its assets
+      contents: write
+      # keyless signing via Sigstore
+      id-token: write
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout the tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+          persist-credentials: false
+
+      - name: Build the source archive
+        id: archive
+        env:
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          name="hobbes-${version}"
+          # git archive is reproducible for a given tree, unlike the
+          # auto-generated GitHub tarball whose compression has changed before
+          git archive --format=tar --prefix="${name}/" "$TAG" \
+            | gzip -n > "${name}.tar.gz"
+          sha256sum "${name}.tar.gz" > SHA256SUMS
+          cat SHA256SUMS
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the checksum file
+        run: |
+          set -euo pipefail
+          # sign the checksums rather than the archive: one signature covers
+          # every asset listed, and verifying it needs no large download
+          cosign sign-blob --yes \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+
+      - name: Publish the release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          generate_release_notes: true
+          files: |
+            ${{ steps.archive.outputs.name }}.tar.gz
+            SHA256SUMS
+            SHA256SUMS.sig
+            SHA256SUMS.pem

--- a/README.md
+++ b/README.md
@@ -1346,3 +1346,11 @@ Releases are cut by pushing a signed tag, which names the release:
 git tag -s v1.0.0 -m "hobbes 1.0.0"
 git push origin v1.0.0
 ```
+
+Each major version also carries a codename — two alliterative words from
+philosophy, lettered in order, so `v1.x` is *Analytic Aporia*, `v2.x` is
+*Being Becoming*, and so on through *Zeno's Zenith*. The full list lives in
+[RELEASE_CODENAMES.tsv](RELEASE_CODENAMES.tsv); the release workflow reads it
+to title the release (`v1.0.0 "Analytic Aporia"`). The tag remains the
+authoritative version — the codename is decoration, and a major version with
+no row simply has none.

--- a/README.md
+++ b/README.md
@@ -1327,20 +1327,25 @@ archive, a `SHA256SUMS` file, and a Sigstore signature over those checksums.
 
 Signing is keyless — the signature is bound to the release workflow's OIDC
 identity and recorded in the public Rekor transparency log — so there is no
-signing key to manage. To verify a release:
+signing key to manage. Verify against that exact identity: the pattern below
+binds to this repository, this workflow file *and* a tag ref, so a signature
+produced by any other workflow here would not be accepted.
 
 ```bash
 cosign verify-blob \
   --certificate SHA256SUMS.pem \
   --signature SHA256SUMS.sig \
-  --certificate-identity-regexp '^https://github.com/morganstanley/hobbes/' \
+  --certificate-identity-regexp \
+    '^https://github\.com/morganstanley/hobbes/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
 
 sha256sum -c SHA256SUMS
 ```
 
-Releases are cut by pushing a signed tag, which names the release:
+Releases are cut by pushing a tag matching `v*`, which names the release.
+Signing the tag is recommended — it attests who cut it — but the workflow
+does not require it, and the release signature is independent of it:
 
 ```bash
 git tag -s v1.0.0 -m "hobbes 1.0.0"

--- a/README.md
+++ b/README.md
@@ -1318,3 +1318,31 @@ Another example we've seen earlier is the hobbes `Connect` constraint.  This als
 
 These are just some examples of extensions to hobbes through the `Unqualifier` interface, but there are undoubtedly many other ways that this option can be useful to applications using hobbes.
 
+
+## Releases
+
+Releases are source-only: Hobbes is consumed by compiling it, so no build
+artifacts are published. Each release consists of a reproducible source
+archive, a `SHA256SUMS` file, and a Sigstore signature over those checksums.
+
+Signing is keyless — the signature is bound to the release workflow's OIDC
+identity and recorded in the public Rekor transparency log — so there is no
+signing key to manage. To verify a release:
+
+```bash
+cosign verify-blob \
+  --certificate SHA256SUMS.pem \
+  --signature SHA256SUMS.sig \
+  --certificate-identity-regexp '^https://github.com/morganstanley/hobbes/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+
+sha256sum -c SHA256SUMS
+```
+
+Releases are cut by pushing a signed tag, which names the release:
+
+```bash
+git tag -s v1.0.0 -m "hobbes 1.0.0"
+git push origin v1.0.0
+```

--- a/RELEASE_CODENAMES.tsv
+++ b/RELEASE_CODENAMES.tsv
@@ -1,0 +1,33 @@
+# Release codenames, one per major version: v<major>.x.y is named by the
+# <major>'th letter. Two alliterative words drawn from philosophy.
+#
+# Read by .github/workflows/release.yml to title the release. Adding a row
+# here is all that is needed to name a future major version.
+#
+# major	letter	codename
+1	A	Analytic Aporia
+2	B	Being Becoming
+3	C	Categorical Cogito
+4	D	Dialectical Dasein
+5	E	Empirical Epoché
+6	F	Fallibilist Forms
+7	G	Given Ground
+8	H	Hermeneutic Horizon
+9	I	Immanent Idea
+10	J	Just Judgment
+11	K	Kantian Kingdom
+12	L	Logical Logos
+13	M	Material Monad
+14	N	Noumenal Now
+15	O	Ontic Openness
+16	P	Phenomenal Praxis
+17	Q	Quiet Quietism
+18	R	Rational Recurrence
+19	S	Skeptical Sublime
+20	T	Transcendental Telos
+21	U	Universal Unmoved
+22	V	Virtuous Void
+23	W	Willed World
+24	X	Xenial
+25	Y	Yielding Yoke
+26	Z	Zeno's Zenith

--- a/RELEASE_CODENAMES.tsv
+++ b/RELEASE_CODENAMES.tsv
@@ -28,6 +28,6 @@
 21	U	Universal Unmoved
 22	V	Virtuous Void
 23	W	Willed World
-24	X	Xenial
+24	X	Xenial Xenia
 25	Y	Yielding Yoke
 26	Z	Zeno's Zenith


### PR DESCRIPTION
Closes the last in-repo gap from the OpenSSF Scorecard work (#516, #518): the repository has never cut a release, so consumers build from `main` with no way to state which source they compiled, and Signed-Releases is unscored.

## Source-only, by design

Hobbes is consumed by compiling it, so **no build artifacts are published**. A release is:

| Asset | What it is |
| --- | --- |
| `hobbes-<version>.tar.gz` | source archive for the tag |
| `SHA256SUMS` | checksum of that archive |
| `SHA256SUMS.sig` + `SHA256SUMS.pem` | Sigstore signature and certificate |

Signing the checksum file rather than the archive means one signature covers every asset listed, and verifying it needs no large download.

## No signing key to manage

Signing is **keyless** via Sigstore: the signature is bound to the workflow's OIDC identity and recorded in the public Rekor transparency log. There is no key to issue, store or rotate, and the workflow needs no repository secret — only `id-token: write`.

Verification (documented in the README):

```bash
cosign verify-blob \
  --certificate SHA256SUMS.pem --signature SHA256SUMS.sig \
  --certificate-identity-regexp '^https://github.com/morganstanley/hobbes/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  SHA256SUMS
sha256sum -c SHA256SUMS
```

## How the tag and release name are set

**The tag names the release — nothing here invents a version.** Pushing a tag matching `v*` triggers the workflow, and the release takes that tag's name:

```bash
git tag -s v1.0.0 -m "hobbes 1.0.0"
git push origin v1.0.0
```

The archive prefix strips the leading `v` (`v1.0.0` becomes `hobbes-1.0.0/`). `workflow_dispatch` accepts an existing tag so a release can be republished without re-pushing the tag. A signed *tag* is recommended but not required by the workflow — the release signature is independent of it.

No versioning scheme is imposed. Worth deciding separately: `testplan` uses CalVer (`25.8.0`); semver would suit a library with a C++ API better.

## Notes

- The archive is built with `git archive` + `gzip -n` rather than GitHub's auto-generated tarball, whose compression has changed in the past and whose checksums are therefore not stable over time.
- Actions pinned by commit SHA with version comments; the job takes `contents: write` and `id-token: write` on top of a read-only default.
- Scorecard evaluates the most recent five releases, so the score improves as releases accumulate rather than jumping on the first one.

## Testing

- YAML validated. The workflow cannot run until a `v*` tag exists, so the first tag is also its first live exercise — `workflow_dispatch` is there to re-run it if that first attempt needs a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
