### PR TITLE
Bound the page index against the page table in the fregion reader

### DIFF
--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -365,7 +365,10 @@ inline file_pageindex_t pageIndex(const imagefile* f, uint64_t fpos) { return fp
 // anywhere when the image is malformed, so the index has to be checked before
 // it is used to look up page metadata.
 inline void ensurePageInTable(const imagefile* f, file_pageindex_t page) {
-  if (static_cast<size_t>(page) >= f->pages.size()) {
+  // widen the table size to the index type rather than narrowing the index:
+  // file_pageindex_t is 64 bits, so where size_t is narrower the cast would
+  // truncate and a large index could wrap into range and pass this check
+  if (page >= static_cast<file_pageindex_t>(f->pages.size())) {
     throw std::runtime_error(
       "Not a valid structured data file: page index (" + hobbes::string::from(page) +
       ") is outside the page table of " + hobbes::string::from(f->pages.size()) +

--- a/include/hobbes/fregion.H
+++ b/include/hobbes/fregion.H
@@ -360,6 +360,19 @@ inline size_t pageOffset(const imagefile* f, file_pageindex_t page) { return f->
 // the page index implied by an absolute position
 inline file_pageindex_t pageIndex(const imagefile* f, uint64_t fpos) { return fpos / f->page_size; }
 
+// A page index derived from a file position is only meaningful if the page
+// table actually describes that page. Reading a record can leave the cursor
+// anywhere when the image is malformed, so the index has to be checked before
+// it is used to look up page metadata.
+inline void ensurePageInTable(const imagefile* f, file_pageindex_t page) {
+  if (static_cast<size_t>(page) >= f->pages.size()) {
+    throw std::runtime_error(
+      "Not a valid structured data file: page index (" + hobbes::string::from(page) +
+      ") is outside the page table of " + hobbes::string::from(f->pages.size()) +
+      " page(s): " + f->path);
+  }
+}
+
 // an absolute file position from a page and relative position
 inline size_t position(const imagefile* f, file_pageindex_t page, uint16_t offset) { return pageOffset(f, page) + static_cast<uint64_t>(offset); }
 
@@ -852,6 +865,10 @@ inline size_t readEnvironmentPage(imagefile* f, file_pageindex_t p) {
     size_t           pos   = filePosition(f) - 1;
     auto tpage = file_pageindex_t(pos / f->page_size);
     uint16_t         rpos  = (pos % f->page_size) + 1;
+
+    // a crafted image can make the record above run past the end of the page
+    // table, and this loop only terminates by consulting that page's metadata
+    ensurePageInTable(f, tpage);
 
     if (rpos == (f->page_size - f->pages[tpage].availBytes())) {
       break;

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -1163,3 +1163,50 @@ TEST(Storage, FRegionRejectsLengthBeyondFileSize) {
     unlink(path.data());
   }
 }
+
+TEST(Storage, FRegionRejectsPageIndexBeyondPageTable) {
+  // reading environment records walks the cursor forward and then asks the
+  // page table how much of the current page is in use, to decide whether to
+  // keep going. In a crafted image a record can leave the cursor past the end
+  // of the table, so the derived page index has to be checked before it is
+  // used to index it -- otherwise that lookup reads out of bounds, which is
+  // what fuzzing the reader turns up first and by a wide margin.
+  hobbes::fregion::imagefile f;
+  f.path      = "synthetic";
+  f.fd        = -1;
+  f.page_size = 4096;
+  f.file_size = 4096 * 3;
+  f.pages.resize(3);
+
+  // every page the table describes is fine, including the last
+  bool threw = false;
+  try {
+    hobbes::fregion::ensurePageInTable(&f, 0);
+    hobbes::fregion::ensurePageInTable(&f, 2);
+  } catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(!threw);
+
+  // one past the end is not
+  threw = false;
+  try { hobbes::fregion::ensurePageInTable(&f, 3); }
+  catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+
+  // nor is a wildly out-of-range index
+  threw = false;
+  try { hobbes::fregion::ensurePageInTable(&f, 1u << 30); }
+  catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+
+  // an empty table accepts nothing
+  hobbes::fregion::imagefile e;
+  e.path      = "synthetic-empty";
+  e.fd        = -1;
+  e.page_size = 4096;
+  e.file_size = 0;
+
+  threw = false;
+  try { hobbes::fregion::ensurePageInTable(&e, 0); }
+  catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+}

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -1198,6 +1198,14 @@ TEST(Storage, FRegionRejectsPageIndexBeyondPageTable) {
   catch (const std::exception&) { threw = true; }
   EXPECT_TRUE(threw);
 
+  // a page index is 64 bits wide, so an index whose low 32 bits land inside
+  // the table must still be rejected -- narrowing it to size_t first would
+  // let this through wherever size_t is 32 bits
+  threw = false;
+  try { hobbes::fregion::ensurePageInTable(&f, hobbes::fregion::file_pageindex_t(1) << 32); }
+  catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+
   // an empty table accepts nothing
   hobbes::fregion::imagefile e;
   e.path      = "synthetic-empty";


### PR DESCRIPTION
## The bug

`readEnvironmentPage` reads environment records in a loop, and decides whether to keep going by asking the page table how much of the current page is in use:

```cpp
size_t pos   = filePosition(f) - 1;
auto   tpage = file_pageindex_t(pos / f->page_size);
if (rpos == (f->page_size - f->pages[tpage].availBytes())) {
```

`tpage` is derived from wherever the previous record left the cursor. A malformed image can leave that past the end of `f->pages`, so the lookup reads out of bounds.

ASan reports it inside `availBytes()` (`fregion.H:106`), which is just `return this->ptfd & 0x3FFF;` — so the report points at a field read rather than at the indexing that is actually wrong.

## Why it matters

Structured data files are an untrusted-input surface per [`doc/en/security.rst`](doc/en/security.rst) — `hobbes::fregion::reader` is named there explicitly.

This is what fuzzing the reader finds first, by a wide margin: **2,532 of the 3,501 artifacts** from an overnight campaign reduce to this single bug. It reproduces on both arm64 and x86-64, smallest reproducer 521 bytes.

## The fix

A new `ensurePageInTable()` helper, called before the lookup. It follows the shape and error style of `ensureLengthInFile()` from #522.

Those are different checks and neither subsumes the other: #522 bounds a **length read out of the image**, this bounds an **index derived from a position**.

## Verification

Both hosts' reproducers now execute cleanly:

| reproducer | origin | before | after |
|---|---|---|---|
| 558 bytes | x86-64 | heap-buffer-overflow | clean |
| 521 bytes | arm64 | heap-buffer-overflow | clean |

Cross-architecture matters here — page size is 16 KB on Apple Silicon against 4 KB on Linux, and the reader takes page size from the file header, so passing the arm64-produced image on x86-64 shows the fix is not page-size-specific.

`hobbes-test`: 163 pass, 0 fail (ASan + UBSan build, clang-18).

The new test builds a synthetic `imagefile` and checks the boundary directly — last valid index accepted, one past the end rejected, wildly out-of-range rejected, and an empty table accepting nothing.