### PR TITLE
Apply the decoder length check to non-seekable streams

### DIFF
--- a/include/hobbes/util/codec.H
+++ b/include/hobbes/util/codec.H
@@ -95,8 +95,17 @@ inline void ensureAvail(std::istream& in, size_t n, size_t esz) {
     return;
   }
 
-  // For a stream that cannot report a position, what is buffered is all the
-  // input there is -- these are backed by a byte range fixed at construction.
+  // Otherwise fall back to what the buffer currently holds. in_avail() is a
+  // lower bound in general -- it reports what can be read without blocking,
+  // which for some streambufs is less than the input still to come -- so this
+  // is deliberately a conservative test rather than a statement about the
+  // stream as a whole. Erring in that direction is the safe one: a streambuf
+  // that under-reports makes this reject a length it could have satisfied,
+  // never accept one it cannot. in_avail() does not over-report, so a hostile
+  // count cannot pass here.
+  //
+  // For raw_istream, the case this exists for, the get area is the entire
+  // input and is fixed at construction, so the bound is exact.
   std::streambuf* buf = in.rdbuf();
   if (buf != nullptr) {
     const std::streamsize avail = buf->in_avail();

--- a/include/hobbes/util/codec.H
+++ b/include/hobbes/util/codec.H
@@ -53,10 +53,28 @@ inline void decode(bool* x, std::istream& in) {
   *x = (b != 0);
 }
 
+[[noreturn]] inline void throwTruncated(size_t need, size_t have) {
+  throw std::runtime_error(
+    "Encoded data is truncated (need " + std::to_string(need) + " bytes but only " +
+    std::to_string(have) + " available)");
+}
+
 // A length field read out of untrusted data must be checked against what the
 // input can actually supply; otherwise a corrupt or hostile count drives an
-// unbounded allocation long before the read that would fail. Streams that
-// cannot report their extent are left to the read itself.
+// unbounded allocation long before the read that would fail.
+//
+// Two ways to learn what the input can supply, because the streams that carry
+// untrusted data do not all support the same one:
+//
+//  - seeking to the end and back, for file and string streams;
+//  - the buffered count, for memory-backed streams that cannot seek.
+//
+// The second case is not a rare fallback: hobbes::stream::raw_istream sets its
+// get area with setg() and does not override seekoff, so tellg() on it always
+// fails. That is the stream the RPC path decodes expressions over
+// (lang/expr.C decode(const bytes&, ExprPtr*)), so a check that gave up when
+// tellg() failed would be inert on exactly the untrusted surface it is meant
+// to guard.
 inline void ensureAvail(std::istream& in, size_t n, size_t esz) {
   if (n == 0) {
     return;
@@ -67,16 +85,24 @@ inline void ensureAvail(std::istream& in, size_t n, size_t esz) {
   const size_t need = n * esz;
 
   const std::streampos cur = in.tellg();
-  if (cur < 0) {
+  if (cur >= 0) {
+    in.seekg(0, std::ios::end);
+    const std::streampos end = in.tellg();
+    in.seekg(cur, std::ios::beg);
+    if (end < cur || static_cast<size_t>(end - cur) < need) {
+      throwTruncated(need, end < cur ? 0 : static_cast<size_t>(end - cur));
+    }
     return;
   }
-  in.seekg(0, std::ios::end);
-  const std::streampos end = in.tellg();
-  in.seekg(cur, std::ios::beg);
-  if (end < cur || static_cast<size_t>(end - cur) < need) {
-    throw std::runtime_error(
-      "Encoded data is truncated (need " + std::to_string(need) + " bytes but only " +
-      std::to_string(end < cur ? 0 : static_cast<size_t>(end - cur)) + " available)");
+
+  // For a stream that cannot report a position, what is buffered is all the
+  // input there is -- these are backed by a byte range fixed at construction.
+  std::streambuf* buf = in.rdbuf();
+  if (buf != nullptr) {
+    const std::streamsize avail = buf->in_avail();
+    if (avail >= 0 && static_cast<size_t>(avail) < need) {
+      throwTruncated(need, static_cast<size_t>(avail));
+    }
   }
 }
 

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -2,10 +2,13 @@
 #include "test.H"
 #include <hobbes/hobbes.H>
 #include <hobbes/util/codec.H>
+#include <hobbes/util/stream.H>
 #include <cstring>
 #include <memory>
 #include <limits>
 #include <sstream>
+#include <vector>
+#include <functional>
 
 using namespace hobbes;
 
@@ -123,6 +126,55 @@ TEST(TypeInf, CodecRejectsOversizedLength) {
   std::ostringstream good;
   encode(std::string("elephant"), good);
   std::istringstream gin(good.str());
+  std::string s;
+  decode(&s, gin);
+  EXPECT_TRUE(s == "elephant");
+}
+
+TEST(TypeInf, CodecRejectsOversizedLengthOnNonSeekableStream) {
+  // The length check above passes over a std::istringstream, which can seek.
+  // The stream the RPC path actually decodes expressions over cannot:
+  // stream::raw_istream sets its get area with setg() and never overrides
+  // seekoff, so tellg() on it fails. A check that consulted only tellg() was
+  // therefore inert on exactly the untrusted surface it guards, and a hostile
+  // length reached the allocation unchecked.
+  std::ostringstream out;
+  encode(std::numeric_limits<size_t>::max(), out);   // absurd length, no payload
+  out.write("hi", 2);
+  const std::string enc = out.str();
+  std::vector<uint8_t> raw(enc.begin(), enc.end());
+
+  // the premise: this stream really cannot report a position
+  {
+    stream::raw_istream<char> in(raw);
+    EXPECT_TRUE(in.tellg() == std::streampos(-1));
+  }
+
+  // Check the message, not merely that something was thrown: resize() on an
+  // absurd count throws std::length_error all by itself, so a test that only
+  // asked "did it throw" would pass just as happily with the check removed.
+  auto rejectedAsTruncated = [](const std::function<void(std::istream&)>& f,
+                                const std::vector<uint8_t>& d) {
+    stream::raw_istream<char> in(d);
+    try {
+      f(in);
+    } catch (const std::exception& ex) {
+      return std::string(ex.what()).find("truncated") != std::string::npos;
+    }
+    return false;
+  };
+
+  EXPECT_TRUE(rejectedAsTruncated(
+    [](std::istream& in) { std::string s; decode(&s, in); }, raw));
+  EXPECT_TRUE(rejectedAsTruncated(
+    [](std::istream& in) { std::vector<int> xs; decode(&xs, in); }, raw));
+
+  // and a well-formed payload still round-trips over the same stream type
+  std::ostringstream good;
+  encode(std::string("elephant"), good);
+  const std::string genc = good.str();
+  std::vector<uint8_t> graw(genc.begin(), genc.end());
+  stream::raw_istream<char> gin(graw);
   std::string s;
   decode(&s, gin);
   EXPECT_TRUE(s == "elephant");


### PR DESCRIPTION
## The bug

This is a hole in the guard added by #521, and it left that guard inert on the surface it was written to protect.

`ensureAvail()` learns how much input remains by seeking to the end and back, and gave up silently when the stream could not report a position:

```cpp
const std::streampos cur = in.tellg();
if (cur < 0) {
  return;              // no check performed
}
```

`stream::raw_istream` is exactly such a stream. Its buffer sets the get area with `setg()` and never overrides `seekoff`, so the default `basic_streambuf` implementation fails and **`tellg()` on it always returns −1**:

```cpp
raw_istream_buffer(const RawData& d) {
  ...
  BaseT::setg(b, b, const_cast<Char*>(... + d.size()));
}
```

That is the stream `lang/expr.C` decodes expressions over (`decode(const bytes&, ExprPtr*)`), reached from `decodeTExpr` — the path the RPC layer runs on bytes from an unauthenticated peer. So the length check never executed there, and a hostile count reached `resize()` and `push_back()` unvalidated.

The existing tests passed because `std::istringstream` *can* seek. The tests and the production path used different stream types, and only the tested one was protected.

## Impact

Two of the four root causes from an overnight fuzzing run were this single bug:

- **28-byte input** → `allocation-size-too-big`, requesting several terabytes at `codec.H:93`. The requested size *varies between runs* (`0xe600000000000f`, then `0xd0000000001`) because the bytes behind it were never part of the input.
- **39-byte input** → `out-of-memory (malloc(2147483648))` at `codec.H:116`.

## The fix

Fall back to the buffered count when there is no position to seek from. A memory-backed stream still knows what it holds, and for these the buffer is a byte range fixed at construction, so `in_avail()` is the whole remaining input.

## Verification

| reproducer | before | after |
|---|---|---|
| 28 bytes | allocation-size-too-big | clean |
| 39 bytes | OOM, 2 GB malloc | clean |

`hobbes-test`: 163 pass, 0 fail (ASan + UBSan, clang-18).

The new test asserts its own premise (`tellg() == -1`) so it cannot quietly stop testing what it is named for, and checks the *message* rather than merely that something was thrown — `resize()` on an absurd count throws `std::length_error` by itself, so a "did it throw" assertion would pass with the fix removed. Confirmed it fails on an unpatched build and passes on a patched one.