### PR TITLE
Retire Renovate and widen Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,31 @@
 version: 2
 updates:
+  # Every workflow pins its actions to a commit SHA, so these updates are the
+  # only thing that moves those pins. Grouping keeps a quiet week to one PR.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     groups:
       codeql-actions:
         patterns:
           - "github/codeql-action/*"
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
+  # Base image for the devcontainer; both .devcontainer/docker/devcontainer.json
+  # and .devcontainer/podman/devcontainer.json build from this Dockerfile.
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+
+  # Images the CI build containers are based on --
+  # docker/build/rhel9.Dockerfile and docker/build/xenial.Dockerfile.
+  - package-ecosystem: "docker"
+    directory: "/docker/build"
     schedule:
       interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Two dependency-update bots were configured here, but only one was ever used. Renovate has not opened a single pull request against this repository — 0 of the last 200 — while Dependabot has been keeping the action pins current. A second configuration that never runs is a second thing to keep correct, so this removes `renovate.json` and puts the effort into Dependabot instead.

## What changes

**Removed** `renovate.json`.

**`.github/dependabot.yml`** gains:

- a third entry watching `/docker/build`, so the images the CI build containers derive from — `rockylinux:9` in `rhel9.Dockerfile` and `ubuntu:noble` in `xenial.Dockerfile` — are tracked like everything else. These were the only container images in the repo nothing was watching.
- grouping for minor and patch action bumps, plus `open-pull-requests-limit: 5`. Every workflow pins its actions to a commit SHA, so Dependabot is the only thing that moves those pins; without grouping that becomes a stream of one-line PRs. The existing `codeql-actions` group is listed first and so still wins for those.

## Coverage after this change

| Surface | Watched by |
|---|---|
| Workflow actions (all 5 workflows) | `github-actions` at `/` |
| `.devcontainer/Dockerfile` | `docker` at `/.devcontainer` |
| `docker/build/{rhel9,xenial}.Dockerfile` | `docker` at `/docker/build` — **new** |
| `flake.nix` / `flake.lock` | nothing — see below |

Both `devcontainer.json` files build from `../Dockerfile` rather than naming an image directly, so the existing `/.devcontainer` entry already covers them; no `devcontainers` ecosystem entry is needed.

## Two things worth knowing

**Nix is not covered.** Dependabot has no Nix support, so `flake.lock` stays a manual update. Renovate does support Nix in principle, but never ran here, so nothing regresses — the gap predates this PR. If we want it automated, a scheduled `nix flake update` workflow is the usual answer and can be a separate change.

**The `/docker/build` entry wants a post-merge check.** Dependabot matches Dockerfiles by name, and these use the `<name>.Dockerfile` form rather than a plain `Dockerfile`. That form is expected to match, but it is worth confirming on the repository's Dependabot "last checked" page once this lands rather than assuming it silently works.

OpenSSF Scorecard's Dependency-Update-Tool check is satisfied by either tool, so removing Renovate while keeping Dependabot leaves that check at 10/10.