### PR TITLE
Cover the fregion page-table bound from the reader, not just the helper

### DIFF
--- a/test/Storage.C
+++ b/test/Storage.C
@@ -1218,3 +1218,67 @@ TEST(Storage, FRegionRejectsPageIndexBeyondPageTable) {
   catch (const std::exception&) { threw = true; }
   EXPECT_TRUE(threw);
 }
+
+TEST(Storage, FRegionRejectsEnvironmentRunningPastPageTable) {
+  // The test above checks the bound in isolation, which leaves the thing that
+  // actually mattered untested: that reading an image consults it. This one
+  // opens a crafted image and drives the real path, so removing the check
+  // from readEnvironmentPage fails here rather than passing quietly.
+  //
+  // The image describes two pages but is four pages long. Page 1 is marked as
+  // an environment page whose free-byte count says it is full, while the
+  // records on it are 24 bytes each and so never land on the offset that ends
+  // the walk. The reader therefore keeps consuming records into page 2, which
+  // the page table does not describe -- and page 2 is present in the file, so
+  // the reads succeed and the only thing standing between that and an
+  // out-of-bounds read of the page table is the bound being checked.
+  const uint16_t pageSize  = 256;   // HFREGION_MIN_PAGE_SIZE
+  const size_t   pageCount = 4;
+  std::vector<unsigned char> img(pageSize * pageCount, 0);
+
+  auto put16 = [&](size_t at, uint16_t v) {
+    img[at]     = static_cast<unsigned char>(v & 0xFF);
+    img[at + 1] = static_cast<unsigned char>((v >> 8) & 0xFF);
+  };
+  auto put32 = [&](size_t at, uint32_t v) {
+    for (size_t i = 0; i < 4; ++i) {
+      img[at + i] = static_cast<unsigned char>((v >> (8 * i)) & 0xFF);
+    }
+  };
+
+  // filehead: magic, page size, format version
+  put32(0, 0x10a1db0dU);
+  put16(4, pageSize);
+  put16(6, HFREGION_CURRENT_FILE_FORMAT_VERSION);
+
+  // the page table: page 0 is the TOC page, page 1 claims to be a full
+  // environment page, and the null entry ends the table at two pages
+  put16(8,  static_cast<uint16_t>(hobbes::fregion::pagedata::encode(hobbes::fregion::pagetype::toc, 0)));
+  put16(10, static_cast<uint16_t>(hobbes::fregion::pagedata::encode(hobbes::fregion::pagetype::environment, 0)));
+  put16(12, static_cast<uint16_t>(hobbes::fregion::pagedata::encode(hobbes::fregion::pagetype::null, 0)));
+
+  // page 1 onward stays zeroed: each environment record then decodes as an
+  // offset of 0, an empty name and an empty type, consuming 24 bytes, which
+  // never divides the page evenly and so never terminates the walk
+
+  std::string tmpl = "/tmp/hobbes-fregion-envwalk-XXXXXX";
+  std::vector<char> path(tmpl.begin(), tmpl.end());
+  path.push_back('\0');
+  int fd = mkstemp(path.data());
+  EXPECT_TRUE(fd >= 0);
+  if (fd >= 0) {
+    EXPECT_TRUE(::write(fd, img.data(), img.size()) == static_cast<ssize_t>(img.size()));
+    close(fd);
+
+    // a malformed image must be reported, not read out of bounds
+    bool threw = false;
+    try {
+      hobbes::fregion::reader r(path.data());
+    } catch (const std::exception&) {
+      threw = true;
+    }
+    EXPECT_TRUE(threw);
+
+    unlink(path.data());
+  }
+}

--- a/test/Storage.C
+++ b/test/Storage.C
@@ -1232,8 +1232,10 @@ TEST(Storage, FRegionRejectsEnvironmentRunningPastPageTable) {
   // the page table does not describe -- and page 2 is present in the file, so
   // the reads succeed and the only thing standing between that and an
   // out-of-bounds read of the page table is the bound being checked.
-  const uint16_t pageSize  = 256;   // HFREGION_MIN_PAGE_SIZE
-  const size_t   pageCount = 4;
+  // the smallest page the format allows, so the image stays small; the record
+  // size below is what matters, not this particular value
+  const auto   pageSize  = static_cast<uint16_t>(HFREGION_MIN_PAGE_SIZE);
+  const size_t pageCount = 4;
   std::vector<unsigned char> img(pageSize * pageCount, 0);
 
   auto put16 = [&](size_t at, uint16_t v) {
@@ -1247,7 +1249,7 @@ TEST(Storage, FRegionRejectsEnvironmentRunningPastPageTable) {
   };
 
   // filehead: magic, page size, format version
-  put32(0, 0x10a1db0dU);
+  put32(0, HFREGION_FILE_PREFIX_BYTES);
   put16(4, pageSize);
   put16(6, HFREGION_CURRENT_FILE_FORMAT_VERSION);
 


### PR DESCRIPTION
Follow-up to #526. That PR merged at `7202779`, one commit before this test was pushed — auto-merge fired against the older head — so the fix landed without the regression test that binds it to the defect.

## The gap

`FRegionRejectsPageIndexBeyondPageTable` (merged in #526) calls `ensurePageInTable()` directly with synthetic indices. It never opens an image, so **deleting the `ensurePageInTable(f, tpage);` call from `readEnvironmentPage` leaves it green** while fully restoring the out-of-bounds read. The test guards the helper's arithmetic, not the thing that was broken.

## What this adds

`FRegionRejectsEnvironmentRunningPastPageTable` opens a crafted image through `hobbes::fregion::reader` and drives the real path.

The image is built from the documented format rather than checked in as a captured reproducer, so it explains why it is malformed:

- it **declares two pages** (`toc`, `environment`, then a `null` entry ending the table) but is **four pages long**;
- page 1 is marked as an environment page whose free-byte count says it is full, while the zero-filled records on it decode as 24 bytes each — which never divides 256 evenly, so the walk never lands on the offset that terminates it;
- the reader therefore keeps consuming records into page 2, which the page table does not describe. Page 2 is present in the file, so the reads succeed and the only thing between that and indexing past the table is the bound.

## Verified in both directions

Without the check (`fregion.H` at its pre-#526 state, this test alone):

```
==3487370==ERROR: AddressSanitizer: heap-buffer-overflow
    #5 test_Storage_FRegionRejectsEnvironmentRunningPastPageTable() test/Storage.C:1221
SUMMARY: AddressSanitizer: heap-buffer-overflow
         include/hobbes/fregion.H:106 in hobbes::fregion::pagedata::availBytes() const
==3487370==ABORTING
```

That is the same crash signature as the fuzzing artifacts that motivated #526 — same function, same line.

With the check, on current `main`:

```
FRegionRejectsLengthBeyondFileSize            SUCCESS (600.195us)
FRegionRejectsPageIndexBeyondPageTable        SUCCESS (265.943us)
FRegionRejectsEnvironmentRunningPastPageTable SUCCESS (306.438us)
```

Storage group 28/28, exit 0 (clang-18, ASan + UBSan).

Test-only change; no production code is touched.