### PR TITLE
Stop leaking the expression built for a nested let

### DIFF
--- a/lib/hobbes/read/pgen/hexpr.parse.C
+++ b/lib/hobbes/read/pgen/hexpr.parse.C
@@ -3676,13 +3676,13 @@ yyreduce:
 
   case 129: /* l5expr: "let" letbindings "in" l0expr  */
 #line 696 "hexpr.y"
-                                      { (yyval.exp) = compileNestedLetMatch(*(yyvsp[-2].letbindings), ExprPtr((yyvsp[0].exp)), m((yylsp[-3]),(yylsp[0])))->clone(); }
+                                      { (yyval.exp) = compileNestedLetMatch(*(yyvsp[-2].letbindings), ExprPtr((yyvsp[0].exp)), m((yylsp[-3]),(yylsp[0]))); }
 #line 3681 "hexpr.parse.C"
     break;
 
   case 130: /* l5expr: "let" letbindings ";" "in" l0expr  */
 #line 697 "hexpr.y"
-                                          { (yyval.exp) = compileNestedLetMatch(*(yyvsp[-3].letbindings), ExprPtr((yyvsp[0].exp)), m((yylsp[-4]),(yylsp[0])))->clone(); }
+                                          { (yyval.exp) = compileNestedLetMatch(*(yyvsp[-3].letbindings), ExprPtr((yyvsp[0].exp)), m((yylsp[-4]),(yylsp[0]))); }
 #line 3687 "hexpr.parse.C"
     break;
 

--- a/lib/hobbes/read/pgen/hexpr.y
+++ b/lib/hobbes/read/pgen/hexpr.y
@@ -693,8 +693,8 @@ l4expr: l4expr "*" l4expr { $$ = TAPP2(var("*", m(@2)), $1, $3, m(@1, @3)); }
 l5expr: l6expr { $$ = $1; }
 
       /* local variable introduction */
-      | "let" letbindings "in" l0expr { $$ = compileNestedLetMatch(*$2, ExprPtr($4), m(@1,@4))->clone(); }
-      | "let" letbindings ";" "in" l0expr { $$ = compileNestedLetMatch(*$2, ExprPtr($5), m(@1,@5))->clone(); }
+      | "let" letbindings "in" l0expr { $$ = compileNestedLetMatch(*$2, ExprPtr($4), m(@1,@4)); }
+      | "let" letbindings ";" "in" l0expr { $$ = compileNestedLetMatch(*$2, ExprPtr($5), m(@1,@5)); }
 
       /* pattern matching */
       | "match" l6exprs "with" patternexps { $$ = compileMatch(yyParseCC, *$2, normPatternRules(*$4, m(@1,@4)), m(@1,@4))->clone(); }


### PR DESCRIPTION
## The bug

`compileNestedLetMatch` returns a raw owning `Expr*` — it already calls `clone()` on the expression it builds:

```cpp
Expr* compileNestedLetMatch(const LetBindings& bs, const ExprPtr& e, const LexicalAnnotation& la) {
  ...
  return r->clone();
}
```

Two of its four call sites then called `clone()` a **second** time and assigned that to `$$`, leaving the first clone with no owner:

```
| "let" letbindings "in" l0expr { $$ = compileNestedLetMatch(*$2, ExprPtr($4), m(@1,@4))->clone(); }
```

The two `do`-block sites immediately below assign the result directly, which is correct — these two are the odd ones out. (`compileMatch` and friends nearby return `ExprPtr`, so `->clone()` on *those* is right; the inconsistent return type is what makes this easy to get wrong.)

## Impact

The leaked object is a whole expression subtree, so the cost scales with how much the `let` binds. LeakSanitizer reports **518,488 bytes across 7,696 allocations** from a 179-byte input found by fuzzing the parser.

Reading source text is on the untrusted side of the trust boundary ([`doc/en/security.rst`](doc/en/security.rst)), so a long-lived process parsing input it did not author leaks steadily.

## Verification

| | leaked | allocations |
|---|---|---|
| before | 518,488 bytes | 7,696 |
| after | 23,124 bytes | 422 |

The remainder is not this bug. Parsing a trivial input (`1`) leaks the **byte-identical** 23,124 / 422, all of it one-time `compileBootCode` state held by the fuzz harness's function-local `static hobbes::cc`, which is never destroyed. Every byte that scales with input is gone.

`hobbes-test`: 163 pass, 0 fail (ASan + UBSan, clang-18).

## A note on the generated parser

`lib/hobbes/read/pgen/hexpr.parse.C` is edited alongside the grammar because it is checked in and compiled directly — CMake does not run bison, `pgen.sh` is manual. The checked-in file was produced by bison 3.8.2; regenerating it on either machine I have would rewrite it wholesale with a different bison version, so the four action lines are edited by hand to match the grammar exactly.